### PR TITLE
Make MaxMind DB file path being set from configuration

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -259,8 +259,11 @@ public class ServiceConfiguration {
         /**
          * Default geolocation service implementation.
          */
+        @Value("${gdpr.geolocation.maxmind.db-archive-path}")
+        String maxMindDatabaseArchive;
+
         private GeoLocationService createGeoLocationService() {
-            return MaxMindGeoLocationService.create("/maxmind_db.tar.gz", "GeoLite2-Country.mmdb");
+            return MaxMindGeoLocationService.create(maxMindDatabaseArchive, "GeoLite2-Country.mmdb");
         }
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,3 +63,5 @@ gdpr:
     http-default-timeout-ms: 2000
   geolocation:
     enabled: true
+    maxmind:
+      db-archive-path: /maxmind_db.tar.gz

--- a/src/test/resources/org/prebid/server/ApplicationTest/test-application.properties
+++ b/src/test/resources/org/prebid/server/ApplicationTest/test-application.properties
@@ -130,3 +130,4 @@ status-response=ok
 analytics.log.enabled=true
 gdpr.host-vendor-id=1
 gdpr.vendorlist.filesystem-cache-dir=src/test/resources/org/prebid/server/ApplicationTest/gdpr-vendorlist
+gdpr.geolocation.maxmind.db-archive-path=/org/prebid/server/geolocation/GeoLite2-test.tar.gz


### PR DESCRIPTION
Moved MaxMind DB file path to configuration property to avoid errors in tests when file is not being downloaded (use existing test DB file instead).