### PR TITLE
Fix bidresponse.ext containing empty errors list

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -1129,11 +1129,13 @@ public class ExchangeService {
 
         final Map<String, List<ExtBidderError>> errors = new HashMap<>();
         for (BidderResponse bidderResponse : results) {
-            errors.put(bidderResponse.getBidder(), errorsDetails(bidderResponse.getSeatBid().getErrors()));
+            final List<BidderError> bidderErrors = bidderResponse.getSeatBid().getErrors();
+            if (CollectionUtils.isNotEmpty(bidderErrors)) {
+                errors.put(bidderResponse.getBidder(), errorsDetails(bidderErrors));
+            }
         }
 
         errors.putAll(extractDeprecatedBiddersErrors(bidRequest));
-
         errors.putAll(extractCacheErrors(cacheErrors));
 
         final Map<String, Integer> responseTimeMillis = results.stream()
@@ -1143,7 +1145,7 @@ public class ExchangeService {
             responseTimeMillis.put(CACHE, cacheExecutionTime);
         }
 
-        return ExtBidResponse.of(extResponseDebug, errors, responseTimeMillis, null);
+        return ExtBidResponse.of(extResponseDebug, errors.isEmpty() ? null : errors, responseTimeMillis, null);
     }
 
     private Map<String, List<ExtBidderError>> extractDeprecatedBiddersErrors(BidRequest bidRequest) {

--- a/src/test/java/org/prebid/server/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/ApplicationTest.java
@@ -486,6 +486,7 @@ public class ApplicationTest extends VertxTest {
         final String expectedAuctionResponse = openrtbAuctionResponseFrom(
                 "openrtb2/ttx/test-auction-ttx-response.json",
                 response, singletonList(TTX));
+        System.out.println(response.asString());
 
         JSONAssert.assertEquals(expectedAuctionResponse, response.asString(), JSONCompareMode.NON_EXTENSIBLE);
     }

--- a/src/test/java/org/prebid/server/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/ApplicationTest.java
@@ -486,7 +486,6 @@ public class ApplicationTest extends VertxTest {
         final String expectedAuctionResponse = openrtbAuctionResponseFrom(
                 "openrtb2/ttx/test-auction-ttx-response.json",
                 response, singletonList(TTX));
-        System.out.println(response.asString());
 
         JSONAssert.assertEquals(expectedAuctionResponse, response.asString(), JSONCompareMode.NON_EXTENSIBLE);
     }

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -1848,6 +1848,25 @@ public class ExchangeServiceTest extends VertxTest {
     }
 
     @Test
+    public void shouldNotContainErrorsIfBidderErrorsAreEmpty() throws JsonProcessingException {
+        // given
+        final Bid bid = Bid.builder().id("bidId").impid("impId").price(BigDecimal.ONE).build();
+        givenHttpConnector("bidder", mock(BidderRequester.class), givenSeatBid(singletonList(givenBid(bid))));
+
+        final BidRequest bidRequest = givenBidRequest(singletonList(
+                // imp ids are not really used for matching, included them here for clarity
+                givenImp(singletonMap("bidder", 1), builder -> builder.id("impId"))));
+
+        // when
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
+
+        // then
+        final ExtBidResponse ext = mapper.treeToValue(bidResponse.getExt(), ExtBidResponse.class);
+        assertThat(ext.getErrors()).isNull();
+    }
+
+    @Test
     public void shouldContainCacheResponseTime() throws JsonProcessingException {
         // given
         final Bid bid = Bid.builder().id("bidId").impid("impId").price(BigDecimal.ONE).build();

--- a/src/test/resources/org/prebid/server/ApplicationTest/cache/update/test-auction-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/cache/update/test-auction-response.json
@@ -126,9 +126,6 @@
         }
       }
     },
-    "errors": {
-      "rubicon": []
-    },
     "responsetimemillis": {
       "rubicon": "{{ rubicon.response_time_ms }}"
     }

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/adform/test-auction-adform-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/adform/test-auction-adform-response.json
@@ -159,9 +159,6 @@
         }
       }
     },
-    "errors": {
-      "adform": []
-    },
     "responsetimemillis": {
       "adform": "{{ adform.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/adkerneladn/test-auction-adkerneladn-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/adkerneladn/test-auction-adkerneladn-response.json
@@ -240,9 +240,6 @@
         }
       }
     },
-    "errors": {
-      "adkernelAdn": []
-    },
     "responsetimemillis": {
       "adkernelAdn": "{{ adkernelAdn.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/adtelligent/test-auction-adtelligent-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/adtelligent/test-auction-adtelligent-response.json
@@ -161,9 +161,6 @@
         }
       }
     },
-    "errors": {
-      "adtelligent": []
-    },
     "responsetimemillis": {
       "adtelligent": "{{ adtelligent.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/beachfront/test-auction-beachfront-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/beachfront/test-auction-beachfront-response.json
@@ -166,9 +166,6 @@
         }
       }
     },
