### PR TITLE
Set /setuid as usersync-url for host-bidder in /cookie_sync response

### DIFF
--- a/docs/endpoints/cookieSync.md
+++ b/docs/endpoints/cookieSync.md
@@ -53,3 +53,20 @@ This will return a JSON object that will allow the client to request cookie sync
     ]
 }
 ```
+
+### Special behavior for HOST-BIDDER
+
+if `host-cookie` exists and `uids` cookie contains HOST-BIDDER uid with different value - the `host-cookie` value will be used.
+
+So, available scenarios:
+1. `host-cookie` specified, `uids.HOST-BIDDER` exists, `host-cookie` value **is equal** to  `uids.HOST-BIDDER`: no action (HAPPY PATH)
+2. `host-cookie` specified, `uids.HOST-BIDDER` exists, `host-cookie` value **is NOT equal** to  `uids.HOST-BIDDER`: use `host-cookie` value for `uids.HOST-BIDDER`
+3. `host-cookie` specified, no `uids.HOST-BIDDER`: use `host-cookie` value for `uids.HOST-BIDDER`
+4. no `host-cookie`, `uids.HOST-BIDDER` exists: no action (continue use  `uids.HOST-BIDDER` existing value)
+5. no `host-cookie`, no `uids.HOST-BIDDER`: no action
+
+In both of cases 2 and 3 the `uids.HOST-BIDDER` is broken, but `host-cookie` is valid value. So, `uids.HOST-BIDDER` value should be updated.
+In regular situation PBS just put pre-configured `usersync-url` in `/cookie_sync` response.
+But for `HOST-BIDDER` it is not necessary to call `usersync-url`for obtaining new UID because we already have it in `host-cookie`.
+
+So, all we need is to use direct `/setuid?bidder=%s&gdpr=%s&gdpr_consent=%s&uid=%s` url as `usersync-url` in `/cookie_sync` response to set http cookie to user.

--- a/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
+++ b/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
@@ -229,11 +229,11 @@ public class BeachfrontBidder implements Bidder<BeachfrontRequests> {
         final String userId = user.getId();
         final String buyerId = user.getBuyeruid();
         return User.builder()
-                //   Exchange-specific ID for the user. At least one of id or
-                //   buyeruid is recommended.
+                // Exchange-specific ID for the user. At least one of id or
+                // buyeruid is recommended.
                 .id(StringUtils.isNotEmpty(userId) ? userId : null)
-                //   Buyer-specific ID for the user as mapped by the exchange for
-                //   the buyer. At least one of buyeruid or id is recommended.
+                // Buyer-specific ID for the user as mapped by the exchange for
+                // the buyer. At least one of buyeruid or id is recommended.
                 .buyeruid(StringUtils.isNotEmpty(buyerId) ? buyerId : null)
                 .build();
     }

--- a/src/main/java/org/prebid/server/handler/CookieSyncHandler.java
+++ b/src/main/java/org/prebid/server/handler/CookieSyncHandler.java
@@ -10,6 +10,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.analytics.AnalyticsReporter;
 import org.prebid.server.analytics.model.CookieSyncEvent;
@@ -17,6 +18,8 @@ import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.bidder.Usersyncer;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.cookie.UidsCookieService;
+import org.prebid.server.cookie.model.UidWithExpiry;
+import org.prebid.server.cookie.proto.Uids;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.gdpr.GdprService;
 import org.prebid.server.gdpr.model.GdprPurpose;
@@ -25,6 +28,7 @@ import org.prebid.server.metric.Metrics;
 import org.prebid.server.proto.request.CookieSyncRequest;
 import org.prebid.server.proto.response.BidderUsersyncStatus;
 import org.prebid.server.proto.response.CookieSyncResponse;
+import org.prebid.server.proto.response.UsersyncInfo;
 import org.prebid.server.util.HttpUtil;
 
 import java.util.Collection;
@@ -43,6 +47,7 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
     private static final Set<GdprPurpose> GDPR_PURPOSES =
             Collections.unmodifiableSet(EnumSet.of(GdprPurpose.informationStorageAndAccess));
 
+    private final String externalUrl;
     private final long defaultTimeout;
     private final UidsCookieService uidsCookieService;
     private final BidderCatalog bidderCatalog;
@@ -53,9 +58,11 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
     private final Metrics metrics;
     private final TimeoutFactory timeoutFactory;
 
-    public CookieSyncHandler(long defaultTimeout, UidsCookieService uidsCookieService, BidderCatalog bidderCatalog,
+    public CookieSyncHandler(String externalUrl, long defaultTimeout, UidsCookieService uidsCookieService,
+                             BidderCatalog bidderCatalog,
                              GdprService gdprService, Integer gdprHostVendorId, boolean useGeoLocation,
                              AnalyticsReporter analyticsReporter, Metrics metrics, TimeoutFactory timeoutFactory) {
+        this.externalUrl = HttpUtil.validateUrl(Objects.requireNonNull(externalUrl));
         this.defaultTimeout = defaultTimeout;
         this.uidsCookieService = Objects.requireNonNull(uidsCookieService);
         this.bidderCatalog = Objects.requireNonNull(bidderCatalog);
@@ -194,8 +201,8 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
         }
 
         final List<BidderUsersyncStatus> bidderStatuses = bidders.stream()
-                .map(bidder -> bidderStatusFor(bidder, uidsCookie, biddersRejectedByGdpr, gdpr, gdprConsent))
-                .filter(Objects::nonNull) // skip bidder with live Uid
+                .map(bidder -> bidderStatusFor(bidder, context, uidsCookie, biddersRejectedByGdpr, gdpr, gdprConsent))
+                .filter(Objects::nonNull) // skip bidder with live UID
                 .collect(Collectors.toList());
 
         final List<BidderUsersyncStatus> updatedBidderStatuses;
@@ -222,9 +229,9 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
     /**
      * Creates {@link BidderUsersyncStatus} for given bidder.
      */
-    private BidderUsersyncStatus bidderStatusFor(String bidder, UidsCookie uidsCookie,
-                                                 Collection<String> biddersRejectedByGdpr, String gdpr,
-                                                 String gdprConsent) {
+    private BidderUsersyncStatus bidderStatusFor(String bidder, RoutingContext context, UidsCookie uidsCookie,
+                                                 Collection<String> biddersRejectedByGdpr,
+                                                 String gdpr, String gdprConsent) {
         final BidderUsersyncStatus result;
         final boolean isNotAlias = !bidderCatalog.isAlias(bidder);
 
@@ -244,10 +251,13 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
                     .build();
         } else {
             final Usersyncer usersyncer = bidderCatalog.usersyncerByName(bidderNameFor(bidder));
-            if (!uidsCookie.hasLiveUidFrom(usersyncer.cookieFamilyName())) {
+            final UsersyncInfo updatedUsersyncInfo = updatedUsersyncInfo(context, gdpr, gdprConsent, usersyncer);
+
+            if (updatedUsersyncInfo != null || !uidsCookie.hasLiveUidFrom(usersyncer.cookieFamilyName())) {
                 result = bidderStatusBuilder(bidder)
                         .noCookie(true)
-                        .usersync(usersyncer.usersyncInfo().withGdpr(gdpr, gdprConsent))
+                        .usersync(ObjectUtils.defaultIfNull(updatedUsersyncInfo,
+                                usersyncer.usersyncInfo().withGdpr(gdpr, gdprConsent)))
                         .build();
             } else {
                 result = null;
@@ -259,5 +269,43 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
 
     private static BidderUsersyncStatus.BidderUsersyncStatusBuilder bidderStatusBuilder(String bidder) {
         return BidderUsersyncStatus.builder().bidder(bidder);
+    }
+
+    /**
+     * Returns {@link UsersyncInfo} with updated usersync-url (pointed directly to Prebid Server /setuid endpoint)
+     * or null if normal usersync flow should be applied.
+     * <p>
+     * Uids cookie should be in sync with host-cookie value, so the next conditions must be satisfied:
+     * <p>
+     * 1. Given {@link Usersyncer} should have the same cookie family value as configured host-cookie-family.
+     * <p>
+     * 2. Host-cookie must be present in HTTP request.
+     * <p>
+     * 3. Host-bidder uid value in uids cookie should not exist or be different from host-cookie uid value.
+     */
+    private UsersyncInfo updatedUsersyncInfo(RoutingContext context, String gdpr, String gdprConsent,
+                                             Usersyncer usersyncer) {
+        final String cookieFamilyName = usersyncer.cookieFamilyName();
+        if (Objects.equals(cookieFamilyName, uidsCookieService.getHostCookieFamily())) {
+
+            final String hostCookieUid = uidsCookieService.parseHostCookie(context);
+            if (hostCookieUid != null) {
+
+                final Uids parsedUids = uidsCookieService.parseUids(context);
+                final Map<String, UidWithExpiry> uidsMap = parsedUids != null ? parsedUids.getUids() : null;
+                final UidWithExpiry uidWithExpiry = uidsMap != null ? uidsMap.get(cookieFamilyName) : null;
+                final String uid = uidWithExpiry != null ? uidWithExpiry.getUid() : null;
+
+                if (!Objects.equals(hostCookieUid, uid)) {
+                    final String url = String.format("%s/setuid?bidder=%s&gdpr=%s&gdpr_consent=%s&uid=%s",
+                            externalUrl, cookieFamilyName, gdpr, gdprConsent, hostCookieUid);
+                    final UsersyncInfo usersyncInfo = usersyncer.usersyncInfo();
+
+                    return UsersyncInfo.of(url, usersyncInfo.getType(),
+                            usersyncInfo.getSupportCORS());
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -239,6 +239,7 @@ public class WebConfiguration {
 
     @Bean
     CookieSyncHandler cookieSyncHandler(
+            @Value("${external-url}") String externalUrl,
             @Value("${cookie-sync.default-timeout-ms}") int defaultTimeoutMs,
             UidsCookieService uidsCookieService,
             BidderCatalog bidderCatalog,
@@ -249,8 +250,8 @@ public class WebConfiguration {
             Metrics metrics,
             TimeoutFactory timeoutFactory) {
 
-        return new CookieSyncHandler(defaultTimeoutMs, uidsCookieService, bidderCatalog, gdprService, hostVendorId,
-                useGeoLocation, analyticsReporter, metrics, timeoutFactory);
+        return new CookieSyncHandler(externalUrl, defaultTimeoutMs, uidsCookieService, bidderCatalog, gdprService,
+                hostVendorId, useGeoLocation, analyticsReporter, metrics, timeoutFactory);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -288,7 +288,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -331,7 +332,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -353,7 +355,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -375,7 +378,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -398,7 +402,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -444,7 +449,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -490,7 +496,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -536,7 +543,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
+                .containsOnly(
+                        "request.imp[0].banner has no sizes. Define \"w\" and \"h\", or include \"format\" elements");
     }
 
     @Test
@@ -579,7 +587,7 @@ public class RequestValidatorTest extends VertxTest {
 
     @Test
     public void validateShouldReturnValidationMessageWhenBannerFormatHeightWeightAndOneOfRatiosPresent() {
-        //give
+        // given
         final BidRequest bidRequest = overwriteBannerFormatInFirstImp(validBidRequestBuilder().build(),
                 formatBuilder -> Format.builder().h(1).w(2).hratio(5));
 
@@ -1536,7 +1544,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.context is invalid. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
+                .containsOnly(
+                        "request.imp[0].native.request.context is invalid. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
     }
 
     @Test
@@ -1550,7 +1559,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.contextsubtype is invalid. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
+                .containsOnly(
+                        "request.imp[0].native.request.contextsubtype is invalid. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
 
     }
 
@@ -1565,7 +1575,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.context is 2, but contextsubtype is 11. This is an invalid combination. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
+                .containsOnly(
+                        "request.imp[0].native.request.context is 2, but contextsubtype is 11. This is an invalid combination. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
 
     }
 
@@ -1580,7 +1591,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.context is 3, but contextsubtype is 21. This is an invalid combination. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
+                .containsOnly(
+                        "request.imp[0].native.request.context is 3, but contextsubtype is 21. This is an invalid combination. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
 
     }
 
@@ -1595,7 +1607,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.context is 2, but contextsubtype is 31. This is an invalid combination. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
+                .containsOnly(
+                        "request.imp[0].native.request.context is 2, but contextsubtype is 31. This is an invalid combination. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=39");
 
     }
 
@@ -1650,7 +1663,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.eventtrackers[0].event is invalid. See section 7.6: https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=43");
+                .containsOnly(
+                        "request.imp[0].native.request.eventtrackers[0].event is invalid. See section 7.6: https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=43");
 
     }
 
@@ -1666,7 +1680,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.eventtrackers[0].method is required. See section 7.7: https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=43");
+                .containsOnly(
+                        "request.imp[0].native.request.eventtrackers[0].method is required. See section 7.7: https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=43");
 
     }
 
@@ -1682,7 +1697,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.eventtrackers[0].methods[0] is invalid. See section 7.7: https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=43");
+                .containsOnly(
+                        "request.imp[0].native.request.eventtrackers[0].methods[0] is invalid. See section 7.7: https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=43");
 
     }
 
@@ -1713,7 +1729,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.plcmttype is invalid. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=40");
+                .containsOnly(
+                        "request.imp[0].native.request.plcmttype is invalid. See https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf#page=40");
     }
 
     @Test
@@ -2211,7 +2228,8 @@ public class RequestValidatorTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("request.imp[0].native.request.assets[0].video.protocols[0] must be in the range [1, 10]. Got 0");
+                .containsOnly(
+                        "request.imp[0].native.request.assets[0].video.protocols[0] must be in the range [1, 10]. Got 0");
     }
 
     @Test

--- a/src/test/resources/org/prebid/server/ApplicationTest/test-application.properties
+++ b/src/test/resources/org/prebid/server/ApplicationTest/test-application.properties
@@ -107,9 +107,11 @@ cache.path=/cache
 cache.query=uuid=%PBS_CACHE_UUID%
 recaptcha-url=http://localhost:8090/optout
 recaptcha-secret=abc
-host-cookie.domain=cookie-domain
 host-cookie.opt-out-url=http://optout/url
 host-cookie.opt-in-url=http://optin/url
+host-cookie.family=rubicon
+host-cookie.cookie-name=host-cookie-name
+host-cookie.domain=cookie-domain
 metrics.accounts.default-verbosity=none
 settings.filesystem.settings-filename=src/test/resources/org/prebid/server/ApplicationTest/test-app-settings.yml
 settings.filesystem.stored-requests-dir=src/test/resources/org/prebid/server/ApplicationTest/storedrequests


### PR DESCRIPTION
This PR continues the idea of https://github.com/rubicon-project/prebid-server-java/pull/248
It changes `/cookie_sync` behavior for two cases:

- `host-cookie` specified, `uids.HOST-BIDDER` exists, `host-cookie` value **is NOT equal** to  `uids.HOST-BIDDER`: use `host-cookie` value for `uids.HOST-BIDDER`
- `host-cookie` specified, no `uids.HOST-BIDDER`: use `host-cookie` value for `uids.HOST-BIDDER`

In both of cases we have broken `uids.HOST-BIDDER`, but valid `host-cookie` value. So, we should update `uids.HOST-BIDDER` value.
In regular situation we just put pre-configured `usersync-url` in `/cookie_sync` response. But for `HOST-BIDDER` it is not necessary to call `usersync-url`for obtaining new UID because we already have it in `host-cookie`.
So, all we need is to use direct `/setuid?bidder=${HOST-BIDDER}&gdpr=${GDPR}&gdpr_consent=${GDPR-CONSENT}&uid=${host-cookie}` url as `usersync-url` in `/cookie_sync` response to set http cookie to user.
