### PR TITLE
Fix duplicate key error while analytics HttpContext creating

### DIFF
--- a/src/main/java/org/prebid/server/analytics/model/HttpContext.java
+++ b/src/main/java/org/prebid/server/analytics/model/HttpContext.java
@@ -35,15 +35,16 @@ public class HttpContext {
     }
 
     private static Map<String, String> queryParams(RoutingContext context) {
-        final MultiMap params = context.request().params();
-        return params.names().stream()
-                .collect(Collectors.toMap(Function.identity(), params::get));
+        return toMap(context.request().params());
     }
 
     private static Map<String, String> headers(RoutingContext context) {
-        final MultiMap headers = context.request().headers();
-        return headers.names().stream()
-                .collect(Collectors.toMap(Function.identity(), headers::get));
+        return toMap(context.request().headers());
+    }
+
+    private static Map<String, String> toMap(MultiMap multiMap) {
+        return multiMap.names().stream()
+                .collect(Collectors.toMap(Function.identity(), multiMap::get));
     }
 
     private static Map<String, String> cookies(RoutingContext context) {

--- a/src/main/java/org/prebid/server/analytics/model/HttpContext.java
+++ b/src/main/java/org/prebid/server/analytics/model/HttpContext.java
@@ -1,11 +1,13 @@
 package org.prebid.server.analytics.model;
 
+import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
 import lombok.Builder;
 import lombok.Value;
 import org.prebid.server.util.HttpUtil;
 
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -33,13 +35,15 @@ public class HttpContext {
     }
 
     private static Map<String, String> queryParams(RoutingContext context) {
-        return context.request().params().entries().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        final MultiMap params = context.request().params();
+        return params.names().stream()
+                .collect(Collectors.toMap(Function.identity(), params::get));
     }
 
     private static Map<String, String> headers(RoutingContext context) {
-        return context.request().headers().entries().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        final MultiMap headers = context.request().headers();
+        return headers.names().stream()
+                .collect(Collectors.toMap(Function.identity(), headers::get));
     }
 
     private static Map<String, String> cookies(RoutingContext context) {


### PR DESCRIPTION
Fixes:
```
java.lang.IllegalStateException: Duplicate key
        at java.util.stream.Collectors.lambda$throwingMerger$154(Unknown Source)
        at java.util.HashMap.merge(Unknown Source)
        at java.util.stream.Collectors.lambda$toMap$212(Unknown Source)
        at java.util.stream.ReduceOps$3ReducingSink.accept(Unknown Source)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
        at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)
        at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
        at java.util.stream.ReferencePipeline.collect(Unknown Source)
        at org.prebid.server.analytics.model.HttpContext.headers(HttpContext.java:42)
        at org.prebid.server.analytics.model.HttpContext.from(HttpContext.java:30)
        at org.prebid.server.handler.openrtb2.AuctionHandler.handle(AuctionHandler.java:77)
        at org.prebid.server.handler.openrtb2.AuctionHandler.handle(AuctionHandler.java:39)
        at io.vertx.ext.web.impl.RouteImpl.handleContext(RouteImpl.java:227)
```