### PR TITLE
Format decimal bidAdjustmentFactor according to US locale using decimal point separator

### DIFF
--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -54,6 +55,7 @@ import java.util.stream.Stream;
 public class RequestValidator {
 
     private static final String PREBID_EXT = "prebid";
+    private static final Locale LOCALE = Locale.US;
 
     private final BidderCatalog bidderCatalog;
     private final BidderParamValidator bidderParamValidator;
@@ -132,8 +134,8 @@ public class RequestValidator {
             final BigDecimal adjustmentFactor = bidderAdjustment.getValue();
             if (adjustmentFactor.compareTo(BigDecimal.ZERO) <= 0) {
                 throw new ValidationException(
-                        "request.ext.prebid.bidadjustmentfactors.%s must be a positive number. Got %f",
-                        bidder, adjustmentFactor);
+                        "request.ext.prebid.bidadjustmentfactors.%s must be a positive number. Got %s",
+                        bidder, format(adjustmentFactor));
             }
 
         }
@@ -141,6 +143,10 @@ public class RequestValidator {
 
     private boolean isUnknownBidderOrAlias(String bidder, Map<String, String> aliases) {
         return !bidderCatalog.isValidName(bidder) && !aliases.containsKey(bidder);
+    }
+
+    private static String format(BigDecimal value) {
+        return String.format(LOCALE, "%f", value);
     }
 
     private ExtBidRequest parseAndValidateExtBidRequest(BidRequest bidRequest) throws ValidationException {

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -1503,7 +1503,9 @@ public class RequestValidatorTest extends VertxTest {
         // given
         final BidRequest bidRequest = validBidRequestBuilder()
                 .ext(mapper.valueToTree(ExtBidRequest.of(
-                        ExtRequestPrebid.of(null, singletonMap("rubicon", BigDecimal.valueOf(-1.1)), null, null, null))))
+                        ExtRequestPrebid.of(
+                                null,
+                                singletonMap("rubicon", BigDecimal.valueOf(-1.1)), null, null, null))))
                 .build();
 
         // when
@@ -1520,7 +1522,9 @@ public class RequestValidatorTest extends VertxTest {
         // given
         final BidRequest bidRequest = validBidRequestBuilder()
                 .ext(mapper.valueToTree(ExtBidRequest.of(
-                        ExtRequestPrebid.of(null, singletonMap("unknownBidder", BigDecimal.valueOf(1.1F)), null, null, null))))
+                        ExtRequestPrebid.of(
+                                null,
+                                singletonMap("unknownBidder", BigDecimal.valueOf(1.1F)), null, null, null))))
                 .build();
 
         // when


### PR DESCRIPTION
Pushed commit with the incorrect name mentioning "comma" instead of "point"