### PR TITLE
AdServerService to enrich openrtb2's responses

### DIFF
--- a/src/main/java/org/prebid/server/auction/AdServerService.java
+++ b/src/main/java/org/prebid/server/auction/AdServerService.java
@@ -8,6 +8,6 @@ import java.util.Map;
 
 public interface AdServerService {
 
-    Future<Map<String, String>> buildAdServerKeyValues(RoutingContext context, BidRequest request);
+    Future<Map<String, Object>> buildAdServerKeyValues(RoutingContext context, BidRequest request);
 
 }

--- a/src/main/java/org/prebid/server/auction/AdServerService.java
+++ b/src/main/java/org/prebid/server/auction/AdServerService.java
@@ -1,0 +1,13 @@
+package org.prebid.server.auction;
+
+import com.iab.openrtb.request.BidRequest;
+import io.vertx.core.Future;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Map;
+
+public interface AdServerService {
+
+    Future<Map<String, String>> buildAdServerKeyValues(RoutingContext context, BidRequest request);
+
+}

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -138,7 +138,7 @@ public class ExchangeService {
             updateMetricsFromResponses(bidderResponses);
 
             return toBidResponse(bidderResponses, bidRequest, keywordsCreator,
-                    (Map<String, String>) result.list().get(1), shouldCacheBids, timeout);
+                    (Map<String, Object>) result.list().get(1), shouldCacheBids, timeout);
         });
     }
 
