### PR TITLE
Add RoutingContext to BidResponsePostProcessor interface

### DIFF
--- a/src/main/java/org/prebid/server/auction/BidResponsePostProcessor.java
+++ b/src/main/java/org/prebid/server/auction/BidResponsePostProcessor.java
@@ -3,6 +3,7 @@ package org.prebid.server.auction;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.response.BidResponse;
 import io.vertx.core.Future;
+import io.vertx.ext.web.RoutingContext;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.cookie.proto.Uids;
 
@@ -15,12 +16,13 @@ public interface BidResponsePostProcessor {
     /**
      * This method is called when auction is finished.
      *
-     * @param bidRequest original auction request
-     * @param uidsCookie auction request {@link Uids} container
+     * @param bidRequest  original auction request
+     * @param uidsCookie  auction request {@link Uids} container
      * @param bidResponse auction result
      * @return a {@link Future} with (possibly modified) auction result
      */
-    Future<BidResponse> postProcess(BidRequest bidRequest, UidsCookie uidsCookie, BidResponse bidResponse);
+    Future<BidResponse> postProcess(RoutingContext context, BidRequest bidRequest, UidsCookie uidsCookie,
+                                    BidResponse bidResponse);
 
     /**
      * Returns {@link NoOpBidResponsePostProcessor} instance that just does nothing to original auction result.
@@ -34,7 +36,8 @@ public interface BidResponsePostProcessor {
      */
     class NoOpBidResponsePostProcessor implements BidResponsePostProcessor {
         @Override
-        public Future<BidResponse> postProcess(BidRequest bidRequest, UidsCookie uidsCookie, BidResponse bidResponse) {
+        public Future<BidResponse> postProcess(RoutingContext context, BidRequest bidRequest, UidsCookie uidsCookie,
+                                               BidResponse bidResponse) {
             return Future.succeededFuture(bidResponse);
         }
     }

--- a/src/main/java/org/prebid/server/auction/BidResponsePostProcessor.java
+++ b/src/main/java/org/prebid/server/auction/BidResponsePostProcessor.java
@@ -16,6 +16,7 @@ public interface BidResponsePostProcessor {
     /**
      * This method is called when auction is finished.
      *
+     * @param context     represents initial web request
      * @param bidRequest  original auction request
      * @param uidsCookie  auction request {@link Uids} container
      * @param bidResponse auction result

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -18,6 +18,7 @@ import com.iab.openrtb.response.SeatBid;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
+import io.vertx.ext.web.RoutingContext;
 import lombok.Builder;
 import lombok.Value;
 import org.apache.commons.collections4.CollectionUtils;
@@ -126,7 +127,7 @@ public class ExchangeService {
      * response containing returned bids and additional information in extensions.
      */
     public Future<BidResponse> holdAuction(BidRequest bidRequest, UidsCookie uidsCookie, Timeout timeout,
-                                           MetricsContext metricsContext) {
+                                           MetricsContext metricsContext, RoutingContext context) {
         // extract ext from bid request
         final ExtBidRequest requestExt;
         try {
@@ -135,16 +136,10 @@ public class ExchangeService {
             return Future.failedFuture(e);
         }
 
-        final Map<String, String> aliases = getAliases(requestExt);
-
+        final Map<String, String> aliases = aliases(requestExt);
         final ExtRequestTargeting targeting = targeting(requestExt);
-
-        // build cache specific params holder
         final BidRequestCacheInfo cacheInfo = bidRequestCacheInfo(targeting, requestExt);
-
-        // build targeting keywords creator
-        final TargetingKeywordsCreator keywordsCreator = buildKeywordsCreator(targeting, bidRequest.getApp() != null);
-
+        final TargetingKeywordsCreator keywordsCreator = keywordsCreator(targeting, bidRequest.getApp() != null);
         final String publisherId = publisherId(bidRequest);
 
         final long startTime = clock.millis();
@@ -163,7 +158,8 @@ public class ExchangeService {
                 .map(bidderResponses -> updateMetricsFromResponses(bidderResponses, publisherId))
                 .compose(result ->
                         toBidResponse(result, bidRequest, keywordsCreator, cacheInfo, publisherId, timeout))
-                .compose(bidResponse -> bidResponsePostProcessor.postProcess(bidRequest, uidsCookie, bidResponse));
+                .compose(bidResponse ->
+                        bidResponsePostProcessor.postProcess(context, bidRequest, uidsCookie, bidResponse));
     }
 
     /**
@@ -181,7 +177,7 @@ public class ExchangeService {
     /**
      * Extracts aliases from {@link ExtBidRequest}.
      */
-    private static Map<String, String> getAliases(ExtBidRequest requestExt) {
+    private static Map<String, String> aliases(ExtBidRequest requestExt) {
         final ExtRequestPrebid prebid = requestExt != null ? requestExt.getPrebid() : null;
         final Map<String, String> aliases = prebid != null ? prebid.getAliases() : null;
         return aliases != null ? aliases : Collections.emptyMap();
@@ -619,7 +615,7 @@ public class ExchangeService {
      * Returns null if bidrequest.ext.prebid.targeting is missing - it means that no targeting keywords
      * should be included in bid response.
      */
-    private static TargetingKeywordsCreator buildKeywordsCreator(ExtRequestTargeting targeting, boolean isApp) {
+    private static TargetingKeywordsCreator keywordsCreator(ExtRequestTargeting targeting, boolean isApp) {
         return targeting != null
                 ? TargetingKeywordsCreator.create(parsePriceGranularity(targeting.getPricegranularity()),
                 targeting.getIncludewinners(), targeting.getIncludebidderkeys(), isApp)

--- a/src/main/java/org/prebid/server/auction/PreBidRequestContextFactory.java
+++ b/src/main/java/org/prebid/server/auction/PreBidRequestContextFactory.java
@@ -199,7 +199,7 @@ public class PreBidRequestContextFactory {
                     logger.warn("Invalid mediaType: {0}", mediaType);
                 }
             }
-            if (bidMediaTypes.size() == 0) {
+            if (bidMediaTypes.isEmpty()) {
                 bidMediaTypes.add(MediaType.banner);
             }
         } else {

--- a/src/main/java/org/prebid/server/auction/PriceGranularity.java
+++ b/src/main/java/org/prebid/server/auction/PriceGranularity.java
@@ -41,7 +41,7 @@ public class PriceGranularity {
 
     /**
      * Creates {@link PriceGranularity} for string representation and puts it to
-     * {@link EnumMap<PriceGranularityType, PriceGranularity>}
+     * {@link EnumMap<PriceGranularityType, PriceGranularity>}.
      */
     private static void putStringPriceGranularity(PriceGranularityType type, Integer precision,
                                                   ExtGranularityRange... ranges) {
@@ -77,7 +77,7 @@ public class PriceGranularity {
     }
 
     /**
-     * Creates {@link PriceGranularity} from {@link List<ExtGranularityRange>} and validates it.
+     * Creates {@link PriceGranularity} from list of {@link ExtGranularityRange}s and validates it.
      */
     private static PriceGranularity createFromRanges(Integer precision, List<ExtGranularityRange> ranges) {
         if (CollectionUtils.isEmpty(ranges)) {
@@ -94,7 +94,7 @@ public class PriceGranularity {
     }
 
     /**
-     * Returns {@link PriceGranularity} by string representation if it is present in map, otherwise returns null
+     * Returns {@link PriceGranularity} by string representation if it is present in map, otherwise returns null.
      */
     public static PriceGranularity createFromString(String stringPriceGranularity) {
         if (isValidStringPriceGranularityType(stringPriceGranularity)) {
@@ -113,21 +113,21 @@ public class PriceGranularity {
     }
 
     /**
-     * Returns {@link List<ExtGranularityRange>}
+     * Returns list of {@link ExtGranularityRange}s.
      */
     public List<ExtGranularityRange> getRanges() {
         return ranges;
     }
 
     /**
-     * Returns max value among all ranges
+     * Returns max value among all ranges.
      */
     public BigDecimal getRangesMax() {
         return rangesMax;
     }
 
     /**
-     * Returns {@link PriceGranularity} precision
+     * Returns {@link PriceGranularity} precision.
      */
     public Integer getPrecision() {
         return precision;

--- a/src/main/java/org/prebid/server/auction/StoredRequestProcessor.java
+++ b/src/main/java/org/prebid/server/auction/StoredRequestProcessor.java
@@ -201,7 +201,7 @@ public class StoredRequestProcessor {
             }
         }
 
-        if (errors.size() > 0) {
+        if (!errors.isEmpty()) {
             throw new InvalidRequestException(errors);
         }
 

--- a/src/main/java/org/prebid/server/bidder/HttpAdapterRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpAdapterRequester.java
@@ -161,7 +161,7 @@ public class HttpAdapterRequester implements BidderRequester {
     }
 
     /**
-     * Calculates secure type from {@link List<Imp>}. Values of secure in imps should be same, 0 or 1. If different
+     * Calculates secure type from list of {@link Imp}s. Values of secure in imps should be same, 0 or 1. If different
      * values found {@link InvalidRequestException} will be thrown.
      */
     private static Integer toSecure(List<Imp> imps) {
@@ -183,25 +183,26 @@ public class HttpAdapterRequester implements BidderRequester {
     }
 
     /**
-     * Creates {@link Result<AdapterRequest>} from {@link BidRequest}. In case {@link BidRequest} has
-     * empty {@link List<Imp>} or neither of was converted to {@link AdUnitBid}, {@link InvalidRequestException} will
-     * be thrown.
+     * Creates {@link Result<AdapterRequest>} from {@link BidRequest}.
+     * <p>
+     * In case {@link BidRequest} has empty list of {@link Imp}s or neither of was converted to {@link AdUnitBid},
+     * {@link InvalidRequestException} will be thrown.
      */
     private Result<AdapterRequest> toBidder(BidRequest bidRequest) {
-        if (bidRequest.getImp().size() == 0) {
+        if (bidRequest.getImp().isEmpty()) {
             throw new InvalidRequestException(String.format("There no imps in bidRequest for bidder %s", bidderName));
         }
         final Result<List<AdUnitBid>> adUnitBidsResult = toAdUnitBids(bidRequest.getImp());
         final List<AdUnitBid> adUnitBids = adUnitBidsResult.getValue();
         final List<BidderError> errors = adUnitBidsResult.getErrors();
-        if (adUnitBids.size() > 0) {
+        if (!adUnitBids.isEmpty()) {
             return Result.of(AdapterRequest.of(bidderName, adUnitBids), errors);
         }
         throw new InvalidRequestException(messages(errors));
     }
 
     /**
-     * Converts {@link List}&lt;{@link BidderError}&gt; to {@link List}&lt;{@link String}&gt; error messages
+     * Converts {@link List}&lt;{@link BidderError}&gt; to {@link List}&lt;{@link String}&gt; error messages.
      */
     private static List<String> messages(List<BidderError> errors) {
         return CollectionUtils.emptyIfNull(errors).stream().map(BidderError::getMessage).collect(Collectors.toList());
@@ -246,8 +247,8 @@ public class HttpAdapterRequester implements BidderRequester {
     }
 
     /**
-     * Creates sizes {@link List<Format>} from {@link Imp}. In case sizes list is empty, {@link InvalidRequestException}
-     * will be thrown.
+     * Creates sizes list of {@link Format}s from {@link Imp}.
+     * In case sizes list is empty, {@link InvalidRequestException} will be thrown.
      */
     private static List<Format> toAdUnitBidSizes(Imp imp) {
         final List<Format> sizes = new ArrayList<>();
@@ -377,14 +378,14 @@ public class HttpAdapterRequester implements BidderRequester {
     }
 
     /**
-     * Converts {@link List<BidderDebug>} to {@link List<ExtHttpCall>}.
+     * Converts a list of {@link BidderDebug} to list of {@link ExtHttpCall}s.
      */
     private List<ExtHttpCall> toExtHttpCalls(List<BidderDebug> bidderDebugs) {
         return bidderDebugs.stream().map(HttpAdapterRequester::toExtHttpCall).collect(Collectors.toList());
     }
 
     /**
-     * Creates {@link ExtHttpCall} from {@link BidderDebug}
+     * Creates {@link ExtHttpCall} from {@link BidderDebug}.
      */
     private static ExtHttpCall toExtHttpCall(BidderDebug bidderDebug) {
         return ExtHttpCall.builder()

--- a/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
@@ -68,8 +68,9 @@ public class HttpBidderRequester<T> implements BidderRequester {
     }
 
     /**
-     * Creates {@link Future<BidderSeatBid>} with empty {@link List<BidderBid>} and {@link List<ExtHttpCall>} with
-     * {@link List<BidderError>}. If errors list is empty, creates error which indicates of bidder unexpected behaviour.
+     * Creates {@link Future<BidderSeatBid>} with empty list of {@link BidderBid}s
+     * and list of {@link ExtHttpCall}s with list of {@link BidderError}s.
+     * If errors list is empty, creates error which indicates of bidder unexpected behaviour.
      */
     private Future<BidderSeatBid> emptyBidderSeatBidWithErrors(List<BidderError> bidderErrors) {
         return Future.succeededFuture(

--- a/src/main/java/org/prebid/server/bidder/adform/AdformBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adform/AdformBidder.java
@@ -44,8 +44,9 @@ public class AdformBidder implements Bidder<Void> {
 
     private static final String VERSION = "0.1.2";
     private static final String BANNER = "banner";
-    private static final TypeReference<ExtPrebid<?, ExtImpAdform>> ADFORM_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpAdform>>() {
+
+    private static final TypeReference<ExtPrebid<?, ExtImpAdform>> ADFORM_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpAdform>>() {
             };
 
     private final String endpointUrl;
@@ -66,7 +67,7 @@ public class AdformBidder implements Bidder<Void> {
         final List<ExtImpAdform> extImpAdforms = extImpAdformsResult.getValue();
         final List<BidderError> errors = extImpAdformsResult.getErrors();
 
-        if (extImpAdforms.size() == 0) {
+        if (extImpAdforms.isEmpty()) {
             return Result.of(Collections.emptyList(), errors);
         }
 
@@ -101,7 +102,7 @@ public class AdformBidder implements Bidder<Void> {
     /**
      * Converts Adform Response format to {@link List} of {@link BidderBid}s with {@link List} of errors.
      * Returns empty result {@link List} in case of "No Content" response status.
-     * Returns empty result {@link List} with errors in case of response status different from "OK" or "No Content"
+     * Returns empty result {@link List} with errors in case of response status different from "OK" or "No Content".
      */
     @Override
     public Result<List<BidderBid>> makeBids(HttpCall<Void> httpCall, BidRequest bidRequest) {
@@ -123,7 +124,7 @@ public class AdformBidder implements Bidder<Void> {
     }
 
     /**
-     * Retrieves from {@link Imp} and filter not valid {@link ExtImpAdform} and returns list result with errors
+     * Retrieves from {@link Imp} and filter not valid {@link ExtImpAdform} and returns list result with errors.
      */
     private Result<List<ExtImpAdform>> getExtImpAdforms(List<Imp> imps) {
         final List<BidderError> errors = new ArrayList<>();
@@ -156,35 +157,35 @@ public class AdformBidder implements Bidder<Void> {
     }
 
     /**
-     * Converts {@link ExtImpAdform} {@link List} to master tag {@link List}
+     * Converts {@link ExtImpAdform} {@link List} to master tag {@link List}.
      */
     private List<Long> getMasterTagIds(List<ExtImpAdform> extImpAdforms) {
         return extImpAdforms.stream().map(ExtImpAdform::getMasterTagId).collect(Collectors.toList());
     }
 
     /**
-     * Converts {@link ExtImpAdform} {@link List} to price types {@link List}
+     * Converts {@link ExtImpAdform} {@link List} to price types {@link List}.
      */
     private List<String> getPriceType(List<ExtImpAdform> extImpAdforms) {
         return extImpAdforms.stream().map(ExtImpAdform::getPriceType).collect(Collectors.toList());
     }
 
     /**
-     * Retrieves referer from {@link Site}
+     * Retrieves referer from {@link Site}.
      */
     private String getReferer(Site site) {
         return site != null ? site.getPage() : "";
     }
 
     /**
-     * Retrieves userId from {@link User}
+     * Retrieves userId from {@link User}.
      */
     private String getUserId(User user) {
         return user != null ? user.getBuyeruid() : "";
     }
 
     /**
-     * Defines if request should be secured from {@link List} of {@link Imp}s
+     * Defines if request should be secured from {@link List} of {@link Imp}s.
      */
     private Boolean getSecure(List<Imp> imps) {
         return imps.stream()
@@ -192,28 +193,28 @@ public class AdformBidder implements Bidder<Void> {
     }
 
     /**
-     * Retrieves userAgent from {@link Device}
+     * Retrieves userAgent from {@link Device}.
      */
     private String getUserAgent(Device device) {
         return device != null ? ObjectUtils.firstNonNull(device.getUa(), "") : "";
     }
 
     /**
-     * Retrieves ip from {@link Device}
+     * Retrieves ip from {@link Device}.
      */
     private String getIp(Device device) {
         return device != null ? ObjectUtils.firstNonNull(device.getIp(), "") : "";
     }
 
     /**
-     * Retrieves ifs from {@link Device}
+     * Retrieves ifs from {@link Device}.
      */
     private String getIfa(Device device) {
         return device != null ? ObjectUtils.firstNonNull(device.getIfa(), "") : "";
     }
 
     /**
-     * Retrieves tid from {@link Source}
+     * Retrieves tid from {@link Source}.
      */
     private String getTid(Source source) {
         return source != null ? ObjectUtils.firstNonNull(source.getTid(), "") : "";
@@ -224,10 +225,10 @@ public class AdformBidder implements Bidder<Void> {
      */
     private List<BidderBid> toBidderBid(List<AdformBid> adformBids, List<Imp> imps) {
         final List<BidderBid> bidderBids = new ArrayList<>();
+
         for (int i = 0; i < adformBids.size(); i++) {
             final AdformBid adformBid = adformBids.get(i);
-            if (StringUtils.isEmpty(adformBid.getBanner())
-                    || !Objects.equals(adformBid.getResponse(), BANNER)) {
+            if (StringUtils.isEmpty(adformBid.getBanner()) || !Objects.equals(adformBid.getResponse(), BANNER)) {
                 continue;
             }
             final Imp imp = imps.get(i);
@@ -243,6 +244,7 @@ public class AdformBidder implements Bidder<Void> {
                             .build(),
                     BidType.banner, null));
         }
+
         return bidderBids;
     }
 }

--- a/src/main/java/org/prebid/server/bidder/adkerneladn/AdkernelAdnBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adkerneladn/AdkernelAdnBidder.java
@@ -41,8 +41,8 @@ import java.util.stream.Collectors;
 
 public class AdkernelAdnBidder implements Bidder<BidRequest> {
 
-    private static final TypeReference<ExtPrebid<?, ExtImpAdkernelAdn>> ADKERNELADN_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpAdkernelAdn>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpAdkernelAdn>> ADKERNELADN_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpAdkernelAdn>>() {
             };
 
     private static final String DEFAULT_BID_CURRENCY = "USD";
@@ -96,10 +96,9 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         return adkernelAdnExt;
     }
 
-    //Group impressions by AdKernel-specific parameters `pubId` & `host`
+    // Group impressions by AdKernel-specific parameters `pubId` & `host`.
     private static Map<ExtImpAdkernelAdn, List<Imp>> dispatchImpressions(List<Imp> imps,
                                                                          List<ExtImpAdkernelAdn> impExts) {
-
         final Map<ExtImpAdkernelAdn, List<Imp>> result = new HashMap<>();
 
         for (int i = 0; i < imps.size(); i++) {
@@ -111,9 +110,8 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         return result;
     }
 
-    //Alter impression info to comply with adkernel platform requirements
+    // Alter impression info to comply with adkernel platform requirements.
     private static Imp compatImpression(Imp imp) {
-
         final Imp.ImpBuilder impBuilder = imp.toBuilder();
         final Banner compatBanner = imp.getBanner();
 
@@ -147,23 +145,23 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         return impBuilder.build();
     }
 
-    private static List<HttpRequest<BidRequest>> buildAdapterRequests(BidRequest prebidBidrequest,
+    private static List<HttpRequest<BidRequest>> buildAdapterRequests(BidRequest preBidRequest,
                                                                       Map<ExtImpAdkernelAdn, List<Imp>> pubToImps,
                                                                       String endpointUrl) {
         final List<HttpRequest<BidRequest>> result = new ArrayList<>();
 
-        for (ExtImpAdkernelAdn impExt : pubToImps.keySet()) {
-            final BidRequest outgoingRequest = createBidRequest(prebidBidrequest, pubToImps.get(impExt));
+        for (Map.Entry<ExtImpAdkernelAdn, List<Imp>> entry : pubToImps.entrySet()) {
+            final BidRequest outgoingRequest = createBidRequest(preBidRequest, entry.getValue());
             final String body = Json.encode(outgoingRequest);
-            result.add(HttpRequest.of(HttpMethod.POST, buildEndpoint(impExt, endpointUrl), body, headers(),
+            result.add(HttpRequest.of(HttpMethod.POST, buildEndpoint(entry.getKey(), endpointUrl), body, headers(),
                     outgoingRequest));
         }
 
         return result;
     }
 
-    private static BidRequest createBidRequest(BidRequest prebidBidRequest, List<Imp> imps) {
-        final BidRequest.BidRequestBuilder bidRequestBuilder = prebidBidRequest.toBuilder();
+    private static BidRequest createBidRequest(BidRequest preBidRequest, List<Imp> imps) {
+        final BidRequest.BidRequestBuilder bidRequestBuilder = preBidRequest.toBuilder();
 
         final List<Imp> modifiedImps = new ArrayList<>();
         for (Imp imp : imps) {
@@ -175,12 +173,12 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         }
         bidRequestBuilder.imp(modifiedImps);
 
-        final Site site = prebidBidRequest.getSite();
+        final Site site = preBidRequest.getSite();
         if (site != null) {
             bidRequestBuilder.site(site.toBuilder().publisher(null).domain("").build());
         }
 
-        final App app = prebidBidRequest.getApp();
+        final App app = preBidRequest.getApp();
         if (app != null) {
             bidRequestBuilder.app(app.toBuilder().publisher(null).build());
         }
@@ -236,7 +234,7 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
                 .collect(Collectors.toList());
     }
 
-    // getType figures out which media type this bid is for
+    // Figures out which media type this bid is for.
     private static BidType getType(String impId, List<Imp> imps) {
         for (Imp imp : imps) {
             if (imp.getId().equals(impId) && imp.getVideo() != null) {

--- a/src/main/java/org/prebid/server/bidder/adtelligent/AdtelligentBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adtelligent/AdtelligentBidder.java
@@ -42,8 +42,8 @@ import java.util.stream.Collectors;
  */
 public class AdtelligentBidder implements Bidder<BidRequest> {
 
-    private static final TypeReference<ExtPrebid<?, ExtImpAdtelligent>> ADTELLIGENT_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpAdtelligent>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpAdtelligent>> ADTELLIGENT_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpAdtelligent>>() {
             };
 
     private final String endpointUrl;

--- a/src/main/java/org/prebid/server/bidder/appnexus/AppnexusBidder.java
+++ b/src/main/java/org/prebid/server/bidder/appnexus/AppnexusBidder.java
@@ -52,8 +52,8 @@ public class AppnexusBidder implements Bidder<BidRequest> {
     private static final int AD_POSITION_ABOVE_THE_FOLD = 1; // openrtb.AdPosition.AdPositionAboveTheFold
     private static final int AD_POSITION_BELOW_THE_FOLD = 3; // openrtb.AdPosition.AdPositionBelowTheFold
 
-    private static final TypeReference<ExtPrebid<?, ExtImpAppnexus>> APPNEXUS_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpAppnexus>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpAppnexus>> APPNEXUS_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpAppnexus>>() {
             };
 
     private final String endpointUrl;

--- a/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
+++ b/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
@@ -63,9 +63,10 @@ public class BeachfrontBidder implements Bidder<BeachfrontRequests> {
     private static final String BEACHFRONT_VERSION = "0.1.1";
     private static final String VIDEO_ENDPOINT_SUFFIX = "&prebidserver";
 
-    private static final TypeReference<ExtPrebid<?, ExtImpBeachfront>> BEACHFRONT_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpBeachfront>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpBeachfront>> BEACHFRONT_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpBeachfront>>() {
             };
+
     private static final MultiMap VIDEO_HEADERS = BidderUtil.headers();
 
     private final String bannerEndpointUrl;
@@ -278,8 +279,9 @@ public class BeachfrontBidder implements Bidder<BeachfrontRequests> {
     }
 
     /**
-     * Creates {@link List<BeachfrontSlot>} from {@link Imp}. If Imp has audio or native type, adds error about
-     * unsupported type.
+     * Creates list of {@link BeachfrontSlot}s from {@link Imp}.
+     * <p>
+     * If Imp has audio or native type, adds error about unsupported type.
      * <p>
      * All banner imps without extension, or with extension which can't be deserialized, considering as invalid.
      * If all imps are invalid, throws {@link InvalidRequestException}.
@@ -465,7 +467,9 @@ public class BeachfrontBidder implements Bidder<BeachfrontRequests> {
     }
 
     /**
-     * Parses response body to {@link List<BeachfrontResponseSlot>}. Throws {@link PreBidException} in case of failure.
+     * Parses response body to list of {@link BeachfrontResponseSlot}s.
+     * <p>
+     * Throws {@link PreBidException} in case of failure.
      */
     private static List<BeachfrontResponseSlot> makeBeachfrontResponseSlots(String responseBody) {
         if (responseBody == null) {
@@ -507,7 +511,7 @@ public class BeachfrontBidder implements Bidder<BeachfrontRequests> {
     }
 
     /**
-     * Creates {@link Result} with empty {@link List<BidderBid>} and bad server errors.
+     * Creates {@link Result} with empty list of {@link BidderBid}s and bad server errors.
      */
     private static Result<List<BidderBid>> makeErrorResponse(List<BidderError> errors) {
         errors.add(BidderError.badServerResponse("Failed to process the beachfront response"));

--- a/src/main/java/org/prebid/server/bidder/eplanning/EplanningBidder.java
+++ b/src/main/java/org/prebid/server/bidder/eplanning/EplanningBidder.java
@@ -40,8 +40,9 @@ import java.util.stream.Collectors;
 public class EplanningBidder implements Bidder<BidRequest> {
 
     private static final String DEFAULT_EXCHANGE_ID = "5a1ad71d2d53a0f5";
-    private static final TypeReference<ExtPrebid<?, ExtImpEplanning>> EPLANNING_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpEplanning>>() {
+
+    private static final TypeReference<ExtPrebid<?, ExtImpEplanning>> EPLANNING_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpEplanning>>() {
             };
 
     private final String endpointUrlTemplate;
@@ -162,7 +163,7 @@ public class EplanningBidder implements Bidder<BidRequest> {
     }
 
     /**
-     * Extracts bids from {@link BidResponse} and creates {@link List<BidderBid>} from them.
+     * Extracts bids from {@link BidResponse} and creates list of {@link BidderBid}s from them.
      */
     private static Result<List<BidderBid>> extractBids(BidResponse bidResponse) {
         if (bidResponse == null || CollectionUtils.isEmpty(bidResponse.getSeatbid())) {

--- a/src/main/java/org/prebid/server/bidder/facebook/FacebookBidder.java
+++ b/src/main/java/org/prebid/server/bidder/facebook/FacebookBidder.java
@@ -45,9 +45,11 @@ import java.util.stream.Collectors;
 public class FacebookBidder implements Bidder<BidRequest> {
 
     private static final Random RANDOM = new Random();
-    private static final TypeReference<ExtPrebid<?, ExtImpFacebook>> FACEBOOK_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpFacebook>>() {
+
+    private static final TypeReference<ExtPrebid<?, ExtImpFacebook>> FACEBOOK_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpFacebook>>() {
             };
+
     private static final Integer LEGACY_BANNER_WIDTH = 320;
     private static final Integer LEGACY_BANNER_HEIGHT = 50;
 

--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconAdapter.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconAdapter.java
@@ -116,7 +116,7 @@ public class RubiconAdapter extends OpenrtbAdapter {
     }
 
     private static void validateBidRequests(List<BidRequest> bidRequests) {
-        if (bidRequests.size() == 0) {
+        if (bidRequests.isEmpty()) {
             throw new PreBidException("Invalid ad unit/imp");
         }
     }

--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
@@ -87,8 +87,8 @@ public class RubiconBidder implements Bidder<BidRequest> {
     private static final String PREBID_SERVER_USER_AGENT = "prebid-server/1.0";
     private static final String DEFAULT_BID_CURRENCY = "USD";
 
-    private static final TypeReference<ExtPrebid<?, ExtImpRubicon>> RUBICON_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpRubicon>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpRubicon>> RUBICON_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpRubicon>>() {
             };
 
     private final String endpointUrl;

--- a/src/main/java/org/prebid/server/bidder/somoaudience/SomoaudienceBidder.java
+++ b/src/main/java/org/prebid/server/bidder/somoaudience/SomoaudienceBidder.java
@@ -36,8 +36,8 @@ import java.util.stream.Collectors;
 
 public class SomoaudienceBidder implements Bidder<BidRequest> {
 
-    private static final TypeReference<ExtPrebid<?, ExtImpSomoaudience>> SOMOAUDIENCE_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpSomoaudience>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpSomoaudience>> SOMOAUDIENCE_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpSomoaudience>>() {
             };
 
     private final String endpointUrl;

--- a/src/main/java/org/prebid/server/bidder/sovrn/SovrnBidder.java
+++ b/src/main/java/org/prebid/server/bidder/sovrn/SovrnBidder.java
@@ -44,8 +44,8 @@ import java.util.stream.Collectors;
  */
 public class SovrnBidder implements Bidder<BidRequest> {
 
-    private static final TypeReference<ExtPrebid<?, ExtImpSovrn>> SOVRN_EXT_TYPE_REFERENCE = new
-            TypeReference<ExtPrebid<?, ExtImpSovrn>>() {
+    private static final TypeReference<ExtPrebid<?, ExtImpSovrn>> SOVRN_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpSovrn>>() {
             };
 
     private final String endpointUrl;

--- a/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
@@ -64,6 +64,7 @@ public class AmpHandler implements Handler<RoutingContext> {
     private static final TypeReference<ExtBidResponse> EXT_BID_RESPONSE_TYPE_REFERENCE =
             new TypeReference<ExtBidResponse>() {
             };
+
     private static final MetricsContext METRICS_CONTEXT = MetricsContext.of(MetricName.amp);
 
     private final long defaultTimeout;
@@ -117,7 +118,7 @@ public class AmpHandler implements Handler<RoutingContext> {
                         updateAppAndNoCookieAndImpsRequestedMetrics(bidRequest, uidsCookie, isSafari))
                 .compose(bidRequest ->
                         exchangeService.holdAuction(bidRequest, uidsCookie, timeout(bidRequest, startTime),
-                                METRICS_CONTEXT)
+                                METRICS_CONTEXT, context)
                                 .map(bidResponse -> Tuple2.of(bidRequest, bidResponse)))
                 .map((Tuple2<BidRequest, BidResponse> result) ->
                         addToEvent(result.getRight(), ampEventBuilder::bidResponse, result))

--- a/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
@@ -92,7 +92,7 @@ public class AuctionHandler implements Handler<RoutingContext> {
                 .map(bidRequest -> Tuple2.of(bidRequest, toMetricsContext(bidRequest)))
                 .compose((Tuple2<BidRequest, MetricsContext> result) ->
                         exchangeService.holdAuction(result.getLeft(), uidsCookie, timeout(result.getLeft(), startTime),
-                                result.getRight())
+                                result.getRight(), context)
                                 .map(bidResponse -> Tuple2.of(bidResponse, result.getRight())))
                 .map((Tuple2<BidResponse, MetricsContext> result) ->
                         addToEvent(result, result.getLeft(), auctionEventBuilder::bidResponse))

--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 
 /**
  * A component that validates {@link BidRequest} objects for openrtb2 auction endpoint.
- * Validations are processed by the validate method and returns {@link ValidationResult}
+ * Validations are processed by the validate method and returns {@link ValidationResult}.
  */
 public class RequestValidator {
 
@@ -65,7 +65,7 @@ public class RequestValidator {
 
     /**
      * Constructs a RequestValidator that will use the BidderParamValidator passed in order to validate all critical
-     * properties of bidRequest
+     * properties of bidRequest.
      */
     public RequestValidator(BidderCatalog bidderCatalog, BidderParamValidator bidderParamValidator) {
         this.bidderCatalog = Objects.requireNonNull(bidderCatalog);
@@ -197,7 +197,7 @@ public class RequestValidator {
     }
 
     /**
-     * Validates {@link List<ExtRequestTargeting>} as set of ranges.
+     * Validates list of {@link ExtRequestTargeting}s as set of ranges.
      */
     private static void validateGranularityRanges(List<ExtGranularityRange> ranges) throws ValidationException {
         if (CollectionUtils.isEmpty(ranges)) {
@@ -220,7 +220,7 @@ public class RequestValidator {
     }
 
     /**
-     * Validates {@link ExtGranularityRange}s increment
+     * Validates {@link ExtGranularityRange}s increment.
      */
     private static void validateGranularityRangeIncrement(ExtGranularityRange range)
             throws ValidationException {
@@ -440,7 +440,7 @@ public class RequestValidator {
 
         final boolean isNotPresentWidth = image.getW() == null || image.getW() == 0;
         final boolean isNotPresentWidthMin = image.getWmin() == null || image.getWmin() == 0;
-        if (isNotPresentWidth & isNotPresentWidthMin) {
+        if (isNotPresentWidth && isNotPresentWidthMin) {
             throw new ValidationException(
                     "request.imp[%d].native.request.assets[%d].img must contain at least one of \"w\" or \"wmin\"",
                     impIndex, assetIndex);

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -151,7 +151,6 @@ public class ExchangeServiceTest extends VertxTest {
 
         given(responseBidValidator.validate(any())).willReturn(ValidationResult.success());
         given(usersyncer.cookieFamilyName()).willReturn("cookieFamily");
-        given(bidResponsePostProcessor.postProcess(any(), any(), any())).willCallRealMethod();
 
         given(currencyService.convertCurrency(any(), any(), any(), any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -181,8 +180,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(null));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         verifyZeroInteractions(bidderCatalog);
@@ -198,8 +197,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("invalid", 0)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         verify(bidderCatalog).isValidName(eq("invalid"));
@@ -215,16 +214,19 @@ public class ExchangeServiceTest extends VertxTest {
 
         given(bidderCatalog.isValidName(invalidBidderName)).willReturn(false);
         given(bidderCatalog.isDeprecatedName(invalidBidderName)).willReturn(true);
-        given(bidderCatalog.errorForDeprecatedName(invalidBidderName)).willReturn("invalid has been deprecated and is no longer available. Use valid instead.");
+        given(bidderCatalog.errorForDeprecatedName(invalidBidderName)).willReturn(
+                "invalid has been deprecated and is no longer available. Use valid instead.");
 
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap(invalidBidderName, 0)));
 
         //when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext).result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         //then
         assertThat(bidResponse.getExt()).isEqualTo(mapper.valueToTree(ExtBidResponse.of(null,
-                Collections.singletonMap(invalidBidderName, Collections.singletonList("invalid has been deprecated and is no longer available. Use valid instead.")),
+                Collections.singletonMap(invalidBidderName, Collections.singletonList(
+                        "invalid has been deprecated and is no longer available. Use valid instead.")),
                 new HashMap<>(), null)));
     }
 
@@ -236,7 +238,7 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final BidRequest capturedBidRequest = captureBidRequest();
@@ -258,7 +260,7 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.id("requestId").tmax(500L));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final BidRequest capturedBidRequest = captureBidRequest();
@@ -289,7 +291,7 @@ public class ExchangeServiceTest extends VertxTest {
                 givenImp(singletonMap("bidder1", 3), identity())));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequest1Captor = ArgumentCaptor.forClass(BidRequest.class);
@@ -337,7 +339,7 @@ public class ExchangeServiceTest extends VertxTest {
                                 .build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -371,7 +373,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .regs(Regs.of(null, mapper.valueToTree(ExtRegs.of(1)))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -393,7 +395,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .regs(Regs.of(null, null))); // no ext
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
@@ -431,7 +433,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .regs(Regs.of(null, mapper.valueToTree(ExtRegs.of(1)))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -467,7 +469,7 @@ public class ExchangeServiceTest extends VertxTest {
                                 singletonMap("bidderAlias", "someBidder"), null, null, null, null)))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -514,7 +516,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .regs(Regs.of(null, mapper.valueToTree(ExtRegs.of(1)))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -540,7 +542,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .regs(Regs.of(null, mapper.valueToTree(ExtRegs.of(1)))));
 
         // when
-        final Future<?> result = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        final Future<?> result = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         assertThat(result.failed()).isTrue();
@@ -558,7 +560,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .regs(Regs.of(null, mapper.createObjectNode().put("gdpr", "invalid"))));
 
         // when and then
-        assertThatThrownBy(() -> exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext))
+        assertThatThrownBy(() -> exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null))
                 .isExactlyInstanceOf(PreBidException.class)
                 .hasMessageStartingWith("Error decoding bidRequest.regs.ext:");
     }
@@ -575,7 +577,7 @@ public class ExchangeServiceTest extends VertxTest {
                         singletonMap("bidderAlias", "bidder"), null, null, null, null)))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -597,7 +599,7 @@ public class ExchangeServiceTest extends VertxTest {
                         singletonMap("bidderAlias", "bidder"), null, null, null, null)))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
@@ -615,8 +617,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(emptyList());
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse).returns(2, BidResponse::getNbr);
@@ -630,8 +632,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).isEmpty();
@@ -650,8 +652,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).hasSize(1).element(0).isEqualTo(SeatBid.builder()
@@ -675,8 +677,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).hasSize(1).element(0).isEqualTo(SeatBid.builder()
@@ -703,8 +705,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(doubleMap("bidder1", 1, "bidder2", 2)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).hasSize(2)
@@ -733,8 +735,8 @@ public class ExchangeServiceTest extends VertxTest {
                         singletonMap("bidderAlias", "bidder"), null, null, null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         verify(bidderRequester, times(2)).requestBids(any(), any());
@@ -756,8 +758,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(doubleMap("bidder1", 1, "bidder2", 2)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         final ExtBidResponse ext = mapper.treeToValue(bidResponse.getExt(), ExtBidResponse.class);
@@ -801,8 +803,8 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.test(1));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         final ExtBidResponse ext = mapper.treeToValue(bidResponse.getExt(), ExtBidResponse.class);
@@ -846,8 +848,8 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("bidder1", 1)));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         final ExtBidResponse ext = mapper.treeToValue(bidResponse.getExt(), ExtBidResponse.class);
@@ -861,7 +863,8 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.ext(mapper.valueToTree(singletonMap("prebid", 1))));
 
         // when
-        final Future<BidResponse> result = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        final Future<BidResponse> result =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         assertThat(result.failed()).isTrue();
@@ -879,8 +882,8 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.ext(mapper.valueToTree(singletonMap("someField", 1))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -898,8 +901,8 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.ext(mapper.valueToTree(singletonMap("prebid", singletonMap("someField", 1)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -927,8 +930,8 @@ public class ExchangeServiceTest extends VertxTest {
                 .willReturn(ValidationResult.error("bid validation error"));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         final ExtBidResponse ext = mapper.treeToValue(bidResponse.getExt(), ExtBidResponse.class);
@@ -962,8 +965,8 @@ public class ExchangeServiceTest extends VertxTest {
                                         null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -999,8 +1002,8 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null), null))))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1038,8 +1041,8 @@ public class ExchangeServiceTest extends VertxTest {
                                 ExtRequestPrebidCacheVastxml.of(null, false)))))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1070,8 +1073,8 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtRequestPrebidCache.of(null, ExtRequestPrebidCacheVastxml.of(null, null)))))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1107,8 +1110,8 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null), null))))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1144,8 +1147,8 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null), null))))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1179,8 +1182,8 @@ public class ExchangeServiceTest extends VertxTest {
                         null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1209,8 +1212,8 @@ public class ExchangeServiceTest extends VertxTest {
                                 null, false, true), null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1237,8 +1240,8 @@ public class ExchangeServiceTest extends VertxTest {
                                 null, true, false), null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)
@@ -1263,7 +1266,7 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.user(user));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final BidRequest capturedBidRequest = captureBidRequest();
@@ -1284,7 +1287,7 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtUser.of(ExtUserPrebid.of(uids), null, null))).build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final User capturedBidRequestUser = captureBidRequest().getUser();
@@ -1306,7 +1309,7 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtUser.of(ExtUserPrebid.of(uids), null, null))).build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final User capturedBidRequestUser = captureBidRequest().getUser();
@@ -1324,7 +1327,7 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.user(User.builder().id("userId").build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final BidRequest capturedBidRequest = captureBidRequest();
@@ -1341,7 +1344,7 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         final BidRequest capturedBidRequest = captureBidRequest();
@@ -1356,7 +1359,7 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         verify(bidderRequester).requestBids(any(), same(timeout));
@@ -1384,7 +1387,7 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null), null))))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext).result();
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         final ArgumentCaptor<Timeout> timeoutCaptor = ArgumentCaptor.forClass(Timeout.class);
@@ -1419,7 +1422,7 @@ public class ExchangeServiceTest extends VertxTest {
                                         ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null), null))))));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         verify(cacheService).cacheBidsOpenrtb(
@@ -1441,8 +1444,8 @@ public class ExchangeServiceTest extends VertxTest {
         given(currencyService.convertCurrency(any(), any(), any(), any())).willReturn(BigDecimal.valueOf(5.0));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid())
@@ -1465,8 +1468,8 @@ public class ExchangeServiceTest extends VertxTest {
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid())
@@ -1488,8 +1491,8 @@ public class ExchangeServiceTest extends VertxTest {
                 .willThrow(new PreBidException("no currency conversion available"));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid).isEmpty();
@@ -1512,8 +1515,8 @@ public class ExchangeServiceTest extends VertxTest {
         given(currencyService.convertCurrency(any(), any(), any(), any())).willReturn(BigDecimal.valueOf(10.0));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid())
@@ -1537,8 +1540,8 @@ public class ExchangeServiceTest extends VertxTest {
                 .willThrow(new PreBidException("no currency conversion available"));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid())
@@ -1562,7 +1565,7 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.site(Site.builder().publisher(Publisher.builder().id("accountId").build()).build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         verify(metrics).updateAccountRequestMetrics(eq("accountId"), eq(MetricName.openrtb2web));
@@ -1583,7 +1586,7 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.app(App.builder().publisher(Publisher.builder().id("accountId").build()).build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         verify(metrics).updateAdapterRequestNobidMetrics(eq("somebidder"), eq("accountId"));
@@ -1609,7 +1612,7 @@ public class ExchangeServiceTest extends VertxTest {
                 builder -> builder.site(Site.builder().publisher(Publisher.builder().id("accountId").build()).build()));
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
         verify(metrics).updateAdapterRequestGotbidsMetrics(eq("somebidder"), eq("accountId"));
@@ -1626,10 +1629,10 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(emptyList());
 
         // when
-        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext);
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
-        verify(bidResponsePostProcessor).postProcess(same(bidRequest), same(uidsCookie), any());
+        verify(bidResponsePostProcessor).postProcess(any(), same(bidRequest), same(uidsCookie), any());
     }
 
     @Test
@@ -1644,8 +1647,8 @@ public class ExchangeServiceTest extends VertxTest {
                         singletonMap("bidder", BigDecimal.valueOf(2.468)), null, null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid())
@@ -1665,8 +1668,8 @@ public class ExchangeServiceTest extends VertxTest {
                         singletonMap("some-other-bidder", BigDecimal.TEN), null, null, null)))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid())
@@ -1693,8 +1696,8 @@ public class ExchangeServiceTest extends VertxTest {
                         ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null), null))))));
 
         // when
-        final BidResponse bidResponse = exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext)
-                .result();
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
         assertThat(bidResponse.getSeatbid()).flatExtracting(SeatBid::getBid)

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -138,8 +138,8 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willThrow(new RuntimeException("Unexpected " +
-                "exception"));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willThrow(new RuntimeException("Unexpected exception"));
 
         // when
         ampHandler.handle(routingContext);
@@ -159,7 +159,7 @@ public class AmpHandlerTest extends VertxTest {
 
         final ObjectNode ext = mapper.createObjectNode();
         ext.set("prebid", new TextNode("non-ExtBidRequest"));
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(givenBidResponse(ext));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any())).willReturn(givenBidResponse(ext));
 
         // when
         ampHandler.handle(routingContext);
@@ -181,8 +181,9 @@ public class AmpHandlerTest extends VertxTest {
         final Map<String, String> targeting = new HashMap<>();
         targeting.put("key1", "value1");
         targeting.put("hb_cache_id_bidder1", "value2");
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, targeting, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(
+                        mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, targeting, null), null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -203,8 +204,8 @@ public class AmpHandlerTest extends VertxTest {
         final Map<String, String> targeting = new HashMap<>();
         targeting.put("key1", "value1");
         targeting.put("hb_cache_id_bidder1", "value2");
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder()
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder()
                         .seatbid(singletonList(SeatBid.builder()
                                 .seat("bidder1")
                                 .bid(singletonList(Bid.builder()
@@ -239,8 +240,9 @@ public class AmpHandlerTest extends VertxTest {
         final BidRequest bidRequest = BidRequest.builder().id("reqId1").test(1).imp(emptyList()).build();
         given(ampRequestFactory.fromRequest(any())).willReturn(Future.succeededFuture(bidRequest));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(givenBidResponseWithExt(
-                mapper.valueToTree(ExtBidResponse.of(ExtResponseDebug.of(null, bidRequest), null, null, null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponseWithExt(mapper.valueToTree(
+                        ExtBidResponse.of(ExtResponseDebug.of(null, bidRequest), null, null, null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -257,8 +259,9 @@ public class AmpHandlerTest extends VertxTest {
                 .willReturn(Future.succeededFuture(
                         BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -274,8 +277,9 @@ public class AmpHandlerTest extends VertxTest {
                 .willReturn(Future.succeededFuture(
                         BidRequest.builder().imp(emptyList()).app(App.builder().build()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -290,8 +294,9 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
 
         given(uidsCookie.hasLiveUids()).willReturn(false);
 
@@ -312,8 +317,9 @@ public class AmpHandlerTest extends VertxTest {
                 .willReturn(Future.succeededFuture(
                         BidRequest.builder().imp(singletonList(Imp.builder().build())).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -358,8 +364,8 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // simulate calling end handler that is supposed to update request_time timer value
         given(httpResponse.endHandler(any())).willAnswer(inv -> {
@@ -394,8 +400,9 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
 
         // simulate calling exception handler that is supposed to update networkerr timer value
         given(httpResponse.exceptionHandler(any())).willAnswer(inv -> {
@@ -416,8 +423,9 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, null, null), null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -450,8 +458,8 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willThrow(new RuntimeException("Unexpected " +
-                "exception"));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willThrow(new RuntimeException("Unexpected exception"));
 
         // when
         ampHandler.handle(routingContext);
@@ -471,9 +479,10 @@ public class AmpHandlerTest extends VertxTest {
         given(ampRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                givenBidResponse(mapper.valueToTree(ExtPrebid.of(
-                        ExtBidPrebid.of(null, singletonMap("hb_cache_id_bidder1", "value1"), null), null))));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(givenBidResponse(mapper.valueToTree(
+                        ExtPrebid.of(ExtBidPrebid.of(null, singletonMap("hb_cache_id_bidder1", "value1"), null),
+                                null))));
 
         // when
         ampHandler.handle(routingContext);
@@ -484,7 +493,8 @@ public class AmpHandlerTest extends VertxTest {
                 .bidResponse(BidResponse.builder().seatbid(singletonList(SeatBid.builder()
                         .bid(singletonList(Bid.builder()
                                 .ext(mapper.valueToTree(ExtPrebid.of(
-                                        ExtBidPrebid.of(null, singletonMap("hb_cache_id_bidder1", "value1"), null), null)))
+                                        ExtBidPrebid.of(null, singletonMap("hb_cache_id_bidder1", "value1"), null),
+                                        null)))
                                 .build()))
                         .build()))
                         .build())

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -116,8 +116,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willThrow(new RuntimeException("Unexpected " +
-                "exception"));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willThrow(new RuntimeException("Unexpected exception"));
 
         // when
         auctionHandler.handle(routingContext);
@@ -133,14 +133,14 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
 
         // then
-        verify(exchangeService).holdAuction(any(), any(), any(), any());
+        verify(exchangeService).holdAuction(any(), any(), any(), any(), any());
         verify(httpResponse).putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
         verify(httpResponse).end(eq("{}"));
     }
@@ -151,8 +151,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).tmax(1000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -167,8 +167,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -183,8 +183,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).tmax(6000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -199,8 +199,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).tmax(1000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         final Instant now = Instant.now();
         given(clock.millis()).willReturn(now.toEpochMilli()).willReturn(now.plusMillis(50L).toEpochMilli());
@@ -218,8 +218,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -231,11 +231,12 @@ public class AuctionHandlerTest extends VertxTest {
     @Test
     public void shouldIncrementOkOpenrtb2AppRequestMetrics() {
         // given
-        given(auctionRequestFactory.fromRequest(any())).willReturn(Future.succeededFuture(
-                BidRequest.builder().imp(emptyList()).app(App.builder().build()).build()));
+        given(auctionRequestFactory.fromRequest(any()))
+                .willReturn(Future.succeededFuture(
+                        BidRequest.builder().imp(emptyList()).app(App.builder().build()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -247,8 +248,8 @@ public class AuctionHandlerTest extends VertxTest {
     @Test
     public void shouldIncrementAppRequestMetrics() {
         // given
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(
@@ -267,8 +268,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         given(uidsCookie.hasLiveUids()).willReturn(false);
 
@@ -289,8 +290,8 @@ public class AuctionHandlerTest extends VertxTest {
                 .willReturn(Future.succeededFuture(
                         BidRequest.builder().imp(singletonList(Imp.builder().build())).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -335,8 +336,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // simulate calling end handler that is supposed to update request_time timer value
         given(httpResponse.endHandler(any())).willAnswer(inv -> {
@@ -371,8 +372,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // simulate calling exception handler that is supposed to update networkerr timer value
         given(httpResponse.exceptionHandler(any())).willAnswer(inv -> {
@@ -393,8 +394,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -426,8 +427,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willThrow(new RuntimeException("Unexpected " +
-                "exception"));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willThrow(new RuntimeException("Unexpected exception"));
 
         // when
         auctionHandler.handle(routingContext);
@@ -447,8 +448,8 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().imp(emptyList()).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
-                Future.succeededFuture(BidResponse.builder().build()));
+        given(exchangeService.holdAuction(any(), any(), any(), any(), any()))
+                .willReturn(Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
@@ -465,7 +466,7 @@ public class AuctionHandlerTest extends VertxTest {
 
     private Timeout captureTimeout() {
         final ArgumentCaptor<Timeout> timeoutCaptor = ArgumentCaptor.forClass(Timeout.class);
-        verify(exchangeService).holdAuction(any(), any(), timeoutCaptor.capture(), any());
+        verify(exchangeService).holdAuction(any(), any(), timeoutCaptor.capture(), any(), any());
         return timeoutCaptor.getValue();
     }
 


### PR DESCRIPTION
Changes:
- The `BidResponsePostProcessor` interface was changed to accept `RoutingContext` argument:
```
Future<BidResponse> postProcess(RoutingContext context, BidRequest bidRequest, 
  UidsCookie uidsCookie, BidResponse bidResponse);
```
- Fixed minor issues.
- Refactored code and JavaDoc.