### PR TITLE
Being able to extract user's cookie sync status with each bidder

### DIFF
--- a/src/main/java/org/prebid/server/auction/BidResponsePostProcessor.java
+++ b/src/main/java/org/prebid/server/auction/BidResponsePostProcessor.java
@@ -3,6 +3,8 @@ package org.prebid.server.auction;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.response.BidResponse;
 import io.vertx.core.Future;
+import org.prebid.server.cookie.UidsCookie;
+import org.prebid.server.cookie.proto.Uids;
 
 /**
  * A hook that is pulled once auction has been held. It allows companies that host Prebid Server to define and apply
@@ -13,11 +15,12 @@ public interface BidResponsePostProcessor {
     /**
      * This method is called when auction is finished.
      *
-     * @param bidRequest  original auction request
+     * @param bidRequest original auction request
+     * @param uidsCookie auction request {@link Uids} container
      * @param bidResponse auction result
      * @return a {@link Future} with (possibly modified) auction result
      */
-    Future<BidResponse> postProcess(BidRequest bidRequest, BidResponse bidResponse);
+    Future<BidResponse> postProcess(BidRequest bidRequest, UidsCookie uidsCookie, BidResponse bidResponse);
 
     /**
      * Returns {@link NoOpBidResponsePostProcessor} instance that just does nothing to original auction result.
@@ -31,7 +34,7 @@ public interface BidResponsePostProcessor {
      */
     class NoOpBidResponsePostProcessor implements BidResponsePostProcessor {
         @Override
-        public Future<BidResponse> postProcess(BidRequest bidRequest, BidResponse bidResponse) {
+        public Future<BidResponse> postProcess(BidRequest bidRequest, UidsCookie uidsCookie, BidResponse bidResponse) {
             return Future.succeededFuture(bidResponse);
         }
     }

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -142,7 +142,7 @@ public class ExchangeService {
                 .map(this::updateMetricsFromResponses)
                 .compose(result ->
                         toBidResponse(result, bidRequest, keywordsCreator, cacheInfo, timeout))
-                .compose(bidResponse -> bidResponsePostProcessor.postProcess(bidRequest, bidResponse));
+                .compose(bidResponse -> bidResponsePostProcessor.postProcess(bidRequest, uidsCookie, bidResponse));
     }
 
     /**

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -127,7 +127,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         given(responseBidValidator.validate(any())).willReturn(ValidationResult.success());
         given(usersyncer.cookieFamilyName()).willReturn("cookieFamily");
-        given(bidResponsePostProcessor.postProcess(any(), any())).willCallRealMethod();
+        given(bidResponsePostProcessor.postProcess(any(), any(), any())).willCallRealMethod();
         given(metrics.forAdapter(anyString())).willReturn(adapterMetrics);
         given(metrics.forAdapter(anyString()).forBidType(any())).willReturn(adapterMarkupMetrics);
         given(currencyService.convertCurrency(any(), any(), any(), any()))
@@ -1170,7 +1170,7 @@ public class ExchangeServiceTest extends VertxTest {
         exchangeService.holdAuction(bidRequest, uidsCookie, timeout);
 
         // then
-        verify(bidResponsePostProcessor).postProcess(same(bidRequest), any());
+        verify(bidResponsePostProcessor).postProcess(same(bidRequest), same(uidsCookie), any());
     }
 
     @Test


### PR DESCRIPTION
- Related issue https://github.com/rubicon-project/prebid-server-java/issues/74
- As per discussed in the original PR https://github.com/rubicon-project/prebid-server-java/pull/75 we adapt BidResponsePostProcessor