### PR TITLE
Fix adding new cache param - returnCreative

### DIFF
--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidCacheBids.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidCacheBids.java
@@ -1,5 +1,6 @@
 package org.prebid.server.proto.openrtb.ext.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -9,5 +10,6 @@ public class ExtRequestPrebidCacheBids {
 
     Integer ttlseconds;
 
+    @JsonProperty("returnCreative")
     Boolean returnCreative;
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidCacheVastxml.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidCacheVastxml.java
@@ -1,5 +1,6 @@
 package org.prebid.server.proto.openrtb.ext.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -9,5 +10,6 @@ public class ExtRequestPrebidCacheVastxml {
 
     Integer ttlseconds;
 
+    @JsonProperty("returnCreative")
     Boolean returnCreative;
 }


### PR DESCRIPTION
Fixed json mapping configuration - add `@JsonProperty` annotation to `returnCreative ` fields.