### PR TITLE
add fields needed for the minimal config in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,14 @@ settings:
     settings-filename: sample-app-settings.yml
     stored-requests-dir: /tmp
     stored-imps-dir: /tmp
+gdpr:
+  vendorlist:
+    filesystem-cache-dir: /tmp
+status-response: "ok"
 ```
 
 Also, create the Data Cache settings file `sample-app-settings.yml` with content:
-```
+```yaml
 accounts:
   - 1001
 ```


### PR DESCRIPTION
The application fails to start up without `gdpr.vendorlist.filesystem-cache-dir` and line 75 implies that `/status` will return 200 OK when it actually defaults to No Content.