### PR TITLE
Make host-cookie precedence over uids

### DIFF
--- a/src/test/java/org/prebid/server/cookie/UidsCookieServiceTest.java
+++ b/src/test/java/org/prebid/server/cookie/UidsCookieServiceTest.java
@@ -204,7 +204,7 @@ public class UidsCookieServiceTest extends VertxTest {
     }
 
     @Test
-    public void shouldReturnRubiconCookieValueFromUidsCookieWhenUidValueIsPresent() {
+    public void shouldReturnRubiconCookieValueFromHostCookieWhenUidValueIsPresentButDiffers() {
         // given
         uidsCookieService = new UidsCookieService("trp_optout", "true", "rubicon", "khaos", "cookie-domain", 90);
 
@@ -220,7 +220,7 @@ public class UidsCookieServiceTest extends VertxTest {
         // then
         verify(routingContext).getCookie(eq("uids"));
         verify(routingContext).getCookie(eq("khaos"));
-        assertThat(uidsCookie.uidFrom(RUBICON)).isEqualTo("J5VLCWQP-26-CWFT");
+        assertThat(uidsCookie.uidFrom(RUBICON)).isEqualTo("abc123");
     }
 
     @Test


### PR DESCRIPTION
This PR changes working with `host-cookie` and `uids`cookies.
For now PBS checked `uids`cookie and if it contains HOST-BIDDER uid then `host-cookie` is ignored.

In new behavior if `host-cookie` exists and `uids` cookie contains HOST-BIDDER uid with different value - the `host-cookie` value will be used.

So, available scenarios:
- `host-cookie` specified, `uids.HOST-BIDDER` exists, `host-cookie` value **is equal** to  `uids.HOST-BIDDER`: no action (HAPPY PATH)
- `host-cookie` specified, `uids.HOST-BIDDER` exists, `host-cookie` value **is NOT equal** to  `uids.HOST-BIDDER`: use `host-cookie` value for `uids.HOST-BIDDER`
- `host-cookie` specified, no `uids.HOST-BIDDER`: use `host-cookie` value for `uids.HOST-BIDDER`
- no `host-cookie`, `uids.HOST-BIDDER` exists: no action (continue use  `uids.HOST-BIDDER` existing value)
- no `host-cookie`, no `uids.HOST-BIDDER`: no action