### PR TITLE
Fix NPE occurring in AppNexus bidder

### DIFF
--- a/src/main/java/org/prebid/server/bidder/appnexus/AppnexusBidder.java
+++ b/src/main/java/org/prebid/server/bidder/appnexus/AppnexusBidder.java
@@ -114,8 +114,8 @@ public class AppnexusBidder implements Bidder<BidRequest> {
     private static String makeDefaultDisplayManagerVer(BidRequest bidRequest, List<BidderError> errors) {
         if (bidRequest.getApp() != null) {
             try {
-                final ExtAppPrebid prebid = Json.mapper.convertValue(bidRequest.getApp().getExt(),
-                        ExtApp.class).getPrebid();
+                final ExtApp extApp = Json.mapper.convertValue(bidRequest.getApp().getExt(), ExtApp.class);
+                final ExtAppPrebid prebid = extApp != null ? extApp.getPrebid() : null;
                 if (prebid != null) {
                     final String source = prebid.getSource();
                     final String version = prebid.getVersion();

--- a/src/test/java/org/prebid/server/bidder/appnexus/AppnexusBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/appnexus/AppnexusBidderTest.java
@@ -189,6 +189,75 @@ public class AppnexusBidderTest extends VertxTest {
     }
 
     @Test
+    public void makeHttpRequestsShouldNotModifyImpDisplaymanagerverIfExtAppPrebidIsNull() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                bidRequestBuilder -> bidRequestBuilder
+                        .app(App.builder()
+                                .ext(mapper.valueToTree(ExtApp.of(null)))
+                                .build()),
+                builder -> builder.banner(Banner.builder().build()),
+                builder -> builder.placementId(20));
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = appnexusBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp)
+                .extracting(Imp::getDisplaymanagerver)
+                .hasSize(1).containsNull();
+    }
+
+    @Test
+    public void makeHttpRequestsShouldNotModifyImpDisplaymanagerverIfExtAppPrebidSourceIsNull() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                bidRequestBuilder -> bidRequestBuilder
+                        .app(App.builder()
+                                .ext(mapper.valueToTree(ExtApp.of(ExtAppPrebid.of(null, "version"))))
+                                .build()),
+                builder -> builder.banner(Banner.builder().build()),
+                builder -> builder.placementId(20));
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = appnexusBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp)
+                .extracting(Imp::getDisplaymanagerver)
+                .hasSize(1).containsNull();
+    }
+
+    @Test
+    public void makeHttpRequestsShouldNotModifyImpDisplaymanagerverIfExtAppPrebidVersionIsNull() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                bidRequestBuilder -> bidRequestBuilder
+                        .app(App.builder()
+                                .ext(mapper.valueToTree(ExtApp.of(ExtAppPrebid.of("source", null))))
+                                .build()),
+                builder -> builder.banner(Banner.builder().build()),
+                builder -> builder.placementId(20));
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = appnexusBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp)
+                .extracting(Imp::getDisplaymanagerver)
+                .hasSize(1).containsNull();
+    }
+
+    @Test
     public void makeHttpRequestsShouldNotModifyImpDisplaymanagerverIfItExists() {
         // given
         final BidRequest bidRequest = givenBidRequest(


### PR DESCRIPTION
- Fixed NPE occurring in AppNexus bidder when app.ext is missing;
- Added tests to cover all cases and ensure the right flow.