@@ -501,7 +501,7 @@ public class ExchangeService {
      */
     private Future<BidResponse> toBidResponse(List<BidderResponse> bidderResponses, BidRequest bidRequest,
                                               TargetingKeywordsCreator keywordsCreator,
-                                              Map<String, String> adServerKeyValues, boolean shouldCacheBids,
+                                              Map<String, Object> adServerKeyValues, boolean shouldCacheBids,
                                               Timeout timeout) {
         final Set<Bid> winningBids = newOrEmptySet(keywordsCreator);
         final Set<Bid> winningBidsByBidder = newOrEmptySet(keywordsCreator);
@@ -656,7 +656,7 @@ public class ExchangeService {
                                                           TargetingKeywordsCreator keywordsCreator,
                                                           Map<Bid, String> winningBidsWithCacheIds,
                                                           Set<Bid> winningBidsByBidder,
-                                                          Map<String, String> adServerKeyValues) {
+                                                          Map<String, Object> adServerKeyValues) {
         final List<SeatBid> seatBids = bidderResponses.stream()
                 .filter(bidderResponse -> !bidderResponse.getSeatBid().getBids().isEmpty())
                 .map(bidderResponse ->
@@ -720,7 +720,7 @@ public class ExchangeService {
      */
     private static ExtBidResponse toExtBidResponse(List<BidderResponse> results, BidRequest bidRequest,
                                                    TargetingKeywordsCreator keywordsCreator,
-                                                   Map<String, String> adServerKeyValues) {
+                                                   Map<String, Object> adServerKeyValues) {
         final Map<String, Integer> responseTimeMillis = results.stream()
                 .collect(Collectors.toMap(BidderResponse::getBidder, BidderResponse::getResponseTime));
 

--- a/src/main/java/org/prebid/server/auction/NoOpAdServerService.java
+++ b/src/main/java/org/prebid/server/auction/NoOpAdServerService.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public class NoOpAdServerService implements AdServerService {
 
     @Override
-    public Future<Map<String, String>> buildAdServerKeyValues(RoutingContext context, BidRequest request) {
+    public Future<Map<String, Object>> buildAdServerKeyValues(RoutingContext context, BidRequest request) {
         return Future.succeededFuture(Collections.EMPTY_MAP);
     }
 

--- a/src/main/java/org/prebid/server/auction/NoOpAdServerService.java
+++ b/src/main/java/org/prebid/server/auction/NoOpAdServerService.java
@@ -1,0 +1,17 @@
+package org.prebid.server.auction;
+
+import com.iab.openrtb.request.BidRequest;
+import io.vertx.core.Future;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class NoOpAdServerService implements AdServerService {
+
+    @Override
+    public Future<Map<String, String>> buildAdServerKeyValues(RoutingContext context, BidRequest request) {
+        return Future.succeededFuture(Collections.EMPTY_MAP);
+    }
+
+}

--- a/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
@@ -114,7 +114,7 @@ public class AmpHandler implements Handler<RoutingContext> {
     private AmpResponse toAmpResponse(BidRequest bidRequest, BidResponse bidResponse) {
         // fetch targeting information from response bids
         final List<SeatBid> seatBids = bidResponse.getSeatbid();
-        final Map<String, String> targeting = seatBids == null ? new HashMap<>() : seatBids.stream()
+        final Map<String, Object> targeting = seatBids == null ? new HashMap<>() : seatBids.stream()
                 .filter(Objects::nonNull)
                 .filter(seatBid -> seatBid.getBid() != null)
                 .flatMap(seatBid -> seatBid.getBid().stream()
@@ -137,8 +137,8 @@ public class AmpHandler implements Handler<RoutingContext> {
         return AmpResponse.of(targeting, extResponseDebug);
     }
 
-    private static void addAdServerKeyValuesToTargeting(Map<String, String> targeting,
-                                                        Map<String, String> adServerKeyValues) {
+    private static void addAdServerKeyValuesToTargeting(Map<String, Object> targeting,
+                                                        Map<String, Object> adServerKeyValues) {
         if (adServerKeyValues != null) targeting.putAll(adServerKeyValues);
     }
 
@@ -153,7 +153,7 @@ public class AmpHandler implements Handler<RoutingContext> {
         return extBidResponse;
     }
 
-    private static Map<String, String> extResponseAdServerKeyValuesFrom(BidResponse bidResponse) {
+    private static Map<String, Object> extResponseAdServerKeyValuesFrom(BidResponse bidResponse) {
         final ExtBidResponse extBidResponse = extResponseFrom(bidResponse);
         return extBidResponse != null ? extBidResponse.getAdserverkeyvalues() : Collections.EMPTY_MAP;
     }

--- a/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
@@ -68,7 +68,7 @@ public class AuctionHandler implements Handler<RoutingContext> {
         auctionRequestFactory.fromRequest(context)
                 .recover(this::updateErrorRequestsMetric)
                 .map(bidRequest -> updateAppAndNoCookieMetrics(bidRequest, uidsCookie.hasLiveUids(), isSafari))
-                .compose(bidRequest -> exchangeService.holdAuction(bidRequest, uidsCookie,
+                .compose(bidRequest -> exchangeService.holdAuction(context, bidRequest, uidsCookie,
                         timeout(bidRequest, startTime)))
                 .setHandler(responseResult -> handleResult(responseResult, context));
     }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtBidResponse.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtBidResponse.java
@@ -30,5 +30,5 @@ public class ExtBidResponse {
      */
     Map<String, ExtResponseSyncData> usersync;
 
-    Map<String, String> adserverkeyvalues;
+    Map<String, Object> adserverkeyvalues;
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtBidResponse.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtBidResponse.java
@@ -29,4 +29,6 @@ public class ExtBidResponse {
      * Defines the contract for bidresponse.ext.usersync
      */
     Map<String, ExtResponseSyncData> usersync;
+
+    Map<String, String> adserverkeyvalues;
 }

--- a/src/main/java/org/prebid/server/proto/response/AmpResponse.java
+++ b/src/main/java/org/prebid/server/proto/response/AmpResponse.java
@@ -10,7 +10,7 @@ import java.util.Map;
 @Value
 public class AmpResponse {
 
-    Map<String, String> targeting;
+    Map<String, Object> targeting;
 
     ExtResponseDebug debug;
 }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -5,10 +5,12 @@ import de.malkusch.whoisServerList.publicSuffixList.PublicSuffixListFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import org.prebid.server.auction.AdServerService;
 import org.prebid.server.auction.AmpRequestFactory;
 import org.prebid.server.auction.AuctionRequestFactory;
 import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.auction.ImplicitParametersExtractor;
+import org.prebid.server.auction.NoOpAdServerService;
 import org.prebid.server.auction.PreBidRequestContextFactory;
 import org.prebid.server.auction.StoredRequestProcessor;
 import org.prebid.server.bidder.BidderCatalog;
@@ -122,13 +124,18 @@ public class ServiceConfiguration {
     }
 
     @Bean
+    AdServerService adServerService() {
+        return new NoOpAdServerService();
+    }
+
+    @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     ExchangeService exchangeService(
             @Value("${auction.expected-cache-time-ms}") long expectedCacheTimeMs,
             BidderCatalog bidderCatalog, ResponseBidValidator responseBidValidator,
-            CacheService cacheService, Metrics metrics, Clock clock) {
+            AdServerService adServerService, CacheService cacheService, Metrics metrics, Clock clock) {
 
-        return new ExchangeService(bidderCatalog, responseBidValidator, cacheService, metrics, clock,
+        return new ExchangeService(bidderCatalog, responseBidValidator, adServerService, cacheService, metrics, clock,
                 expectedCacheTimeMs);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ vertx:
   worker-pool-size: 20
   uploads-dir: file-uploads
   verticle:
-    deploy-timeout-ms: 5000
+    deploy-timeout-ms: 8000
     instances: 1
 http:
   port: 8080

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -55,6 +55,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -536,9 +537,9 @@ public class ExchangeServiceTest extends VertxTest {
                 emptyList()));
 
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("bidder1", 1)));
-        Map<String, String> adServerKeyValues = new HashMap<>(2);
+        Map<String, Object> adServerKeyValues = new HashMap<>(2);
         adServerKeyValues.put("key1", "value1");
-        adServerKeyValues.put("key2", "value2");
+        adServerKeyValues.put("key2", Arrays.asList("value2"));
         given(adServerService.buildAdServerKeyValues(context, bidRequest))
                 .willReturn(Future.succeededFuture(adServerKeyValues));
 

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -41,6 +41,7 @@ import org.prebid.server.proto.openrtb.ext.response.ExtResponseDebug;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -242,9 +243,9 @@ public class AmpHandlerTest extends VertxTest {
     @Test
     public void shouldRespondWithAdServerKeyValuesIncluded() {
         // given
-        Map<String, String> adServerKeyValues = new HashMap<>();
+        Map<String, Object> adServerKeyValues = new HashMap<>();
         adServerKeyValues.put("key1", "value1");
-        adServerKeyValues.put("key2", "value2");
+        adServerKeyValues.put("key2", Arrays.asList("value2", "value3"));
         final BidRequest bidRequest = BidRequest.builder().id("reqId1").build();
         given(ampRequestFactory.fromRequest(any())).willReturn(Future.succeededFuture(bidRequest));
 
@@ -256,7 +257,7 @@ public class AmpHandlerTest extends VertxTest {
 
         // then
         verify(httpResponse).end(
-                eq("{\"targeting\":{\"key1\":\"value1\",\"key2\":\"value2\"}}"));
+                eq("{\"targeting\":{\"key1\":\"value1\",\"key2\":[\"value2\",\"value3\"]}}"));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -99,7 +99,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willThrow(new RuntimeException("Unexpected exception"));
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willThrow(new RuntimeException("Unexpected exception"));
 
         // when
         auctionHandler.handle(routingContext);
@@ -115,14 +115,14 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
 
         // then
-        verify(exchangeService).holdAuction(any(), any(), any());
+        verify(exchangeService).holdAuction(any(), any(), any(), any());
         verify(httpResponse).putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
         verify(httpResponse).end(eq("{}"));
     }
@@ -133,7 +133,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().tmax(1000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         // when
@@ -149,7 +149,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         // when
@@ -165,7 +165,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().tmax(1000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         final Instant now = Instant.now();
@@ -240,13 +240,13 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
     }
 
     private Timeout captureTimeout() {
         final ArgumentCaptor<Timeout> timeoutCaptor = ArgumentCaptor.forClass(Timeout.class);
-        verify(exchangeService).holdAuction(any(), any(), timeoutCaptor.capture());
+        verify(exchangeService).holdAuction(any(), any(), any(), timeoutCaptor.capture());
         return timeoutCaptor.getValue();
     }
 }

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/test-auction-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/test-auction-response.json
@@ -1020,6 +1020,7 @@
       "adform": "{{ adform.response_time_ms }}",
       "sovrn": "{{ sovrn.response_time_ms }}",
       "adtelligent": "{{ adtelligent.response_time_ms }}"
-    }
+    },
+    "adserverkeyvalues" : {}
   }
 }


### PR DESCRIPTION
We considered extending/wrapping ExchangeService but in the end AmpHandler uses its EXT_BID_RESPONSE_TYPE_REFERENCE to map ExtBidResponse. To overcome this we could also have extracted that TypeRefence to make it configurable but in the end we are "affraid of" having problems with this Lombok class because of inheritance (ExtBidResponse -> MarfeelExtBidReponse) (https://reinhard.codes/2015/09/16/lomboks-builder-annotation-and-inheritance/), so we finally decided to create a new component and add a new field into ExtBidResponse

- BidReponse.ext field, which is "mapped" from/to ExtBidResponse, now has a new field adserverkeyvalues
- AdServerService will fill this new field based on BidRequest and RoutingContext(thus we can read/parse custom query params). We have provided a noop impl
- AmpHandler in the last step adds this new key-values from the adServerService to targeting map