### PR TITLE
Fix applying of timeout adjustment

### DIFF
--- a/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
@@ -50,12 +50,10 @@ public class AmpRequestFactory {
     private final StoredRequestProcessor storedRequestProcessor;
     private final AuctionRequestFactory auctionRequestFactory;
 
-    public AmpRequestFactory(long defaultTimeout, long maxTimeout, long timeoutAdjustment,
-                             StoredRequestProcessor storedRequestProcessor,
+    public AmpRequestFactory(TimeoutResolver timeoutResolver, StoredRequestProcessor storedRequestProcessor,
                              AuctionRequestFactory auctionRequestFactory) {
 
-        timeoutResolver = new TimeoutResolver(defaultTimeout, maxTimeout, timeoutAdjustment);
-
+        this.timeoutResolver = Objects.requireNonNull(timeoutResolver);
         this.storedRequestProcessor = Objects.requireNonNull(storedRequestProcessor);
         this.auctionRequestFactory = Objects.requireNonNull(auctionRequestFactory);
     }

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -62,13 +62,12 @@ public class AuctionRequestFactory {
     private final InterstitialProcessor interstitialProcessor;
 
     public AuctionRequestFactory(
-            long defaultTimeout, long maxTimeout, long timeoutAdjustment, long maxRequestSize, String adServerCurrency,
+            TimeoutResolver timeoutResolver, long maxRequestSize, String adServerCurrency,
             StoredRequestProcessor storedRequestProcessor, ImplicitParametersExtractor paramsExtractor,
             UidsCookieService uidsCookieService, BidderCatalog bidderCatalog, RequestValidator requestValidator,
             InterstitialProcessor interstitialProcessor) {
 
-        timeoutResolver = new TimeoutResolver(defaultTimeout, maxTimeout, timeoutAdjustment);
-
+        this.timeoutResolver = Objects.requireNonNull(timeoutResolver);
         this.maxRequestSize = maxRequestSize;
         this.adServerCurrency = validateCurrency(adServerCurrency);
         this.storedRequestProcessor = Objects.requireNonNull(storedRequestProcessor);

--- a/src/main/java/org/prebid/server/auction/PreBidRequestContextFactory.java
+++ b/src/main/java/org/prebid/server/auction/PreBidRequestContextFactory.java
@@ -44,7 +44,6 @@ public class PreBidRequestContextFactory {
     private static final Logger logger = LoggerFactory.getLogger(PreBidRequestContextFactory.class);
 
     private final TimeoutResolver timeoutResolver;
-    private final long defaultTimeout;
     private final ImplicitParametersExtractor paramsExtractor;
     private final ApplicationSettings applicationSettings;
     private final UidsCookieService uidsCookieService;
@@ -52,14 +51,11 @@ public class PreBidRequestContextFactory {
 
     private final Random rand = new Random();
 
-    public PreBidRequestContextFactory(long defaultTimeout, long maxTimeout,
-                                       long timeoutAdjustment, ImplicitParametersExtractor paramsExtractor,
+    public PreBidRequestContextFactory(TimeoutResolver timeoutResolver, ImplicitParametersExtractor paramsExtractor,
                                        ApplicationSettings applicationSettings, UidsCookieService uidsCookieService,
                                        TimeoutFactory timeoutFactory) {
 
-        timeoutResolver = new TimeoutResolver(defaultTimeout, maxTimeout, timeoutAdjustment);
-
-        this.defaultTimeout = defaultTimeout;
+        this.timeoutResolver = Objects.requireNonNull(timeoutResolver);
         this.paramsExtractor = Objects.requireNonNull(paramsExtractor);
         this.applicationSettings = Objects.requireNonNull(applicationSettings);
         this.uidsCookieService = Objects.requireNonNull(uidsCookieService);
@@ -207,7 +203,7 @@ public class PreBidRequestContextFactory {
     private PreBidRequest adjustRequestTimeout(PreBidRequest preBidRequest) {
         final Long requestTimeout = preBidRequest.getTimeoutMillis();
         final long resolvedTimeout = timeoutResolver.resolve(requestTimeout);
-        final long timeout = resolvedTimeout > 0 ? resolvedTimeout : defaultTimeout; // check negative value
+        final long timeout = timeoutResolver.adjustTimeout(resolvedTimeout);
 
         // check, do we really need to update request?
         return !Objects.equals(requestTimeout, timeout)

--- a/src/main/java/org/prebid/server/auction/TimeoutResolver.java
+++ b/src/main/java/org/prebid/server/auction/TimeoutResolver.java
@@ -3,13 +3,13 @@ package org.prebid.server.auction;
 /**
  * Component for processing timeout related functionality.
  */
-class TimeoutResolver {
+public class TimeoutResolver {
 
     private final long defaultTimeout;
     private final long maxTimeout;
     private final long timeoutAdjustment;
 
-    TimeoutResolver(long defaultTimeout, long maxTimeout, long timeoutAdjustment) {
+    public TimeoutResolver(long defaultTimeout, long maxTimeout, long timeoutAdjustment) {
         if (maxTimeout < defaultTimeout) {
             throw new IllegalArgumentException(
                     String.format("Max timeout cannot be less than default timeout: max=%d, default=%d", maxTimeout,
@@ -22,7 +22,7 @@ class TimeoutResolver {
     }
 
     /**
-     * Resolves timeout according to given in request and pre-configured values (default, max, adjustment).
+     * Resolves timeout according to given in request and pre-configured default and max values.
      */
     long resolve(Long requestTimeout) {
         final long result;
@@ -31,10 +31,23 @@ class TimeoutResolver {
             result = defaultTimeout;
         } else if (requestTimeout > maxTimeout) {
             result = maxTimeout;
-        } else if (timeoutAdjustment > 0) {
-            result = requestTimeout - timeoutAdjustment; // negative value should be checked by caller
         } else {
             result = requestTimeout;
+        }
+
+        return result;
+    }
+
+    /**
+     * Determines timeout according to given in request and pre-configured adjustment value.
+     */
+    public long adjustTimeout(long requestTimeout) {
+        final long result;
+
+        if (requestTimeout == defaultTimeout || requestTimeout == maxTimeout) {
+            result = requestTimeout;
+        } else {
+            result = requestTimeout > timeoutAdjustment ? requestTimeout - timeoutAdjustment : requestTimeout;
         }
 
         return result;

--- a/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
@@ -15,6 +15,7 @@ import org.prebid.server.analytics.model.AuctionEvent;
 import org.prebid.server.analytics.model.HttpContext;
 import org.prebid.server.auction.AuctionRequestFactory;
 import org.prebid.server.auction.ExchangeService;
+import org.prebid.server.auction.TimeoutResolver;
 import org.prebid.server.auction.model.Tuple2;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.cookie.UidsCookieService;
@@ -44,10 +45,11 @@ public class AuctionHandler implements Handler<RoutingContext> {
     private final Metrics metrics;
     private final Clock clock;
     private final TimeoutFactory timeoutFactory;
+    private final TimeoutResolver timeoutResolver;
 
     public AuctionHandler(ExchangeService exchangeService, AuctionRequestFactory auctionRequestFactory,
                           UidsCookieService uidsCookieService, AnalyticsReporter analyticsReporter, Metrics metrics,
-                          Clock clock, TimeoutFactory timeoutFactory) {
+                          Clock clock, TimeoutFactory timeoutFactory, TimeoutResolver timeoutResolver) {
         this.exchangeService = Objects.requireNonNull(exchangeService);
         this.auctionRequestFactory = Objects.requireNonNull(auctionRequestFactory);
         this.uidsCookieService = Objects.requireNonNull(uidsCookieService);
@@ -55,6 +57,7 @@ public class AuctionHandler implements Handler<RoutingContext> {
         this.metrics = Objects.requireNonNull(metrics);
         this.clock = Objects.requireNonNull(clock);
         this.timeoutFactory = Objects.requireNonNull(timeoutFactory);
+        this.timeoutResolver = Objects.requireNonNull(timeoutResolver);
     }
 
     @Override
@@ -103,7 +106,8 @@ public class AuctionHandler implements Handler<RoutingContext> {
     }
 
     private Timeout timeout(BidRequest bidRequest, long startTime) {
-        return timeoutFactory.create(startTime, bidRequest.getTmax());
+        final long timeout = timeoutResolver.adjustTimeout(bidRequest.getTmax());
+        return timeoutFactory.create(startTime, timeout);
     }
 
     private void handleResult(AsyncResult<Tuple2<BidResponse, MetricsContext>> responseResult,

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -20,6 +20,7 @@ import org.prebid.server.auction.AmpResponsePostProcessor;
 import org.prebid.server.auction.AuctionRequestFactory;
 import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.auction.PreBidRequestContextFactory;
+import org.prebid.server.auction.TimeoutResolver;
 import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.bidder.HttpAdapterConnector;
 import org.prebid.server.cache.CacheService;
@@ -224,10 +225,11 @@ public class WebConfiguration {
             CompositeAnalyticsReporter analyticsReporter,
             Metrics metrics,
             Clock clock,
-            TimeoutFactory timeoutFactory) {
+            TimeoutFactory timeoutFactory,
+            TimeoutResolver auctionTimeoutResolver) {
 
         return new org.prebid.server.handler.openrtb2.AuctionHandler(exchangeService, auctionRequestFactory,
-                uidsCookieService, analyticsReporter, metrics, clock, timeoutFactory);
+                uidsCookieService, analyticsReporter, metrics, clock, timeoutFactory, auctionTimeoutResolver);
     }
 
     @Bean
@@ -241,11 +243,12 @@ public class WebConfiguration {
             AmpResponsePostProcessor ampResponsePostProcessor,
             Metrics metrics,
             Clock clock,
-            TimeoutFactory timeoutFactory) {
+            TimeoutFactory timeoutFactory,
+            TimeoutResolver ampTimeoutResolver) {
 
         return new AmpHandler(ampRequestFactory, exchangeService, uidsCookieService,
                 ampProperties.getCustomTargetingSet(), bidderCatalog, analyticsReporter, ampResponsePostProcessor,
-                metrics, clock, timeoutFactory);
+                metrics, clock, timeoutFactory, ampTimeoutResolver);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/auction/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AmpRequestFactoryTest.java
@@ -55,6 +55,8 @@ public class AmpRequestFactoryTest extends VertxTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
+    private TimeoutResolver timeoutResolver;
+    @Mock
     private StoredRequestProcessor storedRequestProcessor;
     @Mock
     private AuctionRequestFactory auctionRequestFactory;
@@ -68,9 +70,12 @@ public class AmpRequestFactoryTest extends VertxTest {
 
     @Before
     public void setUp() {
+        given(timeoutResolver.resolve(any())).willReturn(2000L);
+
         given(httpRequest.getParam(eq("tag_id"))).willReturn("tagId");
         given(routingContext.request()).willReturn(httpRequest);
-        factory = new AmpRequestFactory(2000L, 5000L, 0L, storedRequestProcessor, auctionRequestFactory);
+
+        factory = new AmpRequestFactory(timeoutResolver, storedRequestProcessor, auctionRequestFactory);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/auction/TimeoutResolverTest.java
+++ b/src/test/java/org/prebid/server/auction/TimeoutResolverTest.java
@@ -8,39 +8,49 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 public class TimeoutResolverTest {
 
+    private static final long DEFAULT_TIMEOUT = 100L;
+    private static final long MAX_TIMEOUT = 200L;
+
     private TimeoutResolver timeoutResolver;
 
     @Before
     public void setUp() {
-        timeoutResolver = new TimeoutResolver(100L, 200L, 10L);
+        timeoutResolver = new TimeoutResolver(DEFAULT_TIMEOUT, MAX_TIMEOUT, 10L);
     }
 
     @Test
     public void creationShouldFailIfMaxTimeoutLessThanDefault() {
-        assertThatIllegalArgumentException().isThrownBy(() ->
-                new TimeoutResolver(2L, 1L, 0L))
+        assertThatIllegalArgumentException().isThrownBy(() -> new TimeoutResolver(2L, 1L, 0L))
                 .withMessage("Max timeout cannot be less than default timeout: max=1, default=2");
     }
 
     @Test
-    public void shouldReturnExpectedTimeout() {
-        assertThat(timeoutResolver.resolve(42L)).isEqualTo(32L);
+    public void resolveShouldReturnExpectedTimeout() {
+        assertThat(timeoutResolver.resolve(42L)).isEqualTo(42L);
     }
 
     @Test
-    public void shouldReturnDefaultTimeout() {
-        assertThat(timeoutResolver.resolve(null)).isEqualTo(100L);
+    public void resolveShouldReturnDefaultTimeout() {
+        assertThat(timeoutResolver.resolve(null)).isEqualTo(DEFAULT_TIMEOUT);
     }
 
     @Test
-    public void shouldReturnMaxTimeout() {
-        assertThat(timeoutResolver.resolve(300L)).isEqualTo(200L);
+    public void resolveShouldReturnMaxTimeout() {
+        assertThat(timeoutResolver.resolve(300L)).isEqualTo(MAX_TIMEOUT);
     }
 
     @Test
-    public void shouldReturnNegativeTimeout() {
-        // Timeout resolver should not care of determined value,
-        // this must be covered by caller/validator.
-        assertThat(timeoutResolver.resolve(2L)).isEqualTo(-8L);
+    public void adjustTimeoutShouldReturnExpectedTimeout() {
+        assertThat(timeoutResolver.adjustTimeout(42L)).isEqualTo(32L);
+    }
+
+    @Test
+    public void adjustTimeoutShouldReturnDefaultTimeout() {
+        assertThat(timeoutResolver.adjustTimeout(DEFAULT_TIMEOUT)).isEqualTo(DEFAULT_TIMEOUT);
+    }
+
+    @Test
+    public void adjustTimeoutShouldReturnMaxTimeout() {
+        assertThat(timeoutResolver.adjustTimeout(MAX_TIMEOUT)).isEqualTo(MAX_TIMEOUT);
     }
 }


### PR DESCRIPTION
All timeout processing functionality delegated to `TimeoutResolver`:
- `long resolve(Long requestTimeout)` - Resolves timeout according to given in request and pre-configured default and max values.
- `long adjustTimeout(long requestTimeout)` - Determines timeout according to given in request and pre-configured adjustment value.