### PR TITLE
Fix NPE in GdprService when Vendor ID is not in Consent

### DIFF
--- a/src/main/java/org/prebid/server/gdpr/GdprService.java
+++ b/src/main/java/org/prebid/server/gdpr/GdprService.java
@@ -2,6 +2,7 @@ package org.prebid.server.gdpr;
 
 import com.iab.gdpr.consent.VendorConsent;
 import com.iab.gdpr.consent.VendorConsentDecoder;
+import com.iab.gdpr.exception.VendorConsentParseException;
 import io.vertx.core.Future;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -145,7 +146,7 @@ public class GdprService {
     private static Set<Integer> getAllowedPurposeIdsFromConsent(VendorConsent vendorConsent) {
         try {
             return vendorConsent.getAllowedPurposeIds();
-        } catch (ArrayIndexOutOfBoundsException ex) {
+        } catch (ArrayIndexOutOfBoundsException e) {
             throw new InvalidRequestException(
                     "Error when retrieving allowed purpose ids in a reason of invalid consent string");
         }
@@ -169,7 +170,7 @@ public class GdprService {
         final Map<Integer, Boolean> result = new HashMap<>(vendorIds.size());
         for (Integer vendorId : vendorIds) {
             // confirm consent is allowed the vendor
-            final boolean vendorIsAllowed = vendorId != null && isVendorAllowed(vendorConsent, vendorId);
+            final boolean vendorIsAllowed = isVendorAllowed(vendorConsent, vendorIdToPurposes, vendorId);
 
             // confirm purposes
             final boolean purposesAreMatched = vendorIsAllowed
@@ -183,12 +184,17 @@ public class GdprService {
 
     /**
      * Checks if vendorId is in list of allowed vendors in consent string. Throws {@link InvalidRequestException}
-     * in case of gdpr sdk throws {@link ArrayIndexOutOfBoundsException} when consent string is not valid.
+     * in case of gdpr sdk throws exception when consent string is not valid.
      */
-    private static boolean isVendorAllowed(VendorConsent vendorConsent, Integer vendorId) {
+    private static boolean isVendorAllowed(VendorConsent vendorConsent, Map<Integer, Set<Integer>> vendorIdToPurposes,
+                                           Integer vendorId) {
+        if (vendorId == null || !vendorIdToPurposes.containsKey(vendorId)) {
+            return false;
+        }
+
         try {
             return vendorConsent.isVendorAllowed(vendorId);
-        } catch (ArrayIndexOutOfBoundsException ex) {
+        } catch (ArrayIndexOutOfBoundsException | VendorConsentParseException e) {
             throw new InvalidRequestException(
                     "Error when checking if vendor is allowed in a reason of invalid consent string");
         }

--- a/src/main/java/org/prebid/server/vertx/http/BasicHttpClient.java
+++ b/src/main/java/org/prebid/server/vertx/http/BasicHttpClient.java
@@ -80,7 +80,7 @@ public class BasicHttpClient implements HttpClient {
                                  Future<HttpClientResponse> future, long timerId) {
         vertx.cancelTimer(timerId);
 
-        future.complete(HttpClientResponse.of(response.statusCode(), response.headers(), body));
+        future.tryComplete(HttpClientResponse.of(response.statusCode(), response.headers(), body));
     }
 
     private void failResponse(Throwable exception, Future<HttpClientResponse> future, long timerId) {

--- a/src/test/java/org/prebid/server/gdpr/GdprServiceTest.java
+++ b/src/test/java/org/prebid/server/gdpr/GdprServiceTest.java
@@ -152,6 +152,18 @@ public class GdprServiceTest {
     }
 
     @Test
+    public void shouldReturnRestrictedResultIfVendorIdIsAbsentInVendorConsent() {
+        // when
+        final Future<?> future =
+                gdprService.resultByVendor(emptySet(), singleton(20), "1", "BOb3F3yOb3F3yABABBENABoAAAABQAAAgA", null,
+                        null);
+
+        // then
+        assertThat(future.succeeded()).isTrue();
+        assertThat(future.result()).isEqualTo(GdprResponse.of(true, singletonMap(20, false), null));
+    }
+
+    @Test
     public void shouldReturnAllowedResultIfGdprParamIsOneAndConsentParamIsValid() {
         // when
         final Future<?> future =


### PR DESCRIPTION
CL:
- Added additional checking of VendorID in Consent String.
- Safe BasicHttpClient with `tryComplete` call on success.