### PR TITLE
Fixed "Response is closed" exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
-        <vertx.version>3.5.2</vertx.version>
+        <vertx.version>3.5.3</vertx.version>
         <lombok.version>1.16.16</lombok.version>
         <commons.version>3.6</commons.version>
         <commons.collections.version>4.1</commons.collections.version>

--- a/src/main/java/org/prebid/server/bidder/HttpAdapterConnector.java
+++ b/src/main/java/org/prebid/server/bidder/HttpAdapterConnector.java
@@ -156,7 +156,7 @@ public class HttpAdapterConnector {
                                         Future<ExchangeCall> future) {
         // Exception handler can be called more than one time, so all we can do is just to log the error
         if (future.isComplete()) {
-            logger.warn("Exception handler was called after processing has been completed with error: {0}",
+            logger.warn("Exception handler was called after processing has been completed: {0}",
                     exception.getMessage());
             return;
         }

--- a/src/main/java/org/prebid/server/bidder/HttpAdapterConnector.java
+++ b/src/main/java/org/prebid/server/bidder/HttpAdapterConnector.java
@@ -154,6 +154,13 @@ public class HttpAdapterConnector {
      */
     private static void handleException(Throwable exception, BidderDebug.BidderDebugBuilder bidderDebugBuilder,
                                         Future<ExchangeCall> future) {
+        // Exception handler can be called more than one time, so all we can do is just to log the error
+        if (future.isComplete()) {
+            logger.warn("Exception handler was called after processing has been completed with error: {0}",
+                    exception.getMessage());
+            return;
+        }
+
         logger.warn("Error occurred while sending bid request to an exchange", exception);
         final BidderDebug bidderDebug = bidderDebugBuilder.build();
 

--- a/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
@@ -104,6 +104,13 @@ public class HttpBidderRequester<T> implements BidderRequester {
      */
     private static <T> void handleException(Throwable exception, Future<HttpCall<T>> result,
                                             HttpRequest<T> httpRequest) {
+        // Exception handler can be called more than one time, so all we can do is just to log the error
+        if (result.isComplete()) {
+            logger.warn("Exception handler was called after processing has been completed with error: {0}",
+                    exception.getMessage());
+            return;
+        }
+
         logger.warn("Error occurred while sending HTTP request to a bidder", exception);
         final BidderError.Type errorType =
                 exception instanceof TimeoutException || exception instanceof ConnectTimeoutException

--- a/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
@@ -106,7 +106,7 @@ public class HttpBidderRequester<T> implements BidderRequester {
                                             HttpRequest<T> httpRequest) {
         // Exception handler can be called more than one time, so all we can do is just to log the error
         if (result.isComplete()) {
-            logger.warn("Exception handler was called after processing has been completed with error: {0}",
+            logger.warn("Exception handler was called after processing has been completed: {0}",
                     exception.getMessage());
             return;
         }

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -12,7 +12,6 @@ import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CookieHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.handler.StaticHandler;
-import io.vertx.ext.web.handler.TimeoutHandler;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.prebid.server.analytics.CompositeAnalyticsReporter;
@@ -98,7 +97,8 @@ public class WebConfiguration {
     HttpServerOptions httpServerOptions() {
         return new HttpServerOptions()
                 .setHandle100ContinueAutomatically(true)
-                .setCompressionSupported(true);
+                .setCompressionSupported(true)
+                .setIdleTimeout(10); // kick off long processing requests
     }
 
     @Bean
@@ -121,7 +121,6 @@ public class WebConfiguration {
                   StaticHandler staticHandler) {
 
         final Router router = Router.router(vertx);
-        router.route().handler(TimeoutHandler.create(10000)); // kick off long processing requests
         router.route().handler(cookieHandler);
         router.route().handler(bodyHandler);
         router.route().handler(noCacheHandler);


### PR DESCRIPTION
- Updated Vert.x to 3.5.3 version
- Replced `router.route().handler(TimeoutHandler.create(10000))` with `HttpServerOptions.setIdleTimeout(10)`
- RequestTimeMetric moved from `context.response().endHandler(...)` to `setHandler(responseResult -> handleResult(...))`
