### PR TITLE
Bumped up vertx version to 3.5.2 to fix the bug with Connection: close request header and enabled compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
-        <vertx.version>3.5.0</vertx.version>
+        <vertx.version>3.5.2</vertx.version>
         <lombok.version>1.16.16</lombok.version>
         <commons.version>3.6</commons.version>
         <commons.collections.version>4.1</commons.collections.version>


### PR DESCRIPTION
We've stumbled upon this bug after compression has been enabled recently: https://github.com/eclipse/vert.x/issues/2184.

Upgrading to a newer vert.x version fixed that issue.