-    "errors": {
-      "beachfront": []
-    },
     "responsetimemillis": {
       "beachfront": "{{ beachfront.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/brightroll/test-auction-brightroll-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/brightroll/test-auction-brightroll-response.json
@@ -164,9 +164,6 @@
         }
       }
     },
-    "errors": {
-      "brightroll": []
-    },
     "responsetimemillis": {
       "brightroll": "{{ brightroll.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/conversant/alias/test-auction-conversant-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/conversant/alias/test-auction-conversant-response.json
@@ -163,9 +163,6 @@
         }
       }
     },
-    "errors": {
-      "conversantAlias": []
-    },
     "responsetimemillis": {
       "conversantAlias": "{{ conversantAlias.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/conversant/test-auction-conversant-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/conversant/test-auction-conversant-response.json
@@ -222,9 +222,6 @@
         }
       }
     },
-    "errors": {
-      "conversant": []
-    },
     "responsetimemillis": {
       "conversant": "{{ conversant.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/eplanning/test-auction-eplanning-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/eplanning/test-auction-eplanning-response.json
@@ -162,9 +162,6 @@
         }
       }
     },
-    "errors": {
-      "eplanning": []
-    },
     "responsetimemillis": {
       "eplanning": "{{ eplanning.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/facebook/test-auction-facebook-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/facebook/test-auction-facebook-response.json
@@ -162,9 +162,6 @@
         }
       }
     },
-    "errors": {
-      "audienceNetwork": []
-    },
     "responsetimemillis": {
       "audienceNetwork": "{{ audienceNetwork.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/ix/test-auction-ix-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/ix/test-auction-ix-response.json
@@ -189,9 +189,6 @@
         }
       }
     },
-    "errors": {
-      "ix": []
-    },
     "responsetimemillis": {
       "ix": "{{ ix.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/lifestreet/test-auction-lifestreet-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/lifestreet/test-auction-lifestreet-response.json
@@ -232,9 +232,6 @@
         }
       }
     },
-    "errors": {
-      "lifestreet": []
-    },
     "responsetimemillis": {
       "lifestreet": "{{ lifestreet.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/openx/test-auction-openx-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/openx/test-auction-openx-response.json
@@ -375,9 +375,6 @@
         }
       }
     },
-    "errors": {
-      "openx": []
-    },
     "responsetimemillis": {
       "openx": "{{ openx.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/pubmatic/test-auction-pubmatic-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/pubmatic/test-auction-pubmatic-response.json
@@ -261,9 +261,6 @@
         }
       }
     },
-    "errors": {
-      "pubmatic": []
-    },
     "responsetimemillis": {
       "pubmatic": "{{ pubmatic.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/pulsepoint/test-auction-pulsepoint-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/pulsepoint/test-auction-pulsepoint-response.json
@@ -225,9 +225,6 @@
         }
       }
     },
-    "errors": {
-      "pulsepoint": []
-    },
     "responsetimemillis": {
       "pulsepoint": "{{ pulsepoint.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/rhythmone/test-auction-rhythmone-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/rhythmone/test-auction-rhythmone-response.json
@@ -194,9 +194,6 @@
         }
       }
     },
-    "errors": {
-      "rhythmone": []
-    },
     "responsetimemillis": {
       "rhythmone": "{{ rhythmone.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-response.json
@@ -534,9 +534,7 @@
           "code": 2,
           "message": "Appnexus doesn't support audio Imps. Ignoring Imp ID=impId32"
         }
-      ],
-      "appnexusAlias": [],
-      "rubicon": []
+      ]
     },
     "responsetimemillis": {
       "appnexus": "{{ appnexus.response_time_ms }}",

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/somoaudience/test-auction-somoaudience-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/somoaudience/test-auction-somoaudience-response.json
@@ -349,9 +349,6 @@
         }
       }
     },
-    "errors": {
-      "somoaudience": []
-    },
     "responsetimemillis": {
       "somoaudience": "{{ somoaudience.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/sovrn/test-auction-sovrn-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/sovrn/test-auction-sovrn-response.json
@@ -164,9 +164,6 @@
         }
       }
     },
-    "errors": {
-      "sovrn": []
-    },
     "responsetimemillis": {
       "sovrn": "{{ sovrn.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/ttx/test-auction-ttx-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/ttx/test-auction-ttx-response.json
@@ -161,9 +161,6 @@
         }
       }
     },
-    "errors": {
-      "ttx": []
-    },
     "responsetimemillis": {
       "ttx": "{{ ttx.response_time_ms }}",
       "cache": "{{ cache.response_time_ms }}"


### PR DESCRIPTION
Fixed bidresponse.ext containing empty errors list - now, if there are no errors - they are not added to .json file.