### PR TITLE
More granular bidder bids presence and error metrics

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -799,29 +799,31 @@ public class ExchangeService {
                 errors.stream()
                         .map(BidderError::getType)
                         .distinct()
-                        .map(errorType -> {
-                            final MetricName errorMetric;
-                            switch (errorType) {
-                                case bad_input:
-                                    errorMetric = MetricName.badinput;
-                                    break;
-                                case bad_server_response:
-                                    errorMetric = MetricName.badserverresponse;
-                                    break;
-                                case timeout:
-                                    errorMetric = MetricName.timeout;
-                                    break;
-                                case generic:
-                                default:
-                                    errorMetric = MetricName.unknown_error;
-                            }
-                            return errorMetric;
-                        })
+                        .map(ExchangeService::bidderErrorTypeToMetric)
                         .forEach(errorMetric -> adapterMetrics.request().incCounter(errorMetric));
             }
         }
 
         return bidderResponses;
+    }
+
+    private static MetricName bidderErrorTypeToMetric(BidderError.Type errorType) {
+        final MetricName errorMetric;
+        switch (errorType) {
+            case bad_input:
+                errorMetric = MetricName.badinput;
+                break;
+            case bad_server_response:
+                errorMetric = MetricName.badserverresponse;
+                break;
+            case timeout:
+                errorMetric = MetricName.timeout;
+                break;
+            case generic:
+            default:
+                errorMetric = MetricName.unknown_error;
+        }
+        return errorMetric;
     }
 
     /**

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -685,7 +685,7 @@ public class ExchangeService {
             final ValidationResult validationResult = responseBidValidator.validate(bid.getBid());
             if (validationResult.hasErrors()) {
                 for (String error : validationResult.getErrors()) {
-                    errors.add(BidderError.unknown(error));
+                    errors.add(BidderError.generic(error));
                 }
             } else {
                 validBids.add(bid);
@@ -733,7 +733,7 @@ public class ExchangeService {
                 }
                 updatedBidderBids.add(bidderBid);
             } catch (PreBidException ex) {
-                errors.add(BidderError.unknown(ex.getMessage()));
+                errors.add(BidderError.generic(ex.getMessage()));
             }
         }
 

--- a/src/main/java/org/prebid/server/bidder/HttpAdapterConnector.java
+++ b/src/main/java/org/prebid/server/bidder/HttpAdapterConnector.java
@@ -159,7 +159,7 @@ public class HttpAdapterConnector {
 
         final BidderError error = exception instanceof TimeoutException || exception instanceof ConnectTimeoutException
                 ? BidderError.timeout("Timed out")
-                : BidderError.unknown(exception.getMessage());
+                : BidderError.generic(exception.getMessage());
 
         future.complete(ExchangeCall.error(bidderDebug, error));
     }

--- a/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
@@ -108,7 +108,7 @@ public class HttpBidderRequester<T> implements BidderRequester {
         final BidderError.Type errorType =
                 exception instanceof TimeoutException || exception instanceof ConnectTimeoutException
                         ? BidderError.Type.timeout
-                        : BidderError.Type.unknown;
+                        : BidderError.Type.generic;
         result.complete(HttpCall.failure(httpRequest, BidderError.create(exception.getMessage(), errorType)));
     }
 

--- a/src/main/java/org/prebid/server/bidder/model/BidderError.java
+++ b/src/main/java/org/prebid/server/bidder/model/BidderError.java
@@ -18,8 +18,8 @@ public class BidderError {
         return BidderError.of(message, type);
     }
 
-    public static BidderError unknown(String message) {
-        return BidderError.of(message, Type.unknown);
+    public static BidderError generic(String message) {
+        return BidderError.of(message, Type.generic);
     }
 
     public static BidderError badInput(String message) {
@@ -57,6 +57,6 @@ public class BidderError {
         bad_server_response,
 
         timeout,
-        unknown
+        generic
     }
 }

--- a/src/main/java/org/prebid/server/metric/AdapterMetrics.java
+++ b/src/main/java/org/prebid/server/metric/AdapterMetrics.java
@@ -14,23 +14,28 @@ import java.util.function.Function;
 public class AdapterMetrics extends UpdatableMetrics {
 
     private final RequestTypeMetrics requestTypeMetrics;
+    private final RequestMetrics requestMetrics;
     private final Function<BidType, BidTypeMetrics> bidTypeMetricsCreator;
     private final Map<BidType, BidTypeMetrics> bidTypeMetrics;
 
     AdapterMetrics(MetricRegistry metricRegistry, CounterType counterType, String adapterType) {
         super(Objects.requireNonNull(metricRegistry), Objects.requireNonNull(counterType),
-                nameCreator(createPrefix(Objects.requireNonNull(adapterType))));
+                nameCreator(createAdapterPrefix(Objects.requireNonNull(adapterType))));
 
         bidTypeMetricsCreator = bidType ->
-                new BidTypeMetrics(metricRegistry, counterType, createPrefix(adapterType), bidType);
-        requestTypeMetrics = new RequestTypeMetrics(metricRegistry, counterType, createPrefix(adapterType));
+                new BidTypeMetrics(metricRegistry, counterType, createAdapterPrefix(adapterType), bidType);
+        requestTypeMetrics = new RequestTypeMetrics(metricRegistry, counterType, createAdapterPrefix(adapterType));
+        requestMetrics = new RequestMetrics(metricRegistry, counterType, createAdapterPrefix(adapterType));
         bidTypeMetrics = new HashMap<>();
     }
 
     AdapterMetrics(MetricRegistry metricRegistry, CounterType counterType, String account, String adapterType) {
         super(Objects.requireNonNull(metricRegistry), Objects.requireNonNull(counterType),
-                nameCreator(String.format("account.%s.%s", Objects.requireNonNull(account),
+                nameCreator(createAccountAdapterPrefix(Objects.requireNonNull(account),
                         Objects.requireNonNull(adapterType))));
+
+        requestMetrics = new RequestMetrics(metricRegistry, counterType,
+                createAccountAdapterPrefix(account, adapterType));
 
         // not used for account.adapter metrics
         bidTypeMetricsCreator = null;
@@ -38,8 +43,12 @@ public class AdapterMetrics extends UpdatableMetrics {
         bidTypeMetrics = null;
     }
 
-    private static String createPrefix(String adapterType) {
+    private static String createAdapterPrefix(String adapterType) {
         return String.format("adapter.%s", adapterType);
+    }
+
+    private static String createAccountAdapterPrefix(String account, String adapterType) {
+        return String.format("account.%s.%s", account, adapterType);
     }
 
     private static Function<MetricName, String> nameCreator(String prefix) {
@@ -48,6 +57,10 @@ public class AdapterMetrics extends UpdatableMetrics {
 
     public RequestTypeMetrics requestType() {
         return requestTypeMetrics;
+    }
+
+    public RequestMetrics request() {
+        return requestMetrics;
     }
 
     public BidTypeMetrics forBidType(BidType bidType) {

--- a/src/main/java/org/prebid/server/metric/MetricName.java
+++ b/src/main/java/org/prebid/server/metric/MetricName.java
@@ -5,9 +5,6 @@ public enum MetricName {
     requests,
     app_requests,
     no_cookie_requests,
-    no_bid_requests,
-    timeout_requests,
-    error_requests,
     safari_requests,
     safari_no_cookie_requests,
     cookie_sync_requests,
@@ -25,9 +22,14 @@ public enum MetricName {
     amp,
     legacy,
 
-    // request statuses
+    // request and adapter statuses
     ok,
+    nobid,
+    gotbids,
     badinput,
+    badserverresponse,
+    timeout,
+    unknown_error,
     err,
 
     // cookie sync

--- a/src/main/java/org/prebid/server/metric/RequestMetrics.java
+++ b/src/main/java/org/prebid/server/metric/RequestMetrics.java
@@ -1,0 +1,21 @@
+package org.prebid.server.metric;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Request metrics support.
+ */
+public class RequestMetrics extends UpdatableMetrics {
+
+    RequestMetrics(MetricRegistry metricRegistry, CounterType counterType, String prefix) {
+        super(Objects.requireNonNull(metricRegistry), Objects.requireNonNull(counterType),
+                nameCreator(Objects.requireNonNull(prefix)));
+    }
+
+    private static Function<MetricName, String> nameCreator(String prefix) {
+        return metricName -> String.format("%s.requests.%s", prefix, metricName.toString());
+    }
+}

