### PR TITLE
Fixed unhandled exception on highload

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ http:
 admin:
   port: 8060
 http-client:
-  max-pool-size: 1000
+  max-pool-size: 10000
   connect-timeout-ms: 2500
 external-url: http://localhost:8000
 default-timeout-ms: 250


### PR DESCRIPTION
Error in log:
```
2018-07-18 08:38:47.684  WARN 2240 --- [vert.x-eventloop-thread-2] o.p.server.bidder.HttpBidderRequester    : Error occurred while sending HTTP request to a bidder

java.lang.IllegalStateException: Response is closed
	at io.vertx.core.http.impl.HttpServerResponseImpl.checkValid(HttpServerResponseImpl.java:548)
	at io.vertx.core.http.impl.HttpServerResponseImpl.putHeader(HttpServerResponseImpl.java:153)
	at io.vertx.core.http.impl.HttpServerResponseImpl.putHeader(HttpServerResponseImpl.java:53)
	at org.prebid.server.handler.openrtb2.AmpHandler.handleResult(AmpHandler.java:247)
	at org.prebid.server.handler.openrtb2.AmpHandler.lambda$handle$304(AmpHandler.java:131)
	at io.vertx.core.impl.FutureImpl.tryFail(FutureImpl.java:165)
	at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:97)
	at io.vertx.core.Future.lambda$map$2(Future.java:303)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:147)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18)
	at io.vertx.core.impl.SucceededFuture.setHandler(SucceededFuture.java:40)
	at io.vertx.core.Future.lambda$compose$1(Future.java:270)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:147)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:147)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18)
	at io.vertx.core.impl.SucceededFuture.setHandler(SucceededFuture.java:40)
	at io.vertx.core.Future.lambda$compose$1(Future.java:270)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:147)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18)
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:76)
	at io.vertx.core.Future.lambda$compose$1(Future.java:270)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:147)
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18)
	at io.vertx.core.impl.CompositeFutureImpl.lambda$join$4(CompositeFutureImpl.java:119)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at io.vertx.core.Future.lambda$map$2(Future.java:306)
	at io.vertx.core.impl.CompositeFutureImpl.lambda$join$4(CompositeFutureImpl.java:119)
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121)
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83)
	at org.prebid.server.bidder.HttpBidderRequester.lambda$handleResponse$151(HttpBidderRequester.java:96)
	at io.vertx.core.http.impl.HttpClientResponseImpl$BodyHandler.notifyHandler(HttpClientResponseImpl.java:299)
	at io.vertx.core.http.impl.HttpClientResponseImpl.lambda$bodyHandler$0(HttpClientResponseImpl.java:189)
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleEnd(HttpClientResponseImpl.java:253)
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.endResponse(Http1xClientConnection.java:416)
	at io.vertx.core.http.impl.Http1xClientConnection.handleResponseEnd(Http1xClientConnection.java:496)
	at io.vertx.core.http.impl.Http1xClientHandler.handleMessage(Http1xClientHandler.java:118)
	at io.vertx.core.http.impl.Http1xClientHandler.handleMessage(Http1xClientHandler.java:32)
	at io.vertx.core.net.impl.VertxHandler.lambda$channelRead$1(VertxHandler.java:146)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:337)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:195)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:144)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:438)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:253)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1380)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1159)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1194)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1359)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:935)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:141)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:645)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:580)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:497)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:459)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Unknown Source)

2018-07-18 08:38:47.685 ERROR 2240 --- [vert.x-eventloop-thread-2] io.vertx.core.impl.ContextImpl           : Unhandled exception

java.lang.IllegalStateException: Result is already complete: succeeded
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:84)
	at org.prebid.server.bidder.HttpBidderRequester.handleException(HttpBidderRequester.java:112)
	at org.prebid.server.bidder.HttpBidderRequester.lambda$handleResponse$152(HttpBidderRequester.java:98)
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleException(HttpClientResponseImpl.java:266)
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleEnd(HttpClientResponseImpl.java:255)
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.endResponse(Http1xClientConnection.java:416)
	at io.vertx.core.http.impl.Http1xClientConnection.handleResponseEnd(Http1xClientConnection.java:496)
	at io.vertx.core.http.impl.Http1xClientHandler.handleMessage(Http1xClientHandler.java:118)
	at io.vertx.core.http.impl.Http1xClientHandler.handleMessage(Http1xClientHandler.java:32)
	at io.vertx.core.net.impl.VertxHandler.lambda$channelRead$1(VertxHandler.java:146)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:337)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:195)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:144)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:438)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:253)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1380)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1159)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1194)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1359)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:935)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:141)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:645)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:580)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:497)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:459)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Unknown Source)

2018-07-18 08:38:57.526 ERROR 2240 --- [vert.x-eventloop-thread-2] io.vertx.core.impl.ContextImpl           : Unhandled exception

java.lang.IllegalStateException: Response is closed
	at io.vertx.core.http.impl.HttpServerResponseImpl.checkValid(HttpServerResponseImpl.java:548)
	at io.vertx.core.http.impl.HttpServerResponseImpl.end0(HttpServerResponseImpl.java:401)
	at io.vertx.core.http.impl.HttpServerResponseImpl.end(HttpServerResponseImpl.java:319)
	at io.vertx.core.http.impl.HttpServerResponseImpl.end(HttpServerResponseImpl.java:308)
	at io.vertx.ext.web.impl.RoutingContextImplBase.unhandledFailure(RoutingContextImplBase.java:166)
	at io.vertx.ext.web.impl.RoutingContextImpl.checkHandleNoMatch(RoutingContextImpl.java:142)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:134)
	at io.vertx.ext.web.impl.RoutingContextImpl.doFail(RoutingContextImpl.java:465)
	at io.vertx.ext.web.impl.RoutingContextImpl.fail(RoutingContextImpl.java:160)
	at io.vertx.ext.web.handler.impl.TimeoutHandlerImpl.lambda$handle$0(TimeoutHandlerImpl.java:41)
	at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:885)
	at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:844)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:339)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Unknown Source)
```