### PR TITLE
AmpResponsePostProcessor : ease of adding custom key values in AMP RTC response

### DIFF
--- a/src/main/java/org/prebid/server/analytics/model/AmpEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/AmpEvent.java
@@ -1,11 +1,12 @@
 package org.prebid.server.analytics.model;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.iab.openrtb.response.BidResponse;
 import lombok.Builder;
 import lombok.Value;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a transaction at /openrtb2/amp endpoint.
@@ -20,7 +21,7 @@ public class AmpEvent {
 
     BidResponse bidResponse;
 
-    ObjectNode targeting;
+    Map<String, JsonNode> targeting;
 
     String origin;
 }

--- a/src/main/java/org/prebid/server/analytics/model/AmpEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/AmpEvent.java
@@ -1,11 +1,11 @@
 package org.prebid.server.analytics.model;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.response.BidResponse;
 import lombok.Builder;
 import lombok.Value;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a transaction at /openrtb2/amp endpoint.
@@ -20,7 +20,7 @@ public class AmpEvent {
 
     BidResponse bidResponse;
 
-    Map<String, Object> targeting;
+    ObjectNode targeting;
 
     String origin;
 }

--- a/src/main/java/org/prebid/server/analytics/model/AmpEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/AmpEvent.java
@@ -20,7 +20,7 @@ public class AmpEvent {
 
     BidResponse bidResponse;
 
-    Map<String, String> targeting;
+    Map<String, Object> targeting;
 
     String origin;
 }

--- a/src/main/java/org/prebid/server/auction/AmpResponsePostProcessor.java
+++ b/src/main/java/org/prebid/server/auction/AmpResponsePostProcessor.java
@@ -1,0 +1,45 @@
+package org.prebid.server.auction;
+
+import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.response.BidResponse;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import org.prebid.server.proto.response.AmpResponse;
+
+/**
+ * A hook that is pulled prior sending the AMP RTC response back to the client.
+ * It allows companies that host Prebid Server to add custom key values in the AMP RTC response
+ */
+public interface AmpResponsePostProcessor {
+
+    /**
+     * This method is called prior sending the response back to the client
+     *
+     * @param bidRequest  original auction request
+     * @param bidResponse auction result
+     * @param ampResponse AMP RTC response
+     * @param queryParams request's query params
+     * @return a {@link Future} with (possibly modified) amp response result
+     */
+    Future<AmpResponse> postProcess(BidRequest bidRequest, BidResponse bidResponse, AmpResponse ampResponse,
+                                    MultiMap queryParams);
+
+    /**
+     * Returns {@link NoOpAmpResponsePostProcessor} instance that just does nothing.
+     */
+    static AmpResponsePostProcessor noOp() {
+        return new NoOpAmpResponsePostProcessor();
+    }
+
+    /**
+     * Well, dump stub that gives back unaltered AMP response.
+     */
+    class NoOpAmpResponsePostProcessor implements AmpResponsePostProcessor {
+
+        @Override
+        public Future<AmpResponse> postProcess(BidRequest bidRequest, BidResponse bidResponse, AmpResponse ampResponse,
+                                               MultiMap queryParams) {
+            return Future.succeededFuture(ampResponse);
+        }
+    }
+}

--- a/src/main/java/org/prebid/server/proto/response/AmpResponse.java
+++ b/src/main/java/org/prebid/server/proto/response/AmpResponse.java
@@ -10,7 +10,7 @@ import java.util.Map;
 @Value
 public class AmpResponse {
 
-    Map<String, String> targeting;
+    Map<String, Object> targeting;
 
     ExtResponseDebug debug;
 }

--- a/src/main/java/org/prebid/server/proto/response/AmpResponse.java
+++ b/src/main/java/org/prebid/server/proto/response/AmpResponse.java
@@ -1,15 +1,17 @@
 package org.prebid.server.proto.response;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.prebid.server.proto.openrtb.ext.response.ExtResponseDebug;
+
+import java.util.Map;
 
 @AllArgsConstructor(staticName = "of")
 @Value
 public class AmpResponse {
 
-    ObjectNode targeting;
+    Map<String, JsonNode> targeting;
 
     ExtResponseDebug debug;
 }

--- a/src/main/java/org/prebid/server/proto/response/AmpResponse.java
+++ b/src/main/java/org/prebid/server/proto/response/AmpResponse.java
@@ -1,16 +1,15 @@
 package org.prebid.server.proto.response;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.prebid.server.proto.openrtb.ext.response.ExtResponseDebug;
-
-import java.util.Map;
 
 @AllArgsConstructor(staticName = "of")
 @Value
 public class AmpResponse {
 
-    Map<String, Object> targeting;
+    ObjectNode targeting;
 
     ExtResponseDebug debug;
 }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import org.prebid.server.auction.AmpRequestFactory;
+import org.prebid.server.auction.AmpResponsePostProcessor;
 import org.prebid.server.auction.AuctionRequestFactory;
 import org.prebid.server.auction.BidResponsePostProcessor;
 import org.prebid.server.auction.ExchangeService;
