### PR TITLE
Inform ExtBidResponse's usersync field with the user sync status

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -43,6 +43,7 @@ import org.prebid.server.proto.openrtb.ext.response.ExtBidPrebid;
 import org.prebid.server.proto.openrtb.ext.response.ExtBidResponse;
 import org.prebid.server.proto.openrtb.ext.response.ExtHttpCall;
 import org.prebid.server.proto.openrtb.ext.response.ExtResponseDebug;
+import org.prebid.server.proto.openrtb.ext.response.ExtResponseSyncData;
 import org.prebid.server.validation.ResponseBidValidator;
 import org.prebid.server.validation.model.ValidationResult;
 
@@ -141,7 +142,7 @@ public class ExchangeService {
                 .map(CompositeFuture::<BidderResponse>list)
                 .map(this::updateMetricsFromResponses)
                 .compose(result ->
-                        toBidResponse(result, bidRequest, keywordsCreator, cacheInfo, timeout))
+                        toBidResponse(result, bidRequest, keywordsCreator, cacheInfo, timeout, uidsCookie, aliases))
                 .compose(bidResponse -> bidResponsePostProcessor.postProcess(bidRequest, bidResponse));
     }
 
@@ -340,7 +341,11 @@ public class ExchangeService {
         final String uid = uidsBody.get(bidder);
         return StringUtils.isNotBlank(uid)
                 ? uid
-                : uidsCookie.uidFrom(bidderCatalog.usersyncerByName(bidder).cookieFamilyName());
+                : uidsCookie.uidFrom(bidderCookieFamilyName(bidder));
+    }
+
+    private String bidderCookieFamilyName(String bidder) {
+        return bidderCatalog.usersyncerByName(bidder).cookieFamilyName();
     }
 
     /**
@@ -361,7 +366,7 @@ public class ExchangeService {
             metrics.forAdapter(bidder).incCounter(MetricName.requests);
 
             final boolean noBuyerId = !bidderCatalog.isValidName(bidder) || StringUtils.isBlank(
-                    uidsCookie.uidFrom(bidderCatalog.usersyncerByName(bidder).cookieFamilyName()));
+                    uidsCookie.uidFrom(bidderCookieFamilyName(bidder)));
 
             if (bidderRequest.getBidRequest().getApp() == null && noBuyerId) {
                 metrics.forAdapter(bidder).incCounter(MetricName.no_cookie_requests);
@@ -593,14 +598,14 @@ public class ExchangeService {
      */
     private Future<BidResponse> toBidResponse(List<BidderResponse> bidderResponses, BidRequest bidRequest,
                                               TargetingKeywordsCreator keywordsCreator, BidRequestCacheInfo cacheInfo,
-                                              Timeout timeout) {
+                                              Timeout timeout, UidsCookie uidsCookie, Map<String, String> aliases) {
         final Set<Bid> winningBids = newOrEmptySet(keywordsCreator);
         final Set<Bid> winningBidsByBidder = newOrEmptySet(keywordsCreator);
         populateWinningBids(keywordsCreator, bidderResponses, winningBids, winningBidsByBidder);
 
         return toWinningBidsWithCacheIds(winningBids, bidRequest.getImp(), keywordsCreator, cacheInfo, timeout)
                 .map(winningBidsWithCacheIds -> toBidResponseWithCacheInfo(bidderResponses, bidRequest, keywordsCreator,
-                        winningBidsWithCacheIds, winningBidsByBidder));
+                        winningBidsWithCacheIds, winningBidsByBidder, uidsCookie, aliases));
     }
 
     /**
@@ -752,17 +757,18 @@ public class ExchangeService {
      * Creates an OpenRTB {@link BidResponse} from the bids supplied by the bidder,
      * including processing of winning bids with cache IDs.
      */
