### PR TITLE
Set timeout to default value

### DIFF
--- a/src/main/java/org/prebid/server/proto/request/PreBidRequest.java
+++ b/src/main/java/org/prebid/server/proto/request/PreBidRequest.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 import java.util.List;
 
-@Builder
+@Builder(toBuilder = true)
 @Value
 public class PreBidRequest {
 

--- a/src/test/java/org/prebid/server/auction/PreBidRequestContextFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/PreBidRequestContextFactoryTest.java
@@ -437,6 +437,30 @@ public class PreBidRequestContextFactoryTest extends VertxTest {
     }
 
     @Test
+    public void shouldUpdateRequestTimeoutWithDefaultValueIfZeroInRequest() {
+        // given
+        given(routingContext.getBody()).willReturn(givenPreBidRequest(builder -> builder.timeoutMillis(0L)));
+
+        // when
+        final PreBidRequestContext preBidRequestContext = factory.fromRequest(routingContext).result();
+
+        // then
+        assertThat(preBidRequestContext.getPreBidRequest().getTimeoutMillis()).isEqualTo(HTTP_REQUEST_TIMEOUT);
+    }
+
+    @Test
+    public void shouldUpdateRequestTimeoutIfGreaterThan2000InRequest() {
+        // given
+        given(routingContext.getBody()).willReturn(givenPreBidRequest(builder -> builder.timeoutMillis(5000L)));
+
+        // when
+        final PreBidRequestContext preBidRequestContext = factory.fromRequest(routingContext).result();
+
+        // then
+        assertThat(preBidRequestContext.getPreBidRequest().getTimeoutMillis()).isEqualTo(HTTP_REQUEST_TIMEOUT);
+    }
+
+    @Test
     public void shouldSetIsDebugToTrueIfTrueInPreBidRequest() {
         // given
         given(routingContext.getBody()).willReturn(givenPreBidRequest(builder -> builder.isDebug(true)));


### PR DESCRIPTION
Set timeout to default value for ongoing requests in /auction endpoint when 0 <= incoming timeout > 2000