@@ -212,6 +213,11 @@ public class ServiceConfiguration {
     @Bean
     BidResponsePostProcessor bidResponsePostProcessor() {
         return BidResponsePostProcessor.noOp();
+    }
+
+    @Bean
+    AmpResponsePostProcessor ampResponsePostProcessor() {
+        return AmpResponsePostProcessor.noOp();
     }
 
     @Bean

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -13,6 +13,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.prebid.server.analytics.CompositeAnalyticsReporter;
 import org.prebid.server.auction.AmpRequestFactory;
+import org.prebid.server.auction.AmpResponsePostProcessor;
 import org.prebid.server.auction.AuctionRequestFactory;
 import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.auction.PreBidRequestContextFactory;
@@ -174,13 +175,14 @@ public class WebConfiguration {
             AmpProperties ampProperties,
             BidderCatalog bidderCatalog,
             CompositeAnalyticsReporter analyticsReporter,
+            AmpResponsePostProcessor ampResponsePostProcessor,
             Metrics metrics,
             Clock clock,
             TimeoutFactory timeoutFactory) {
 
         return new AmpHandler(defaultTimeoutMs, ampRequestFactory, exchangeService, uidsCookieService,
-                ampProperties.getCustomTargetingSet(), bidderCatalog, analyticsReporter, metrics, clock,
-                timeoutFactory);
+                ampProperties.getCustomTargetingSet(), bidderCatalog, analyticsReporter, ampResponsePostProcessor,
+                metrics, clock, timeoutFactory);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/ApplicationTest.java
@@ -262,7 +262,7 @@ public class ApplicationTest extends VertxTest {
     }
 
     @Test
-    public void ampShouldReturnTargeting() throws IOException {
+    public void ampShouldReturnTargeting() throws IOException, JSONException {
         // given
         // rubicon exchange
         wireMockRule.stubFor(post(urlPathEqualTo("/rubicon-exchange"))
@@ -280,7 +280,7 @@ public class ApplicationTest extends VertxTest {
                 .willReturn(aResponse().withBody(jsonFrom("amp/test-cache-response.json"))));
 
         // when and then
-        given(spec)
+        Response response = given(spec)
                 .header("Referer", "http://www.example.com")
                 .header("X-Forwarded-For", "192.168.244.1")
                 .header("User-Agent", "userAgent")
@@ -295,10 +295,8 @@ public class ApplicationTest extends VertxTest {
                         "&oh=120" +
                         "&timeout=10000000" +
                         "&slot=overwrite-tagId" +
-                        "&curl=https%3A%2F%2Fgoogle.com")
-                .then()
-                .assertThat()
-                .body(Matchers.equalTo(jsonFrom("amp/test-amp-response.json")));
+                        "&curl=https%3A%2F%2Fgoogle.com");
+        JSONAssert.assertEquals(jsonFrom("amp/test-amp-response.json"), response.asString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -14,6 +14,7 @@ import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.Before;
 import org.junit.Rule;
@@ -378,7 +379,7 @@ public class AmpHandlerTest extends VertxTest {
                                 .build()))
                         .build()))
                         .build())
-                .targeting(singletonMap("hb_cache_id_bidder1", "value1"))
+                .targeting(Json.mapper.createObjectNode().put("hb_cache_id_bidder1", "value1"))
                 .origin("http://example.com")
                 .status(200)
                 .errors(emptyList())

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -26,6 +26,7 @@ import org.prebid.server.VertxTest;
 import org.prebid.server.analytics.AnalyticsReporter;
 import org.prebid.server.analytics.model.AmpEvent;
 import org.prebid.server.auction.AmpRequestFactory;
+import org.prebid.server.auction.AmpResponsePostProcessor;
 import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.bidder.Bidder;
 import org.prebid.server.bidder.BidderCatalog;
@@ -107,7 +108,8 @@ public class AmpHandlerTest extends VertxTest {
         final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
         final TimeoutFactory timeoutFactory = new TimeoutFactory(clock);
         ampHandler = new AmpHandler(5000, ampRequestFactory, exchangeService, uidsCookieService,
-                singleton("bidder1"), bidderCatalog, analyticsReporter, metrics, clock, timeoutFactory);
+                singleton("bidder1"), bidderCatalog, analyticsReporter, new AmpResponsePostProcessor.NoOpAmpResponsePostProcessor(), metrics, clock,
+                timeoutFactory);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -14,7 +14,6 @@ import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.Before;
 import org.junit.Rule;
@@ -379,7 +378,7 @@ public class AmpHandlerTest extends VertxTest {
                                 .build()))
                         .build()))
                         .build())
-                .targeting(Json.mapper.createObjectNode().put("hb_cache_id_bidder1", "value1"))
+                .targeting(singletonMap("hb_cache_id_bidder1", TextNode.valueOf("value1")))
                 .origin("http://example.com")
                 .status(200)
                 .errors(emptyList())


### PR DESCRIPTION

- related to https://github.com/rubicon-project/prebid-server-java/issues/84
- AmpResponsePostProcessor is executed prior sending the AMP RTC response back to the client, it allows companies that host Prebid Server to add custom key values in the AMP RTC response
- Changed AmpEvent and AmpResponse targeting map from Map<String, String> to Map<String, Object> to conform with RTC response specification https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-documentation.md#rtc-callout-endpoint-and-response-specification