### PR TITLE
Fix active connections metric

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -66,15 +66,18 @@ But feel free to add additional bidder's specific options.
 ## Metrics
 - `metrics.metricType` - set the type of metric counter for [Dropwizard Metrics](http://metrics.dropwizard.io). Can be `flushingCounter` (default), `counter` or `meter`.
 
-Metrics can be submitted simultaneously to many backends. Currently we support `graphite` and `influxdb`.
+So far metrics cannot be submitted simultaneously to many backends. Currently we support `graphite` and `influxdb`. 
+Also, for debug purposes you can use `console` as metrics backend.
 
 For `graphite` backend type available next options:
+- `metrics.graphite.enabled` - if equals to `true` then `graphite` will be used to submit metrics.
 - `metrics.graphite.prefix` - the prefix of all metric names.
 - `metrics.graphite.host` - the graphite host for sending statistics.
 - `metrics.graphite.port` - the graphite port for sending statistics.
 - `metrics.graphite.interval` - interval in seconds between successive sending metrics.
 
 For `influxdb` backend type available next options:
+- `metrics.influxdb.enabled` - if equals to `true` then `influxdb` will be used to submit metrics.
 - `metrics.influxdb.prefix` - the prefix of all metric names.
 - `metrics.influxdb.protocol` - external service destination protocol.
 - `metrics.influxdb.host` - the influxDb host for sending metrics.
@@ -84,6 +87,10 @@ For `influxdb` backend type available next options:
 - `metrics.influxdb.connectTimeout` - the connect timeout.
 - `metrics.influxdb.readTimeout` - the response timeout.
 - `metrics.influxdb.interval` - interval in seconds between successive sending metrics.
+
+For `console` backend type available next options:
+- `metrics.console.enabled` - if equals to `true` then `console` will be used to submit metrics.
+- `metrics.console.interval` - interval in seconds between successive sending metrics.
 
 It is possible to define how many account-level metrics will be submitted on per-account basis.
 See [metrics documentation](metrics.md) for complete list of metrics submitted at each verbosity level.

--- a/docs/differenceBetweenPBSGo-and-Java.md
+++ b/docs/differenceBetweenPBSGo-and-Java.md
@@ -27,6 +27,7 @@ and not the other for an interim period. This page tracks known differences that
 - PBS-Go fixed the IndexExchange-vs-IX issue. PBS-Java fix is in progress.
 - PBS-Java Rubicon adapter removes `req.cur` from request to XAPI.
 - PBS-Go use "60 seconds buffer + {bid,imp,mediaType}TTL" approach to determine caching TTL period.
+- PBS-Java has different names for system metrics. For example instead of `active_connections` it uses `vertx.http.servers.0.0.0.0:[PORT].open-netsockets.count`. See [Metrics](metrics.md) for details.
 
 ## GDPR differences
 - PBS-Java supports geo location service interface to determine the country for incoming client request (the host company should provide its own implementation).

--- a/docs/differenceBetweenPBSGo-and-Java.md
+++ b/docs/differenceBetweenPBSGo-and-Java.md
@@ -27,7 +27,7 @@ and not the other for an interim period. This page tracks known differences that
 - PBS-Go fixed the IndexExchange-vs-IX issue. PBS-Java fix is in progress.
 - PBS-Java Rubicon adapter removes `req.cur` from request to XAPI.
 - PBS-Go use "60 seconds buffer + {bid,imp,mediaType}TTL" approach to determine caching TTL period.
-- PBS-Java has different names for system metrics. For example instead of `active_connections` it uses `vertx.http.servers.0.0.0.0:[PORT].open-netsockets.count`. See [Metrics](metrics.md) for details.
+- PBS-Java has different names for system metrics. For example instead of `active_connections` it uses `vertx.http.servers.[IP]:[PORT].open-netsockets.count`. See [Metrics](metrics.md) for details.
 
 ## GDPR differences
 - PBS-Java supports geo location service interface to determine the country for incoming client request (the host company should provide its own implementation).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,6 +2,13 @@
 
 This document describes all metrics collected and submitted to configured backends by the Prebid Server.
 
+## System metrics
+- `vertx.http.servers.0.0.0.0:[PORT].open-netsockets.count` - current number of open connections
+
+where [PORT] should be equal to `http.port` configuration property. 
+
+Other available metrics can found at [Vert.x Dropwizard Metrics](https://vertx.io/docs/vertx-dropwizard-metrics/java/#_the_metrics) page.
+
 ## General auction metrics
 - `app_requests` - number of requests received from applications
 - `no_cookie_requests` - number of requests without `uids` cookie or with one that didn't contain at least one live UID
@@ -10,7 +17,6 @@ This document describes all metrics collected and submitted to configured backen
 - `request_time` - timer tracking how long did it take for Prebid Server to serve a request
 - `imps_requested` - number if impressions requested
 - `requests.(ok|badinput|err|networkerr).(openrtb2-web|openrtb-app|amp|legacy)` - number of requests broken down by status and type
-- `active_connections` - current number of open connections
 - `db_circuitbreaker_opened` - number of how many times database circuit breaker was opened (database is unavailable)
 - `db_circuitbreaker_closed` - number of how many times database circuit breaker was closed (database is available again)
 - `db_query_time` - timer tracking how long did it take for database client to obtain the result for a query

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -3,9 +3,11 @@
 This document describes all metrics collected and submitted to configured backends by the Prebid Server.
 
 ## System metrics
-- `vertx.http.servers.0.0.0.0:[PORT].open-netsockets.count` - current number of open connections
+- `vertx.http.servers.[IP]:[PORT].open-netsockets.count` - current number of open connections
 
-where [PORT] should be equal to `http.port` configuration property. 
+where:
+- `[IP]` should be equal to IP address of bound network interface on cluster node for Prebid Server (for example: `0.0.0.0`).
+- `[PORT]` should be equal to `http.port` configuration property.
 
 Other available metrics can found at [Vert.x Dropwizard Metrics](https://vertx.io/docs/vertx-dropwizard-metrics/java/#_the_metrics) page.
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
             <version>${vertx.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-dropwizard-metrics</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/src/main/java/org/prebid/server/handler/ConnectionHandler.java
+++ b/src/main/java/org/prebid/server/handler/ConnectionHandler.java
@@ -20,8 +20,7 @@ public class ConnectionHandler implements Handler<HttpConnection> {
 
     @Override
     public void handle(HttpConnection connection) {
-        metrics.updateActiveConnectionsMetrics(true);
-
-        connection.closeHandler(ignored -> metrics.updateActiveConnectionsMetrics(false));
+        // todo: add error metrics here
+        // connection.exceptionHandler(throwable -> {});
     }
 }

--- a/src/main/java/org/prebid/server/metric/MetricName.java
+++ b/src/main/java/org/prebid/server/metric/MetricName.java
@@ -1,9 +1,6 @@
 package org.prebid.server.metric;
 
 public enum MetricName {
-    // common
-    active_connections,
-
     // database
     db_circuitbreaker_opened,
     db_circuitbreaker_closed,

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -173,14 +173,6 @@ public class Metrics extends UpdatableMetrics {
         forAdapter(bidder).incCounter(MetricName.gdpr_masked);
     }
 
-    public void updateActiveConnectionsMetrics(boolean openConnection) {
-        if (openConnection) {
-            incCounter(MetricName.active_connections);
-        } else {
-            decCounter(MetricName.active_connections);
-        }
-    }
-
     public void updateDatabaseQueryTimeMetric(long millis) {
         updateTimer(MetricName.db_query_time, millis);
     }

--- a/src/main/java/org/prebid/server/metric/UpdatableMetrics.java
+++ b/src/main/java/org/prebid/server/metric/UpdatableMetrics.java
@@ -53,10 +53,6 @@ class UpdatableMetrics {
         incrementer.accept(metricRegistry, name(metricName), value);
     }
 
-    void decCounter(MetricName metricName) {
-        metricRegistry.counter(name(metricName)).dec();
-    }
-
     /**
      * Updates metric's timer with a given value.
      */

--- a/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
@@ -3,6 +3,7 @@ package org.prebid.server.spring.config;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystem;
+import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.prebid.server.json.ObjectMapperConfigurer;
 import org.prebid.server.vertx.ContextRunner;
@@ -18,8 +19,12 @@ public class VertxConfiguration {
     }
 
     @Bean
-    Vertx vertx(@Value("${vertx.worker-pool-size}") Integer workerPoolSize) {
-        return Vertx.vertx(new VertxOptions().setWorkerPoolSize(workerPoolSize));
+    Vertx vertx(@Value("${vertx.worker-pool-size}") int workerPoolSize) {
+        return Vertx.vertx(new VertxOptions()
+                .setWorkerPoolSize(workerPoolSize)
+                .setMetricsOptions(new DropwizardMetricsOptions()
+                        .setEnabled(true)
+                        .setRegistryName(MetricsConfiguration.METRIC_REGISTRY_NAME)));
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/handler/ConnectionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/ConnectionHandlerTest.java
@@ -1,20 +1,13 @@
 package org.prebid.server.handler;
 
-import io.vertx.core.Handler;
 import io.vertx.core.http.HttpConnection;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.prebid.server.metric.Metrics;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class ConnectionHandlerTest {
 
@@ -35,27 +28,12 @@ public class ConnectionHandlerTest {
     }
 
     @Test
-    public void shouldIncrementActiveConnectionsMetrics() {
-        // when
-        connectionHandler.handle(httpConnection);
-
-        // then
-        verify(metrics).updateActiveConnectionsMetrics(eq(true));
+    public void shouldIncrementNetworkErrorsMetrics() {
+        // FIXME
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void shouldDecrementActiveConnectionsMetrics() {
-        // when
-        connectionHandler.handle(httpConnection);
-
-        // then
-        final ArgumentCaptor<Handler<Void>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
-        verify(httpConnection).closeHandler(handlerCaptor.capture());
-        handlerCaptor.getValue().handle(null); // emulate closing of http connection
-
-        final ArgumentCaptor<Boolean> incrementCaptor = ArgumentCaptor.forClass(Boolean.class);
-        verify(metrics, times(2)).updateActiveConnectionsMetrics(incrementCaptor.capture());
-        assertThat(incrementCaptor.getAllValues()).containsExactly(true, false);
+    public void shouldDecrementNetworkErrorsMetrics() {
+        // FIXME
     }
 }

--- a/src/test/java/org/prebid/server/metric/MetricsTest.java
+++ b/src/test/java/org/prebid/server/metric/MetricsTest.java
@@ -490,24 +490,6 @@ public class MetricsTest {
     }
 
     @Test
-    public void shouldIncrementActiveConnectionsMetrics() {
-        // when
-        metrics.updateActiveConnectionsMetrics(true);
-
-        // then
-        assertThat(metricRegistry.counter("active_connections").getCount()).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldDecrementActiveConnectionsMetrics() {
-        // when
-        metrics.updateActiveConnectionsMetrics(false);
-
-        // then
-        assertThat(metricRegistry.counter("active_connections").getCount()).isEqualTo(-1);
-    }
-
-    @Test
     public void shouldUpdateDatabaseQueryTimeMetric() {
         // when
         metrics.updateDatabaseQueryTimeMetric(456L);


### PR DESCRIPTION
CL:
- Added `vertx-dropwizard-metrics` module to support [rich application metrics](https://vertx.io/docs/vertx-dropwizard-metrics/java/#_the_metrics).
- Used single metric registry for built-in Vertx and custom metrics.
- Custom `active_connections` metric implementation replaced with `vertx.http.servers.0.0.0.0:8080.open-netsockets.count`.
- Added `console` metrics backend for debugging purposes.
- Added new `metrics.{graphite,influxdb,console}.enabled` config properties to be more clear and simple control with metrics backends configurations.