### PR TITLE
Changed using of Circuit breaker API

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -111,9 +111,9 @@ For database data source available next options:
 - `settings.database.stored-requests-query` - the SQL query to fetch stored requests.
 - `settings.database.amp-stored-requests-query` - the SQL query to fetch AMP stored requests.
 - `settings.database.circuit-breaker.enabled` - if equals to `true` circuit breaker will be used to make database client more robust.
-- `settings.database.circuit-breaker.max-failures` - the number of failure before opening the circuit.
-- `settings.database.circuit-breaker.timeout-ms` - consider a failure if the operation does not succeed in time.
-- `settings.database.circuit-breaker.reset-timeout-ms` - time spent in open state before attempting to re-try.
+- `settings.database.circuit-breaker.opening-threshold` - the number of failure before opening the circuit.
+- `settings.database.circuit-breaker.opening-interval-ms` - time interval for opening the circuit breaker if failures count reached.
+- `settings.database.circuit-breaker.closing-interval-ms` - time spent in open state before attempting to re-try.
 
 For HTTP data source available next options:
 - `settings.http.endpoint` - the url to fetch stored requests.

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -131,12 +131,13 @@ public class ServiceConfiguration {
             Metrics metrics,
             @Value("${http-client.max-pool-size}") int maxPoolSize,
             @Value("${http-client.connect-timeout-ms}") int connectTimeoutMs,
-            @Value("${http-client.circuit-breaker.max-failures}") int maxFailures,
-            @Value("${http-client.circuit-breaker.timeout-ms}") long timeoutMs,
-            @Value("${http-client.circuit-breaker.reset-timeout-ms}") long resetTimeoutMs) {
+            @Value("${http-client.circuit-breaker.opening-threshold}") int openingThreshold,
+            @Value("${http-client.circuit-breaker.opening-interval-ms}") long openingIntervalMs,
+            @Value("${http-client.circuit-breaker.closing-interval-ms}") long closingIntervalMs) {
 
         final HttpClient httpClient = createBasicHttpClient(vertx, maxPoolSize, connectTimeoutMs);
-        return new CircuitBreakerSecuredHttpClient(vertx, httpClient, metrics, maxFailures, timeoutMs, resetTimeoutMs);
+        return new CircuitBreakerSecuredHttpClient(vertx, httpClient, metrics, openingThreshold, openingIntervalMs,
+                closingIntervalMs);
     }
 
     private static BasicHttpClient createBasicHttpClient(Vertx vertx, int maxPoolSize, int connectTimeoutMs) {
@@ -190,12 +191,12 @@ public class ServiceConfiguration {
         CircuitBreakerSecuredGeoLocationService circuitBreakerSecuredGeoLocationService(
                 Vertx vertx,
                 Metrics metrics,
-                @Value("${gdpr.geolocation.circuit-breaker.max-failures}") int maxFailures,
-                @Value("${gdpr.geolocation.circuit-breaker.timeout-ms}") long timeoutMs,
-                @Value("${gdpr.geolocation.circuit-breaker.reset-timeout-ms}") long resetTimeoutMs) {
+                @Value("${gdpr.geolocation.circuit-breaker.opening-threshold}") int openingThreshold,
+                @Value("${gdpr.geolocation.circuit-breaker.opening-interval-ms}") long openingIntervalMs,
+                @Value("${gdpr.geolocation.circuit-breaker.closing-interval-ms}") long closingIntervalMs) {
 
-            return new CircuitBreakerSecuredGeoLocationService(vertx, createGeoLocationService(), metrics, maxFailures,
-                    timeoutMs, resetTimeoutMs);
+            return new CircuitBreakerSecuredGeoLocationService(vertx, createGeoLocationService(), metrics,
+                    openingThreshold, openingIntervalMs, closingIntervalMs);
         }
 
         /**

--- a/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
@@ -93,15 +93,13 @@ public class SettingsConfiguration {
         @ConditionalOnProperty(prefix = "settings.database.circuit-breaker", name = "enabled", havingValue = "true")
         CircuitBreakerSecuredJdbcClient circuitBreakerSecuredJdbcClient(
                 Vertx vertx, JDBCClient vertxJdbcClient, Metrics metrics, Clock clock, ContextRunner contextRunner,
-                @Value("${settings.database.circuit-breaker.max-failures}") int maxFailures,
-                @Value("${settings.database.circuit-breaker.timeout-ms}") long timeoutMs,
-                @Value("${settings.database.circuit-breaker.reset-timeout-ms}") long resetTimeoutMs) {
+                @Value("${settings.database.circuit-breaker.opening-threshold}") int openingThreshold,
+                @Value("${settings.database.circuit-breaker.opening-interval-ms}") long openingIntervalMs,
+                @Value("${settings.database.circuit-breaker.closing-interval-ms}") long closingIntervalMs) {
 
-            final BasicJdbcClient basicJdbcClient = createBasicJdbcClient(vertx, vertxJdbcClient, metrics, clock,
-                    contextRunner);
-
-            return new CircuitBreakerSecuredJdbcClient(vertx, basicJdbcClient, metrics, maxFailures, timeoutMs,
-                    resetTimeoutMs);
+            final JdbcClient jdbcClient = createBasicJdbcClient(vertx, vertxJdbcClient, metrics, clock, contextRunner);
+            return new CircuitBreakerSecuredJdbcClient(vertx, jdbcClient, metrics, openingThreshold, openingIntervalMs,
+                    closingIntervalMs);
         }
 
         private static BasicJdbcClient createBasicJdbcClient(

--- a/src/main/java/org/prebid/server/vertx/CircuitBreaker.java
+++ b/src/main/java/org/prebid/server/vertx/CircuitBreaker.java
@@ -1,0 +1,108 @@
+package org.prebid.server.vertx;
+
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.circuitbreaker.CircuitBreakerState;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+import java.util.Objects;
+
+/**
+ * Wrapper over Vert.x {@link io.vertx.circuitbreaker.CircuitBreaker} with functionality
+ * to reset failure counter to adjust open-circuit time frame.
+ */
+public class CircuitBreaker {
+
+    private final io.vertx.circuitbreaker.CircuitBreaker breaker;
+    private final long openingIntervalMs;
+
+    private long lastFailure;
+
+    public CircuitBreaker(String name, Vertx vertx, int openingThreshold, long openingIntervalMs,
+                          long closingIntervalMs) {
+        breaker = io.vertx.circuitbreaker.CircuitBreaker.create(
+                Objects.requireNonNull(name),
+                Objects.requireNonNull(vertx),
+                new CircuitBreakerOptions()
+                        .setMaxFailures(openingThreshold)
+                        .setResetTimeout(closingIntervalMs));
+
+        this.openingIntervalMs = openingIntervalMs;
+    }
+
+    /**
+     * Executes the given operation with the circuit breaker control.
+     */
+    public <T> Future<T> execute(Handler<Future<T>> command) {
+        return breaker.execute(future -> execute(command, future));
+    }
+
+    /**
+     * Executes operation and handle result of it on given {@link Future}.
+     */
+    private <T> void execute(Handler<Future<T>> command, Future<T> future) {
+        final Future<T> passedFuture = Future.future();
+        command.handle(passedFuture);
+
+        passedFuture
+                .compose(response -> succeedBreaker(response, future))
+                .recover(exception -> failBreaker(exception, future));
+    }
+
+    /**
+     * Succeeds given {@link Future} and returns it.
+     */
+    private static <T> Future<T> succeedBreaker(T result, Future<T> future) {
+        future.complete(result);
+        return future;
+    }
+
+    /**
+     * Fails given {@link Future} and returns it.
+     */
+    private <T> Future<T> failBreaker(Throwable exception, Future<T> future) {
+        ensureToIncrementFailureCount();
+
+        future.fail(exception);
+        return future;
+    }
+
+    /**
+     * Reset failure counter to adjust open-circuit time frame.
+     */
+    private void ensureToIncrementFailureCount() {
+        final long currentTimeMillis = System.currentTimeMillis();
+
+        if (breaker.state() == CircuitBreakerState.CLOSED && lastFailure > 0
+                && currentTimeMillis - lastFailure > openingIntervalMs) {
+            breaker.reset();
+        }
+
+        lastFailure = currentTimeMillis;
+    }
+
+    /**
+     * Sets a {@link Handler} invoked when the circuit breaker state switches to open.
+     */
+    public CircuitBreaker openHandler(Handler<Void> handler) {
+        breaker.openHandler(handler);
+        return this;
+    }
+
+    /**
+     * Sets a {@link Handler} invoked when the circuit breaker state switches to half-open.
+     */
+    public CircuitBreaker halfOpenHandler(Handler<Void> handler) {
+        breaker.halfOpenHandler(handler);
+        return this;
+    }
+
+    /**
+     * Sets a {@link Handler} invoked when the circuit breaker state switches to close.
+     */
+    public CircuitBreaker closeHandler(Handler<Void> handler) {
+        breaker.closeHandler(handler);
+        return this;
+    }
+}

--- a/src/main/java/org/prebid/server/vertx/http/BasicHttpClient.java
+++ b/src/main/java/org/prebid/server/vertx/http/BasicHttpClient.java
@@ -3,8 +3,8 @@ package org.prebid.server.vertx.http;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
+import org.prebid.server.vertx.http.model.HttpClientResponse;
 
 import java.util.Objects;
 
@@ -25,7 +25,7 @@ public class BasicHttpClient implements HttpClient {
         final Future<HttpClientResponse> future = Future.future();
 
         final HttpClientRequest httpClientRequest = httpClient.requestAbs(method, url)
-                .handler(future::complete)
+                .handler(response -> handleResponse(response, future))
                 .exceptionHandler(future::tryFail);
 
         if (headers != null) {
@@ -43,5 +43,13 @@ public class BasicHttpClient implements HttpClient {
         }
 
         return future;
+    }
+
+    private static void handleResponse(io.vertx.core.http.HttpClientResponse response,
+                                       Future<HttpClientResponse> future) {
+        response
+                .bodyHandler(buffer -> future.complete(
+                        HttpClientResponse.of(response.statusCode(), response.headers(), buffer.toString())))
+                .exceptionHandler(future::fail);
     }
 }

--- a/src/main/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClient.java
+++ b/src/main/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClient.java
@@ -2,15 +2,16 @@ package org.prebid.server.vertx.http;
 
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.circuitbreaker.CircuitBreakerState;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.prebid.server.exception.PreBidException;
 import org.prebid.server.metric.Metrics;
+import org.prebid.server.vertx.http.model.HttpClientResponse;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -26,26 +27,30 @@ public class CircuitBreakerSecuredHttpClient implements HttpClient {
 
     private static final Logger logger = LoggerFactory.getLogger(CircuitBreakerSecuredHttpClient.class);
 
+    private final Function<String, CircuitBreaker> circuitBreakerCreator;
+    private final Map<String, CircuitBreaker> circuitBreakerByName = new ConcurrentHashMap<>();
+    private final Map<String, Long> lastFailureByName = new ConcurrentHashMap<>();
+
     private final HttpClient httpClient;
     private final Metrics metrics;
-
-    private final Map<String, CircuitBreaker> circuitBreakerByName = new ConcurrentHashMap<>();
-    private final Function<String, CircuitBreaker> circuitBreakerCreator;
+    private final long openingIntervalMs;
 
     public CircuitBreakerSecuredHttpClient(Vertx vertx, HttpClient httpClient, Metrics metrics,
-                                           int maxFailures, long timeoutMs, long resetTimeoutMs) {
+                                           int openingThreshold, long openingIntervalMs, long closingIntervalMs) {
         circuitBreakerCreator = name -> CircuitBreaker.create("http-client-circuit-breaker-" + name,
                 Objects.requireNonNull(vertx),
                 new CircuitBreakerOptions()
-                        .setMaxFailures(maxFailures)
-                        .setTimeout(timeoutMs)
-                        .setResetTimeout(resetTimeoutMs))
+                        .setMaxFailures(openingThreshold)
+                        .setResetTimeout(closingIntervalMs))
                 .openHandler(ignored -> circuitOpened(name))
                 .halfOpenHandler(ignored -> circuitHalfOpened(name))
                 .closeHandler(ignored -> circuitClosed(name));
 
         this.httpClient = Objects.requireNonNull(httpClient);
         this.metrics = Objects.requireNonNull(metrics);
+        this.openingIntervalMs = openingIntervalMs;
+
+        logger.info("Initialized HTTP client with Circuit Breaker");
     }
 
     private void circuitOpened(String name) {
@@ -68,8 +73,37 @@ public class CircuitBreakerSecuredHttpClient implements HttpClient {
         final String name = nameFrom(url);
         final CircuitBreaker breaker = circuitBreakerByName.computeIfAbsent(name, circuitBreakerCreator);
 
-        return breaker.<HttpClientResponse>execute(future -> httpClient.request(method, url, headers, body, timeoutMs)
-                .setHandler(future));
+        return breaker.execute(future -> httpClient.request(method, url, headers, body, timeoutMs)
+                .compose(response -> succeedBreaker(response, future))
+                .recover(exception -> failBreaker(exception, future, name, breaker)));
+    }
+
+    private static Future<HttpClientResponse> succeedBreaker(HttpClientResponse response,
+                                                             Future<HttpClientResponse> future) {
+        future.complete(response);
+        return future;
+    }
+
+    private Future<HttpClientResponse> failBreaker(Throwable exception, Future<HttpClientResponse> future,
+                                                   String name, CircuitBreaker breaker) {
+        ensureToIncrementFailureCount(name, breaker);
+
+        future.fail(exception);
+        return future;
+    }
+
+    /**
+     * Reset failure counter to adjust open-circuit time frame.
+     */
+    private void ensureToIncrementFailureCount(String name, CircuitBreaker breaker) {
+        final long currentTimeMillis = System.currentTimeMillis();
+
+        final long lastFailureMs = lastFailureByName.computeIfAbsent(name, ignored -> currentTimeMillis);
+        if (breaker.state() == CircuitBreakerState.CLOSED && currentTimeMillis - lastFailureMs > openingIntervalMs) {
+            breaker.reset();
+        }
+
+        lastFailureByName.put(name, currentTimeMillis);
     }
 
     private static String nameFrom(String urlAsString) {

--- a/src/main/java/org/prebid/server/vertx/http/HttpClient.java
+++ b/src/main/java/org/prebid/server/vertx/http/HttpClient.java
@@ -2,8 +2,8 @@ package org.prebid.server.vertx.http;
 
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
+import org.prebid.server.vertx.http.model.HttpClientResponse;
 
 /**
  * Interface describes HTTP interactions.

--- a/src/main/java/org/prebid/server/vertx/http/model/HttpClientResponse.java
+++ b/src/main/java/org/prebid/server/vertx/http/model/HttpClientResponse.java
@@ -1,0 +1,21 @@
+package org.prebid.server.vertx.http.model;
+
+import io.vertx.core.MultiMap;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Holds Http client response data.
+ * <p>
+ * Should be created in "bodyHandler(...) after response has been read."
+ */
+@AllArgsConstructor(staticName = "of")
+@Value
+public class HttpClientResponse {
+
+    int statusCode;
+
+    MultiMap headers;
+
+    String body;
+}

--- a/src/main/java/org/prebid/server/vertx/jdbc/CircuitBreakerSecuredJdbcClient.java
+++ b/src/main/java/org/prebid/server/vertx/jdbc/CircuitBreakerSecuredJdbcClient.java
@@ -2,6 +2,7 @@ package org.prebid.server.vertx.jdbc;
 
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.circuitbreaker.CircuitBreakerState;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
@@ -24,21 +25,24 @@ public class CircuitBreakerSecuredJdbcClient implements JdbcClient {
     private final JdbcClient jdbcClient;
     private final Metrics metrics;
     private final CircuitBreaker breaker;
+    private final long openingIntervalMs;
+
+    private long lastFailure;
 
     public CircuitBreakerSecuredJdbcClient(Vertx vertx, JdbcClient jdbcClient, Metrics metrics,
-                                           int maxFailures, long timeoutMs, long resetTimeoutMs) {
+                                           int openingThreshold, long openingIntervalMs, long closingIntervalMs) {
 
         breaker = CircuitBreaker.create("jdbc-client-circuit-breaker", Objects.requireNonNull(vertx),
                 new CircuitBreakerOptions()
-                        .setMaxFailures(maxFailures)
-                        .setTimeout(timeoutMs)
-                        .setResetTimeout(resetTimeoutMs))
+                        .setMaxFailures(openingThreshold)
+                        .setResetTimeout(closingIntervalMs))
                 .openHandler(ignored -> circuitOpened())
                 .halfOpenHandler(ignored -> circuitHalfOpened())
                 .closeHandler(ignored -> circuitClosed());
 
         this.jdbcClient = Objects.requireNonNull(jdbcClient);
         this.metrics = Objects.requireNonNull(metrics);
+        this.openingIntervalMs = openingIntervalMs;
 
         logger.info("Initialized JDBC client with Circuit Breaker");
     }
@@ -61,6 +65,32 @@ public class CircuitBreakerSecuredJdbcClient implements JdbcClient {
     public <T> Future<T> executeQuery(String query, List<String> params, Function<ResultSet, T> mapper,
                                       Timeout timeout) {
         return breaker.execute(future -> jdbcClient.executeQuery(query, params, mapper, timeout)
-                .setHandler(future));
+                .compose(response -> succeedBreaker(response, future))
+                .recover(exception -> failBreaker(exception, future)));
+    }
+
+    private static <T> Future<T> succeedBreaker(T response, Future<T> future) {
+        future.complete(response);
+        return future;
+    }
+
+    private <T> Future<T> failBreaker(Throwable exception, Future<T> future) {
+        ensureToIncrementFailureCount();
+
+        future.fail(exception);
+        return future;
+    }
+
+    /**
+     * Reset failure counter to adjust open-circuit time frame.
+     */
+    private void ensureToIncrementFailureCount() {
+        final long currentTimeMillis = System.currentTimeMillis();
+
+        if (breaker.state() == CircuitBreakerState.CLOSED && currentTimeMillis - lastFailure > openingIntervalMs) {
+            breaker.reset();
+        }
+
+        lastFailure = currentTimeMillis;
     }
 }

--- a/src/main/java/org/prebid/server/vertx/jdbc/CircuitBreakerSecuredJdbcClient.java
+++ b/src/main/java/org/prebid/server/vertx/jdbc/CircuitBreakerSecuredJdbcClient.java
@@ -1,8 +1,5 @@
 package org.prebid.server.vertx.jdbc;
 
-import io.vertx.circuitbreaker.CircuitBreaker;
-import io.vertx.circuitbreaker.CircuitBreakerOptions;
-import io.vertx.circuitbreaker.CircuitBreakerState;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
@@ -10,6 +7,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.metric.Metrics;
+import org.prebid.server.vertx.CircuitBreaker;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,27 +20,21 @@ public class CircuitBreakerSecuredJdbcClient implements JdbcClient {
 
     private static final Logger logger = LoggerFactory.getLogger(CircuitBreakerSecuredJdbcClient.class);
 
+    private final CircuitBreaker breaker;
     private final JdbcClient jdbcClient;
     private final Metrics metrics;
-    private final CircuitBreaker breaker;
-    private final long openingIntervalMs;
-
-    private long lastFailure;
 
     public CircuitBreakerSecuredJdbcClient(Vertx vertx, JdbcClient jdbcClient, Metrics metrics,
                                            int openingThreshold, long openingIntervalMs, long closingIntervalMs) {
 
-        breaker = CircuitBreaker.create("jdbc-client-circuit-breaker", Objects.requireNonNull(vertx),
-                new CircuitBreakerOptions()
-                        .setMaxFailures(openingThreshold)
-                        .setResetTimeout(closingIntervalMs))
+        breaker = new CircuitBreaker("jdbc-client-circuit-breaker", Objects.requireNonNull(vertx),
+                openingThreshold, openingIntervalMs, closingIntervalMs)
                 .openHandler(ignored -> circuitOpened())
                 .halfOpenHandler(ignored -> circuitHalfOpened())
                 .closeHandler(ignored -> circuitClosed());
 
         this.jdbcClient = Objects.requireNonNull(jdbcClient);
         this.metrics = Objects.requireNonNull(metrics);
-        this.openingIntervalMs = openingIntervalMs;
 
         logger.info("Initialized JDBC client with Circuit Breaker");
     }
@@ -64,33 +56,6 @@ public class CircuitBreakerSecuredJdbcClient implements JdbcClient {
     @Override
     public <T> Future<T> executeQuery(String query, List<String> params, Function<ResultSet, T> mapper,
                                       Timeout timeout) {
-        return breaker.execute(future -> jdbcClient.executeQuery(query, params, mapper, timeout)
-                .compose(response -> succeedBreaker(response, future))
-                .recover(exception -> failBreaker(exception, future)));
-    }
-
-    private static <T> Future<T> succeedBreaker(T response, Future<T> future) {
-        future.complete(response);
-        return future;
-    }
-
-    private <T> Future<T> failBreaker(Throwable exception, Future<T> future) {
-        ensureToIncrementFailureCount();
-
-        future.fail(exception);
-        return future;
-    }
-
-    /**
-     * Reset failure counter to adjust open-circuit time frame.
-     */
-    private void ensureToIncrementFailureCount() {
-        final long currentTimeMillis = System.currentTimeMillis();
-
-        if (breaker.state() == CircuitBreakerState.CLOSED && currentTimeMillis - lastFailure > openingIntervalMs) {
-            breaker.reset();
-        }
-
-        lastFailure = currentTimeMillis;
+        return breaker.execute(future -> jdbcClient.executeQuery(query, params, mapper, timeout).setHandler(future));
     }
 }

--- a/src/test/java/org/prebid/server/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/ApplicationTest.java
@@ -322,7 +322,7 @@ public class ApplicationTest extends VertxTest {
                 .willReturn(aResponse().withBody(jsonFrom("amp/test-cache-response.json"))));
 
         // when and then
-        Response response = given(spec)
+        final Response response = given(spec)
                 .header("Referer", "http://www.example.com")
                 .header("X-Forwarded-For", "192.168.244.1")
                 .header("User-Agent", "userAgent")
@@ -673,7 +673,7 @@ public class ApplicationTest extends VertxTest {
     }
 
     @Test
-    public void versionHandlerShouldRespondWithCommitRevision() throws IOException {
+    public void versionHandlerShouldRespondWithCommitRevision() {
         given(adminSpec)
                 .get("/version")
                 .then()

--- a/src/test/java/org/prebid/server/gdpr/vendorlist/VendorListServiceTest.java
+++ b/src/test/java/org/prebid/server/gdpr/vendorlist/VendorListServiceTest.java
@@ -5,8 +5,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.FileSystem;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,6 +20,7 @@ import org.prebid.server.gdpr.vendorlist.proto.Vendor;
 import org.prebid.server.gdpr.vendorlist.proto.VendorList;
 import org.prebid.server.proto.response.BidderInfo;
 import org.prebid.server.vertx.http.HttpClient;
+import org.prebid.server.vertx.http.model.HttpClientResponse;
 
 import java.util.Date;
 import java.util.Map;
@@ -31,12 +30,10 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class VendorListServiceTest extends VertxTest {
 
@@ -50,8 +47,6 @@ public class VendorListServiceTest extends VertxTest {
     @Mock
     private HttpClient httpClient;
     @Mock
-    private HttpClientRequest httpClientRequest;
-    @Mock
     private BidderCatalog bidderCatalog;
     @Mock
     private MetaInfo metaInfo;
@@ -61,9 +56,6 @@ public class VendorListServiceTest extends VertxTest {
     @Before
     public void setUp() {
         given(fileSystem.existsBlocking(anyString())).willReturn(false); // always create cache dir
-
-        given(httpClientRequest.setTimeout(anyLong())).willReturn(httpClientRequest);
-        given(httpClientRequest.exceptionHandler(any())).willReturn(httpClientRequest);
 
         given(bidderCatalog.names()).willReturn(singleton(null));
         given(bidderCatalog.metaInfoByName(any())).willReturn(metaInfo);
@@ -129,28 +121,13 @@ public class VendorListServiceTest extends VertxTest {
     @Test
     public void shouldPerformHttpRequestWithExpectedQueryIfVendorListNotFound() {
         // given
-        givenHttpClientResponse(200);
+        givenHttpClientReturnsResponse(200, null);
 
         // when
         vendorListService.forVersion(1);
 
         // then
         verify(httpClient).get(eq("http://vendorlist/1"), anyLong());
-    }
-
-    @Test
-    public void shouldNotAskToSaveFileIfHttpRequestFails() {
-        // given
-        givenHttpClientResponse(200);
-        given(httpClientRequest.exceptionHandler(any()))
-                .willAnswer(withSelfAndPassObjectToHandler(new RuntimeException("Request exception"), 0));
-
-        // when
-        vendorListService.forVersion(1);
-
-        // then
-        verify(httpClient).get(anyString(), anyLong());
-        verify(fileSystem, never()).writeFile(any(), any(), any());
     }
 
     @Test
@@ -299,7 +276,7 @@ public class VendorListServiceTest extends VertxTest {
         givenHttpClientReturnsResponse(200, mapper.writeValueAsString(givenVendorList()));
 
         given(fileSystem.writeFile(anyString(), any(), any()))
-                .willAnswer(withSelfAndPassObjectToHandler(Future.succeededFuture(), 2));
+                .willAnswer(withSelfAndPassObjectToHandler(Future.succeededFuture()));
 
         // when
         vendorListService.forVersion(1); // populate cache
@@ -319,7 +296,7 @@ public class VendorListServiceTest extends VertxTest {
         givenHttpClientReturnsResponse(200, mapper.writeValueAsString(vendorList));
 
         given(fileSystem.writeFile(anyString(), any(), any()))
-                .willAnswer(withSelfAndPassObjectToHandler(Future.succeededFuture(), 2));
+                .willAnswer(withSelfAndPassObjectToHandler(Future.succeededFuture()));
 
         // when
         vendorListService.forVersion(1); // populate cache
@@ -337,33 +314,20 @@ public class VendorListServiceTest extends VertxTest {
     }
 
     private void givenHttpClientReturnsResponse(int statusCode, String response) {
-        final HttpClientResponse httpClientResponse = givenHttpClientResponse(statusCode);
-        given(httpClientResponse.bodyHandler(any()))
-                .willAnswer(withSelfAndPassObjectToHandler(Buffer.buffer(response), 0));
+        given(httpClient.get(anyString(), anyLong()))
+                .willReturn(Future.succeededFuture(HttpClientResponse.of(statusCode, null, response)));
     }
 
     private void givenHttpClientProducesException(Throwable throwable) {
-        final HttpClientResponse httpClientResponse = givenHttpClientResponse(200);
-
-        given(httpClientResponse.bodyHandler(any())).willReturn(httpClientResponse);
-        given(httpClientResponse.exceptionHandler(any())).willAnswer(withSelfAndPassObjectToHandler(throwable, 0));
-    }
-
-    private HttpClientResponse givenHttpClientResponse(int statusCode) {
-        final HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
-        given(httpClientResponse.statusCode()).willReturn(statusCode);
-
         given(httpClient.get(anyString(), anyLong()))
-                .willReturn(Future.succeededFuture(httpClientResponse));
-
-        return httpClientResponse;
+                .willReturn(Future.failedFuture(throwable));
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> Answer<Object> withSelfAndPassObjectToHandler(T obj, int position) {
+    private static <T> Answer<Object> withSelfAndPassObjectToHandler(T obj) {
         return inv -> {
             // invoking handler right away passing mock to it
-            ((Handler<T>) inv.getArgument(position)).handle(obj);
+            ((Handler<T>) inv.getArgument(2)).handle(obj);
             return inv.getMock();
         };
     }

--- a/src/test/java/org/prebid/server/vertx/CircuitBreakerTest.java
+++ b/src/test/java/org/prebid/server/vertx/CircuitBreakerTest.java
@@ -1,0 +1,168 @@
+package org.prebid.server.vertx;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+@RunWith(VertxUnitRunner.class)
+public class CircuitBreakerTest {
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private Vertx vertx;
+
+    private CircuitBreaker circuitBreaker;
+
+    @Before
+    public void setUp() {
+        vertx = Vertx.vertx();
+        circuitBreaker = new CircuitBreaker("name", vertx, 0, 100L, 200L);
+    }
+
+    @After
+    public void tearDown(TestContext context) {
+        vertx.close(context.asyncAssertSuccess());
+    }
+
+    @Test
+    public void creationShouldFailOnNullArguments() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new CircuitBreaker(null, null, 0, 0L, 0L));
+        assertThatNullPointerException().isThrownBy(
+                () -> new CircuitBreaker("name", null, 0, 0L, 0L));
+    }
+
+    @Test
+    public void executeShouldSucceedsIfOperationSucceeds(TestContext context) {
+        // when
+        final Future<?> future = executeWithSuccess(context, "value");
+
+        // then
+        assertThat(future.succeeded()).isTrue();
+        assertThat(future.result()).isEqualTo("value");
+    }
+
+    @Test
+    public void executeShouldFailsIfCircuitIsClosedAndOperationFails(TestContext context) {
+        // when
+        final Future<?> future = executeWithFail(context, "exception");
+
+        // then
+        assertThat(future.failed()).isTrue();
+        assertThat(future.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception");
+    }
+
+    @Test
+    public void executeShouldFailsIfCircuitIsHalfOpenedAndOperationFailsAndClosingTimeIsNotPassedBy(
+            TestContext context) {
+        // when
+        final Future<?> future1 = executeWithFail(context, "exception1");
+        final Future<?> future2 = executeWithFail(context, null);
+
+        // then
+        assertThat(future1.failed()).isTrue();
+        assertThat(future1.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception1");
+
+        assertThat(future2.failed()).isTrue();
+        assertThat(future2.cause()).isInstanceOf(RuntimeException.class).hasMessage("open circuit");
+    }
+
+    @Test
+    public void executeShouldFailsIfCircuitIsHalfOpenedAndOperationFails(TestContext context) {
+        // when
+        final Future<?> future1 = executeWithFail(context, "exception1");
+        final Future<?> future2 = executeWithFail(context, null);
+        waitForClosingInterval(context);
+        final Future<?> future3 = executeWithFail(context, "exception3");
+
+        // then
+        assertThat(future1.failed()).isTrue();
+        assertThat(future1.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception1");
+
+        assertThat(future2.failed()).isTrue();
+        assertThat(future2.cause()).isInstanceOf(RuntimeException.class).hasMessage("open circuit");
+
+        assertThat(future3.failed()).isTrue();
+        assertThat(future3.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception3");
+    }
+
+    @Test
+    public void executeShouldSucceedsIfCircuitIsHalfOpenedAndOperationSucceeds(TestContext context) {
+        // when
+        final Future<?> future1 = executeWithFail(context, "exception1");
+        final Future<?> future2 = executeWithFail(context, "exception2");
+        waitForClosingInterval(context);
+        final Future<?> future3 = executeWithSuccess(context, "value after half-open");
+
+        // then
+        assertThat(future1.failed()).isTrue();
+        assertThat(future1.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception1");
+
+        assertThat(future2.failed()).isTrue();
+        assertThat(future2.cause()).isInstanceOf(RuntimeException.class).hasMessage("open circuit");
+
+        assertThat(future3.succeeded()).isTrue();
+        assertThat(future3.result()).isEqualTo("value after half-open");
+    }
+
+    @Test
+    public void executeShouldFailsWithOriginalExceptionIfOpeningIntervalExceeds(TestContext context) {
+        // when
+        final Future<?> future1 = executeWithFail(context, "exception1");
+        waitForOpeningInterval(context);
+        final Future<?> future2 = executeWithFail(context, "exception2");
+
+        // then
+        assertThat(future1.failed()).isTrue();
+        assertThat(future1.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception1");
+
+        assertThat(future2.failed()).isTrue();
+        assertThat(future2.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception2");
+    }
+
+    private Future<String> executeWithSuccess(TestContext context, String result) {
+        return execute(context, operationFuture -> operationFuture.complete(result));
+    }
+
+    private Future<String> executeWithFail(TestContext context, String errorMessage) {
+        return execute(context, operationFuture -> operationFuture.fail(new RuntimeException(errorMessage)));
+    }
+
+    private Future<String> execute(TestContext context, Handler<Future<String>> handler) {
+        final Future<String> future = circuitBreaker.execute(handler);
+
+        final Async async = context.async();
+        future.setHandler(ar -> async.complete());
+        async.await();
+
+        return future;
+    }
+
+    private void waitForOpeningInterval(TestContext context) {
+        waitForInterval(context, 200L);
+    }
+
+    private void waitForClosingInterval(TestContext context) {
+        waitForInterval(context, 300L);
+    }
+
+    private void waitForInterval(TestContext context, long timeout) {
+        final Async async = context.async();
+        vertx.setTimer(timeout, id -> async.complete());
+        async.await();
+    }
+}

--- a/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
+++ b/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
@@ -2,7 +2,6 @@ package org.prebid.server.vertx.http;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -18,6 +17,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.prebid.server.exception.PreBidException;
 import org.prebid.server.metric.Metrics;
+import org.prebid.server.vertx.http.model.HttpClientResponse;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -73,7 +73,7 @@ public class CircuitBreakerSecuredHttpClientTest {
     @Test
     public void requestShouldSucceedsIfCircuitIsClosedAndWrappedHttpClientSucceeds(TestContext context) {
         // given
-        givenHttpClientReturning(mock(HttpClientResponse.class));
+        givenHttpClientReturning(HttpClientResponse.of(200, null, null));
 
         // when
         final Future<?> future = doRequest(context);
@@ -127,7 +127,7 @@ public class CircuitBreakerSecuredHttpClientTest {
         // when
         final Future<?> future1 = doRequest(context); // 1 call
         final Future<?> future2 = doRequest(context); // 2 call
-        doWaitForResetTime(context);
+        doWaitForClosingInterval(context);
         final Future<?> future3 = doRequest(context); // 3 call
 
         // then
@@ -147,12 +147,12 @@ public class CircuitBreakerSecuredHttpClientTest {
     @Test
     public void requestShouldSucceedsIfCircuitIsHalfOpenedAndWrappedHttpClientSucceeds(TestContext context) {
         // given
-        givenHttpClientReturning(new RuntimeException("exception"), mock(HttpClientResponse.class));
+        givenHttpClientReturning(new RuntimeException("exception"), HttpClientResponse.of(200, null, null));
 
         // when
         final Future<?> future1 = doRequest(context); // 1 call
         final Future<?> future2 = doRequest(context); // 2 call
-        doWaitForResetTime(context);
+        doWaitForClosingInterval(context);
         final Future<?> future3 = doRequest(context); // 3 call
 
         // then
@@ -169,6 +169,27 @@ public class CircuitBreakerSecuredHttpClientTest {
     }
 
     @Test
+    public void requestShouldFailsWithOriginalExceptionIfOpeningIntervalExceeds(TestContext context) {
+        // given
+        givenHttpClientReturning(new RuntimeException("exception1"), new RuntimeException("exception2"));
+
+        // when
+        final Future<?> future1 = doRequest(context); // 1 call
+        doWaitForOpeningInterval(context);
+        final Future<?> future2 = doRequest(context); // 2 call
+
+        // then
+        verify(wrappedHttpClient, times(2))
+                .request(any(), anyString(), any(), any(), anyLong()); // invoked on 1 & 2 calls
+
+        assertThat(future1.failed()).isTrue();
+        assertThat(future1.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception1");
+
+        assertThat(future2.failed()).isTrue();
+        assertThat(future2.cause()).isInstanceOf(RuntimeException.class).hasMessage("exception2");
+    }
+
+    @Test
     public void requestShouldReportMetricsOnCircuitOpened(TestContext context) {
         // given
         givenHttpClientReturning(new RuntimeException("exception"));
@@ -181,14 +202,14 @@ public class CircuitBreakerSecuredHttpClientTest {
     }
 
     @Test
-    public void executeQueryShouldReportMetricsOnCircuitClosed(TestContext context) {
+    public void requestShouldReportMetricsOnCircuitClosed(TestContext context) {
         // given
-        givenHttpClientReturning(new RuntimeException("exception"), mock(HttpClientResponse.class));
+        givenHttpClientReturning(new RuntimeException("exception"), HttpClientResponse.of(200, null, null));
 
         // when
         doRequest(context); // 1 call
         doRequest(context); // 2 call
-        doWaitForResetTime(context);
+        doWaitForClosingInterval(context);
         doRequest(context); // 3 call
 
         // then
@@ -218,9 +239,17 @@ public class CircuitBreakerSecuredHttpClientTest {
         return future;
     }
 
-    private void doWaitForResetTime(TestContext context) {
+    private void doWaitForOpeningInterval(TestContext context) {
+        doWait(context, 200L);
+    }
+
+    private void doWaitForClosingInterval(TestContext context) {
+        doWait(context, 300L);
+    }
+
+    private void doWait(TestContext context, long timeout) {
         final Async async = context.async();
-        vertx.setTimer(300L, id -> async.complete()); // waiting for reset time of circuit breaker
+        vertx.setTimer(timeout, id -> async.complete());
         async.await();
     }
 }

--- a/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
+++ b/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
@@ -100,7 +100,7 @@ public class CircuitBreakerSecuredHttpClientTest {
     }
 
     @Test
-    public void requestShouldFailsIfCircuitIsHalfOpenedButWrappedHttpClientFailsAndResetTimeIsNotPassedBy(
+    public void requestShouldFailsIfCircuitIsHalfOpenedButWrappedHttpClientFailsAndClosingTimeIsNotPassedBy(
             TestContext context) {
         // given
         givenHttpClientReturning(new RuntimeException("exception"));

--- a/src/test/resources/org/prebid/server/ApplicationTest/test-application.properties
+++ b/src/test/resources/org/prebid/server/ApplicationTest/test-application.properties
@@ -11,11 +11,11 @@ adapters.appnexus.endpoint=http://localhost:8090/appnexus-exchange
 adapters.appnexus.usersync-url=//usersync-url/getuid?
 adapters.appnexus.pbs-enforces-gdpr=true
 adapters.beachfront.enabled=true
-adapters.beachfront.banner-endpoint: http://localhost:8090/beachfront-banner-exchange
-adapters.beachfront.video-endpoint: http://localhost:8090/beachfront-video-exchange?exchange_id=
-adapters.beachfront.usersync-url: //beachfront-usersync
-adapters.beachfront.platform-id: 142
-adapters.beachfront.pbs-enforces-gdpr: true
+adapters.beachfront.banner-endpoint:http://localhost:8090/beachfront-banner-exchange
+adapters.beachfront.video-endpoint:http://localhost:8090/beachfront-video-exchange?exchange_id=
+adapters.beachfront.usersync-url://beachfront-usersync
+adapters.beachfront.platform-id:142
+adapters.beachfront.pbs-enforces-gdpr:true
 adapters.brightroll.enabled=true
 adapters.brightroll.endpoint=http://localhost:8090/brightroll-exchange
 adapters.brightroll.usersync-url=//brightroll-usersync
@@ -68,6 +68,10 @@ adapters.sovrn.enabled=true
 adapters.sovrn.endpoint=http://localhost:8090/sovrn-exchange
 adapters.sovrn.usersync-url=//sovrn-usersync
 adapters.sovrn.pbs-enforces-gdpr=true
+http-client.circuit-breaker.enabled=true
+http-client.circuit-breaker.opening-threshold=1
+http-client.circuit-breaker.opening-interval-ms=1000
+http-client.circuit-breaker.closing-interval-ms=10000
 amp.custom-targeting=rubicon
 cache.scheme=http
 cache.host=localhost:8090


### PR DESCRIPTION
Changes:
- add the time interval for opening the circuit breaker
- fixed HTTP Client handling response (response body from `io.vertx.core.http.HttpClientResponse` should be read in `bodyHandler` right after execution, because we'll fetch partial result otherwise)