### PR TITLE
Made ZonedDateTime deserializer tolerant to variable number of nanosecond digits

### DIFF
--- a/src/main/java/org/prebid/server/json/ZonedDateTimeModule.java
+++ b/src/main/java/org/prebid/server/json/ZonedDateTimeModule.java
@@ -11,11 +11,19 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 
 class ZonedDateTimeModule extends SimpleModule {
 
-    private static final DateTimeFormatter FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX");
+    // see https://stackoverflow.com/q/30090710
+    // this format is equal to "yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX" but allows less than 9 nanosecond digits in
+    // parsed strings, as a side effect trailing zeros will be removed when formatting ZonedDateTime into string
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+            .appendPattern("XXX")
+            .toFormatter();
 
     ZonedDateTimeModule() {
         addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer());

--- a/src/test/java/org/prebid/server/cookie/UidsCookieTest.java
+++ b/src/test/java/org/prebid/server/cookie/UidsCookieTest.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.prebid.server.VertxTest;
 import org.prebid.server.cookie.model.UidWithExpiry;
 import org.prebid.server.cookie.proto.Uids;
 
@@ -15,7 +16,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-public class UidsCookieTest {
+public class UidsCookieTest extends VertxTest {
 
     private static final String RUBICON = "rubicon";
     private static final String ADNXS = "adnxs";
@@ -233,7 +234,7 @@ public class UidsCookieTest {
     public void toJsonShouldReturnCookieInValidJsonFormat() {
         // given
         final Map<String, UidWithExpiry> uids = new HashMap<>();
-        uids.put(RUBICON, new UidWithExpiry("J5VLCWQP-26-CWFT", ZonedDateTime.parse("2017-12-30T12:30:40Z[GMT]")));
+        uids.put(RUBICON, new UidWithExpiry("J5VLCWQP-26-CWFT", ZonedDateTime.parse("2017-12-30T12:30:40.123456789Z")));
 
         final UidsCookie uidsCookie = new UidsCookie(Uids.builder()
                 .uids(uids)
@@ -242,6 +243,6 @@ public class UidsCookieTest {
 
         // when and then
         assertThat(uidsCookie.toJson()).isEqualTo("{\"tempUIDs\":{\"rubicon\":{\"uid\":\"J5VLCWQP-26-CWFT\"," +
-                "\"expires\":\"2017-12-30T12:30:40.000000000Z\"}},\"bday\":\"2017-08-15T19:47:59.523908376Z\"}");
+                "\"expires\":\"2017-12-30T12:30:40.123456789Z\"}},\"bday\":\"2017-08-15T19:47:59.523908376Z\"}");
     }
 }

--- a/src/test/java/org/prebid/server/handler/GetuidsHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/GetuidsHandlerTest.java
@@ -64,7 +64,7 @@ public class GetuidsHandlerTest extends VertxTest {
     public void shouldReturnEncodedLegacyCookieAndDecodedJsonAsResponseBody() {
         // given
         final Map<String, UidWithExpiry> uids = new HashMap<>();
-        uids.put(RUBICON, new UidWithExpiry("J5VLCWQP-26-CWFT", ZonedDateTime.parse("2017-12-30T12:30:40Z[GMT]")));
+        uids.put(RUBICON, new UidWithExpiry("J5VLCWQP-26-CWFT", ZonedDateTime.parse("2017-12-30T12:30:40.123456789Z")));
 
         given(uidsCookieService.parseFromRequest(any())).willReturn(new UidsCookie(Uids.builder()
                 .uids(uids)
@@ -73,11 +73,11 @@ public class GetuidsHandlerTest extends VertxTest {
         given(routingContext.addCookie(any())).willReturn(routingContext);
 
         // this uids cookie stands for {"tempUIDs":{"rubicon":{"uid":"J5VLCWQP-26-CWFT",
-        // "expires":"2017-12-30T12:30:40.000000000Z"}},"bday":"2017-08-15T19:47:59.523908376Z"}
+        // "expires":"2017-12-30T12:30:40.123456789Z"}},"bday":"2017-08-15T19:47:59.523908376Z"}
         given(uidsCookieService.toCookie(any())).willReturn(Cookie
-                .cookie("uids", "eyJ0ZW1wVUlEcyI6eyJydWJpY29uIjp7InVpZCI6Iko1VkxDV1FQLTI2LUNXRlQiLCJleHBpcmVzIjoiMjAx"
-                        + "Ny0xMi0zMFQxMjozMDo0MC4wMDAwMDAwMDBaIn19LCJiZGF5IjoiMjAxNy0wOC0xNVQxOTo0Nzo1OS41MjM5MDgzNzZ"
-                        + "aIn0="));
+                .cookie("uids", "eyJ0ZW1wVUlEcyI6eyJydWJpY29uIjp7InVpZCI6Iko1VkxDV1FQLTI2LUNXRlQiLCJleHBpcmVzIjoi" +
+                        "MjAxNy0xMi0zMFQxMjozMDo0MC4xMjM0NTY3ODlaIn19LCJiZGF5IjoiMjAxNy0wOC0xNVQxOTo0Nzo1OS41MjM5MDgz" +
+                        "NzZaIn0="));
 
         // when
         getuidsHandler.handle(routingContext);
@@ -88,14 +88,14 @@ public class GetuidsHandlerTest extends VertxTest {
 
         assertThat(responseBody).isNotNull()
                 .isEqualTo("{\"tempUIDs\":{\"rubicon\":{\"uid\":\"J5VLCWQP-26-CWFT\"," +
-                        "\"expires\":\"2017-12-30T12:30:40.000000000Z\"}}," +
+                        "\"expires\":\"2017-12-30T12:30:40.123456789Z\"}}," +
                         "\"bday\":\"2017-08-15T19:47:59.523908376Z\"}");
         assertThat(cookie.getName()).isNotNull().isEqualTo("uids");
         // this uids cookie stands for {"tempUIDs":{"rubicon":{"uid":"J5VLCWQP-26-CWFT",
-        // "expires":"2017-12-30T12:30:40.000000000Z"}},"bday":"2017-08-15T19:47:59.523908376Z"}
-        assertThat(cookie.getValue()).isNotNull().isEqualTo("eyJ0ZW1wVUlEcyI6eyJydWJpY29uIjp7InVpZCI6Iko1VkxDV1FQLTI2" +
-                "LUNXRlQiLCJleHBpcmVzIjoiMjAxNy0xMi0zMFQxMjozMDo0MC4wMDAwMDAwMDBaIn19LCJiZGF5IjoiMjAxNy0wOC0xNVQxOTo0N" +
-                "zo1OS41MjM5MDgzNzZaIn0=");
+        // "expires":"2017-12-30T12:30:40.123456789Z"}},"bday":"2017-08-15T19:47:59.523908376Z"}
+        assertThat(cookie.getValue()).isNotNull().isEqualTo("eyJ0ZW1wVUlEcyI6eyJydWJpY29uIjp7InVpZCI6Iko1VkxDV1FQLTI" +
+                "2LUNXRlQiLCJleHBpcmVzIjoiMjAxNy0xMi0zMFQxMjozMDo0MC4xMjM0NTY3ODlaIn19LCJiZGF5IjoiMjAxNy0wOC0xNVQxOTo" +
+                "0Nzo1OS41MjM5MDgzNzZaIn0=");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/json/ZonedDateTimeModuleTest.java
+++ b/src/test/java/org/prebid/server/json/ZonedDateTimeModuleTest.java
@@ -6,9 +6,7 @@ import lombok.Value;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,8 +19,7 @@ public class ZonedDateTimeModuleTest {
     @Test
     public void shouldEncodeSuccessfully() throws IOException {
         // given
-        final ZonedDateTime VALUE = ZonedDateTime.of(LocalDateTime.of(2017, Month.DECEMBER, 10, 15, 45, 55, 237018349),
-                ZoneId.of("UTC"));
+        final ZonedDateTime VALUE = ZonedDateTime.of(2017, 12, 10, 15, 45, 55, 237018349, ZoneOffset.UTC);
         final Model model = new Model(VALUE);
 
         // when
@@ -30,6 +27,19 @@ public class ZonedDateTimeModuleTest {
 
         // then
         assertThat(modelAsString).isEqualTo("{\"value\":\"2017-12-10T15:45:55.237018349Z\"}");
+    }
+
+    @Test
+    public void shouldEncodeVariableNumberOfNanos() throws IOException {
+        // given
+        final ZonedDateTime VALUE = ZonedDateTime.of(2017, 12, 10, 15, 45, 55, 237018000, ZoneOffset.UTC);
+        final Model model = new Model(VALUE);
+
+        // when
+        final String modelAsString = MAPPER.writeValueAsString(model);
+
+        // then
+        assertThat(modelAsString).isEqualTo("{\"value\":\"2017-12-10T15:45:55.237018Z\"}");
     }
 
     @Test
@@ -41,13 +51,19 @@ public class ZonedDateTimeModuleTest {
         final Model model = MAPPER.readValue(modelAsString, Model.class);
 
         // then
-        assertThat(model.value.getYear()).isEqualTo(2017);
-        assertThat(model.value.getMonth()).isEqualTo(Month.DECEMBER);
-        assertThat(model.value.getDayOfMonth()).isEqualTo(10);
-        assertThat(model.value.getHour()).isEqualTo(15);
-        assertThat(model.value.getMinute()).isEqualTo(45);
-        assertThat(model.value.getSecond()).isEqualTo(55);
-        assertThat(model.value.getNano()).isEqualTo(237018349);
+        assertThat(model.value).isEqualTo(ZonedDateTime.of(2017, 12, 10, 15, 45, 55, 237018349, ZoneOffset.UTC));
+    }
+
+    @Test
+    public void shouldDecodeVariableNumberOfNanos() throws IOException {
+        // given
+        final String modelAsString = "{\"value\":\"2017-12-10T15:45:55.237018Z\"}";
+
+        // when
+        final Model model = MAPPER.readValue(modelAsString, Model.class);
+
+        // then
+        assertThat(model.value).isEqualTo(ZonedDateTime.of(2017, 12, 10, 15, 45, 55, 237018000, ZoneOffset.UTC));
     }
 
     @Test


### PR DESCRIPTION
Currently Jackson is configured to parse timestamp with format defined at `org.prebid.server.json.ZonedDateTimeModule#FORMATTER` as `yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX` (exactly 9 digits in nanoseconds part).

The problem shows up when uids cookie contains timestamps with the number of nanoseconds digits less than 9, for example 2018-03-15T14:04:19.30409244Z i.e. nanoseconds part isn't padded with zeros.