-    private static BidResponse toBidResponseWithCacheInfo(List<BidderResponse> bidderResponses, BidRequest bidRequest,
+    private BidResponse toBidResponseWithCacheInfo(List<BidderResponse> bidderResponses, BidRequest bidRequest,
                                                           TargetingKeywordsCreator keywordsCreator,
                                                           Map<Bid, CacheIdInfo> winningBidsWithCacheIds,
-                                                          Set<Bid> winningBidsByBidder) {
+                                                          Set<Bid> winningBidsByBidder, UidsCookie uidsCookie,
+                                                          Map<String, String> aliases) {
         final List<SeatBid> seatBids = bidderResponses.stream()
                 .filter(bidderResponse -> !bidderResponse.getSeatBid().getBids().isEmpty())
                 .map(bidderResponse ->
                         toSeatBid(bidderResponse, keywordsCreator, winningBidsWithCacheIds, winningBidsByBidder))
                 .collect(Collectors.toList());
 
-        final ExtBidResponse bidResponseExt = toExtBidResponse(bidderResponses, bidRequest);
+        final ExtBidResponse bidResponseExt = toExtBidResponse(bidderResponses, bidRequest, uidsCookie, aliases);
 
         return BidResponse.builder()
                 .id(bidRequest.getId())
@@ -825,7 +831,8 @@ public class ExchangeService {
      * Creates {@link ExtBidResponse} populated with response time, errors and debug info (if requested) from all
      * bidders
      */
-    private static ExtBidResponse toExtBidResponse(List<BidderResponse> results, BidRequest bidRequest) {
+    private ExtBidResponse toExtBidResponse(List<BidderResponse> results, BidRequest bidRequest,
+                                                   UidsCookie uidsCookie, Map<String, String> aliases) {
         final Map<String, List<ExtHttpCall>> httpCalls = Objects.equals(bidRequest.getTest(), 1)
                 ? results.stream().collect(
                 Collectors.toMap(BidderResponse::getBidder, r -> r.getSeatBid().getHttpCalls()))
@@ -838,7 +845,17 @@ public class ExchangeService {
         final Map<String, Integer> responseTimeMillis = results.stream()
                 .collect(Collectors.toMap(BidderResponse::getBidder, BidderResponse::getResponseTime));
 
-        return ExtBidResponse.of(extResponseDebug, errors, responseTimeMillis, null);
+        final Map<String, ExtResponseSyncData> userSync = results.stream()
+                .collect(Collectors.toMap(BidderResponse::getBidder, br -> {
+                    String bidderCfm = bidderCookieFamilyName(resolveBidder(br.getBidder(), aliases));
+                    return ExtResponseSyncData.of(uidsCookie.hasLiveUidFrom(bidderCfm)
+                            ? ExtResponseSyncData.CookieStatus.available
+                                : (StringUtils.isNotBlank(uidsCookie.uidFrom(bidderCfm))
+                                    ? ExtResponseSyncData.CookieStatus.expired
+                                        : ExtResponseSyncData.CookieStatus.none), null);
+                }));
+
+        return ExtBidResponse.of(extResponseDebug, errors, responseTimeMillis, userSync);
     }
 
     private static List<String> messages(List<BidderError> errors) {

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtResponseSyncData.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtResponseSyncData.java
@@ -1,5 +1,6 @@
 package org.prebid.server.proto.openrtb.ext.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 import java.util.List;
@@ -7,8 +8,9 @@ import java.util.List;
 /**
  * Defines the contract for bidresponse.ext.usersync.{bidder}
  */
+@AllArgsConstructor(staticName = "of")
 @Value
-final class ExtResponseSyncData {
+public final class ExtResponseSyncData {
 
     CookieStatus status;
 

--- a/src/test/resources/org/prebid/server/ApplicationTest/cache/update/test-auction-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/cache/update/test-auction-response.json
@@ -123,6 +123,9 @@
     },
     "responsetimemillis": {
       "rubicon": "{{ rubicon.response_time_ms }}"
+    },
+    "usersync" : {
+      "rubicon": { "status": "expired" }
     }
   }
 }

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/test-auction-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/test-auction-response.json
@@ -1359,6 +1359,23 @@
       "adtelligent": "{{ adtelligent.response_time_ms }}",
       "openx": "{{ openx.response_time_ms }}",
       "eplanning": "{{ eplanning.response_time_ms }}"
+    },
+    "usersync" : {
+      "rubicon": { "status": "expired" },
+      "audienceNetwork": { "status": "expired" },
+      "pulsepoint": { "status": "expired" },
+      "indexExchange": { "status": "expired" },
+      "lifestreet": { "status": "expired" },
+      "pubmatic": { "status": "expired" },
+      "appnexus": { "status": "expired" },
+      "appnexusAlias": { "status": "expired" },
+      "conversant": { "status": "expired" },
+      "conversantAlias": { "status": "expired" },
+      "sovrn": { "status": "expired" },
+      "adtelligent": { "status": "expired" },
+      "adform": { "status": "expired" },
+      "openx": { "status": "none" },
+      "eplanning": { "status": "expired" }
     }
   }
 }


### PR DESCRIPTION
See https://github.com/rubicon-project/prebid-server-java/issues/74

About this PR
- if we do not want this field to be serialized when /openrtb2/auction is invoked maybe we could just mark it as @JsonIgnore
- the current PR does not set ExtResponseSyncData's syncs field