### PR TITLE
Added a metric type for network errors

### DIFF
--- a/src/main/java/org/prebid/server/handler/AuctionHandler.java
+++ b/src/main/java/org/prebid/server/handler/AuctionHandler.java
@@ -327,12 +327,19 @@ public class AuctionHandler implements Handler<RoutingContext> {
             return;
         }
 
+        context.response().exceptionHandler(this::handleResponseException);
+
         context.response()
                 .putHeader(HttpHeaders.DATE, date())
                 .putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
                 .end(Json.encode(response));
 
         metrics.updateRequestTimeMetric(clock.millis() - startTime);
+    }
+
+    private void handleResponseException(Throwable throwable) {
+        logger.warn("Failed to send auction response", throwable);
+        metrics.updateRequestTypeMetric(REQUEST_TYPE_METRIC, MetricName.networkerr);
     }
 
     private static String date() {

--- a/src/main/java/org/prebid/server/metric/MetricName.java
+++ b/src/main/java/org/prebid/server/metric/MetricName.java
@@ -32,6 +32,7 @@ public enum MetricName {
     timeout,
     unknown_error,
     err,
+    networkerr,
 
     // cookie sync
     cookie_sync_requests,


### PR DESCRIPTION
The metrics `requests.networkerr.{legacy,openrtb2-web,openrtb2-app,amp}` was added on a step when response is considered as valid but something goes wrong on sending it to the client.