### PR TITLE
Issue 72 - Currency conversion service doesnt fetch data

### DIFF
--- a/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
+++ b/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
@@ -56,7 +56,8 @@ public class CurrencyConversionService {
      */
     private void populatesLatestCurrencyRates() {
         httpClient.getAbs(currencyServerUrl, this::handleResponse)
-                .exceptionHandler(CurrencyConversionService::handleException);
+                .exceptionHandler(CurrencyConversionService::handleException)
+                .end();
     }
 
     private void handleResponse(HttpClientResponse response) {

--- a/src/test/java/org/prebid/server/auction/CurrencyConversionServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/CurrencyConversionServiceTest.java
@@ -255,6 +255,7 @@ public class CurrencyConversionServiceTest extends VertxTest {
 
         given(httpClient.getAbs(anyString(), any()))
                 .willAnswer(withRequestAndPassResponseToHandler(httpClientResponse));
+        given(httpClientRequest.exceptionHandler(any())).willReturn(httpClientRequest);
         given(httpClientResponse.statusCode()).willReturn(statusCode);
         return httpClientResponse;
     }


### PR DESCRIPTION
As per documented in https://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientRequest.html "Once you are ready to send the request, one of the end() methods should be called" , that was missing

See https://github.com/rubicon-project/prebid-server-java/issues/72