--- a/src/test/java/org/prebid/server/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/ApplicationTest.java
@@ -232,9 +232,10 @@ public class ApplicationTest extends VertxTest {
                 .header("User-Agent", "userAgent")
                 .header("Origin", "http://www.example.com")
                 // this uids cookie value stands for
-                // {"uids":{"rubicon":"J5VLCWQP-26-CWFT","adnxs":"12345","audienceNetwork":"FB-UID","pulsepoint":"PP-UID",
-                // "indexExchange":"IE-UID","lifestreet":"LS-UID","pubmatic":"PM-UID","conversant":"CV-UID",
-                // "sovrn":"990011","adtelligent":"AT-UID","adform":"AF-UID","eplanning":"EP-UID"}}
+                // {"uids":{"rubicon":"J5VLCWQP-26-CWFT","adnxs":"12345","audienceNetwork":"FB-UID",
+                // "pulsepoint":"PP-UID","indexExchange":"IE-UID","lifestreet":"LS-UID","pubmatic":"PM-UID",
+                // "conversant":"CV-UID","sovrn":"990011","adtelligent":"AT-UID","adform":"AF-UID",
+                // "eplanning":"EP-UID"}}
                 .cookie("uids", "eyJ1aWRzIjp7InJ1Ymljb24iOiJKNVZMQ1dRUC0yNi1DV0ZUIiwiYWRueHMiOiIxMjM0NSIsImF"
                         + "1ZGllbmNlTmV0d29yayI6IkZCLVVJRCIsInB1bHNlcG9pbnQiOiJQUC1VSUQiLCJpbmRleEV4Y2hhbmdl"
                         + "IjoiSUUtVUlEIiwibGlmZXN0cmVldCI6IkxTLVVJRCIsInB1Ym1hdGljIjoiUE0tVUlEIiwiY29udmVyc"

--- a/src/test/java/org/prebid/server/bidder/HttpAdapterConnectorTest.java
+++ b/src/test/java/org/prebid/server/bidder/HttpAdapterConnectorTest.java
@@ -290,7 +290,7 @@ public class HttpAdapterConnectorTest extends VertxTest {
 
         // then
         final AdapterResponse adapterResponse = adapterResponseFuture.result();
-        assertThat(adapterResponse.getError()).isEqualTo(BidderError.unknown("Request exception"));
+        assertThat(adapterResponse.getError()).isEqualTo(BidderError.generic("Request exception"));
         assertThat(adapterResponse.getBidderStatus().getError()).isEqualTo("Request exception");
     }
 
@@ -305,7 +305,7 @@ public class HttpAdapterConnectorTest extends VertxTest {
 
         // then
         final AdapterResponse adapterResponse = adapterResponseFuture.result();
-        assertThat(adapterResponse.getError()).isEqualTo(BidderError.unknown("Response exception"));
+        assertThat(adapterResponse.getError()).isEqualTo(BidderError.generic("Response exception"));
         assertThat(adapterResponse.getBidderStatus().getError()).isEqualTo("Response exception");
     }
 

--- a/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
+++ b/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
@@ -363,8 +363,8 @@ public class HttpBidderRequesterTest {
         assertThat(bidderSeatBid.getBids()).hasSize(1);
         assertThat(bidderSeatBid.getErrors()).containsOnly(
                 BidderError.badInput("makeHttpRequestsError"),
-                BidderError.unknown("Request exception"),
-                BidderError.unknown("Response exception"),
+                BidderError.generic("Request exception"),
+                BidderError.generic("Response exception"),
                 BidderError.timeout("Timeout exception"),
                 BidderError.badServerResponse("Unexpected status code: 500. Run with request.test = 1 for more info"),
                 BidderError.badInput("Unexpected status code: 400. Run with request.test = 1 for more info"),

--- a/src/test/java/org/prebid/server/metric/MetricsTest.java
+++ b/src/test/java/org/prebid/server/metric/MetricsTest.java
@@ -30,7 +30,7 @@ public class MetricsTest {
 
     @Test
     public void createShouldReturnMetricsConfiguredWithCounterType() {
-        verifyCreatesConfiguredCounterType(metrics -> metrics.incCounter(MetricName.requests));
+        verifyCreatesConfiguredCounterType(metrics -> metrics.incCounter(MetricName.bids_received));
     }
 
     @Test
@@ -60,16 +60,16 @@ public class MetricsTest {
     @Test
     public void forAdapterShouldReturnAdapterMetricsConfiguredWithCounterType() {
         verifyCreatesConfiguredCounterType(
-                metrics -> metrics.forAdapter(RUBICON).incCounter(MetricName.requests));
+                metrics -> metrics.forAdapter(RUBICON).incCounter(MetricName.bids_received));
     }
 
     @Test
     public void forAdapterShouldReturnAdapterMetricsConfiguredWithAdapterType() {
         // when
-        metrics.forAdapter(RUBICON).incCounter(MetricName.requests);
+        metrics.forAdapter(RUBICON).incCounter(MetricName.bids_received);
 
         // then
-        assertThat(metricRegistry.counter("adapter.rubicon.requests").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("adapter.rubicon.bids_received").getCount()).isEqualTo(1);
     }
 
     @Test
@@ -96,6 +96,29 @@ public class MetricsTest {
     }
 
     @Test
+    public void shouldReturnSameAdapterRequestMetricsOnSuccessiveCalls() {
+        assertThat(metrics.forAdapter(RUBICON).request())
+                .isSameAs(metrics.forAdapter(RUBICON).request());
+    }
+
+    @Test
+    public void shouldReturnAdapterRequestMetricsConfiguredWithCounterType() {
+        verifyCreatesConfiguredCounterType(metrics -> metrics
+                .forAdapter(RUBICON)
+                .request()
+                .incCounter(MetricName.gotbids));
+    }
+
+    @Test
+    public void shouldReturnAdapterRequestMetricsConfiguredWithAdapterType() {
+        // when
+        metrics.forAdapter(RUBICON).request().incCounter(MetricName.gotbids);
+
+        // then
+        assertThat(metricRegistry.counter("adapter.rubicon.requests.gotbids").getCount()).isEqualTo(1);
+    }
+
+    @Test
     public void shouldReturnSameAccountAdapterMetricsOnSuccessiveCalls() {
         assertThat(metrics.forAccount("accountId").forAdapter(RUBICON))
                 .isSameAs(metrics.forAccount("accountId").forAdapter(RUBICON));
@@ -106,16 +129,40 @@ public class MetricsTest {
         verifyCreatesConfiguredCounterType(metrics -> metrics
                 .forAccount("accountId")
                 .forAdapter(RUBICON)
-                .incCounter(MetricName.requests));
+                .incCounter(MetricName.bids_received));
     }
 
     @Test
     public void shouldReturnAccountAdapterMetricsConfiguredWithAccountAndAdapterType() {
         // when
-        metrics.forAccount("accountId").forAdapter(RUBICON).incCounter(MetricName.requests);
+        metrics.forAccount("accountId").forAdapter(RUBICON).incCounter(MetricName.bids_received);
 
         // then
-        assertThat(metricRegistry.counter("account.accountId.rubicon.requests").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("account.accountId.rubicon.bids_received").getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldReturnSameAccountAdapterRequestMetricsOnSuccessiveCalls() {
+        assertThat(metrics.forAccount("accountId").forAdapter(RUBICON).request())
+                .isSameAs(metrics.forAccount("accountId").forAdapter(RUBICON).request());
+    }
+
+    @Test
+    public void shouldReturnAccountAdapterRequestMetricsConfiguredWithCounterType() {
+        verifyCreatesConfiguredCounterType(metrics -> metrics
+                .forAccount("accountId")
+                .forAdapter(RUBICON)
+                .request()
+                .incCounter(MetricName.gotbids));
+    }
+
+    @Test
+    public void shouldReturnAccountAdapterRequestMetricsConfiguredWithAccountAndAdapterType() {
+        // when
+        metrics.forAccount("accountId").forAdapter(RUBICON).request().incCounter(MetricName.gotbids);
+
+        // then
+        assertThat(metricRegistry.counter("account.accountId.rubicon.requests.gotbids").getCount()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
Partly addresses #81:
- `adapter.*.requests.(gotbids,nobid,badinput,badserverresponse,timeout,unkown_error)` metrics
- ` account.*.*.requests.(gotbids,nobid)` metrics