### PR TITLE
Allow Conversant bidder to support app request

### DIFF
--- a/src/main/java/org/prebid/server/bidder/conversant/ConversantAdapter.java
+++ b/src/main/java/org/prebid/server/bidder/conversant/ConversantAdapter.java
@@ -75,15 +75,12 @@ public class ConversantAdapter extends OpenrtbAdapter {
 
         validateAdUnitBidsMediaTypes(adUnitBids, ALLOWED_MEDIA_TYPES);
 
-        final List<AdUnitBidWithParams<ConversantParams>> adUnitBidsWithParams = createAdUnitBidsWithParams(adUnitBids);
-        final List<Imp> imps = makeImps(adUnitBidsWithParams, preBidRequestContext);
-        validateImps(imps);
-
         final PreBidRequest preBidRequest = preBidRequestContext.getPreBidRequest();
         final App app = preBidRequest.getApp();
-        if (app != null && StringUtils.isBlank(app.getId())) {
-            throw new PreBidException("Missing app id");
-        }
+        final List<AdUnitBidWithParams<ConversantParams>> adUnitBidsWithParams = createAdUnitBidsWithParams(adUnitBids,
+                app);
+        final List<Imp> imps = makeImps(adUnitBidsWithParams, preBidRequestContext);
+        validateImps(imps);
 
         return BidRequest.builder()
                 .id(preBidRequest.getTid())
@@ -99,13 +96,19 @@ public class ConversantAdapter extends OpenrtbAdapter {
                 .build();
     }
 
-    private static List<AdUnitBidWithParams<ConversantParams>> createAdUnitBidsWithParams(List<AdUnitBid> adUnitBids) {
+    private static List<AdUnitBidWithParams<ConversantParams>> createAdUnitBidsWithParams(List<AdUnitBid> adUnitBids,
+                                                                                          App app) {
         return adUnitBids.stream()
-                .map(adUnitBid -> AdUnitBidWithParams.of(adUnitBid, parseAndValidateParams(adUnitBid)))
+                .map(adUnitBid -> AdUnitBidWithParams.of(adUnitBid, parseAndValidateParams(adUnitBid, app)))
                 .collect(Collectors.toList());
     }
 
-    private static ConversantParams parseAndValidateParams(AdUnitBid adUnitBid) {
+    private static ConversantParams parseAndValidateParams(AdUnitBid adUnitBid, App app) {
+        final boolean isAppRequest = app != null;
+        if (isAppRequest && StringUtils.isBlank(app.getId())) {
+            throw new PreBidException("Missing app id");
+        }
+
         final ObjectNode paramsNode = adUnitBid.getParams();
         if (paramsNode == null) {
             throw new PreBidException("Conversant params section is missing");
@@ -119,7 +122,7 @@ public class ConversantAdapter extends OpenrtbAdapter {
             throw new PreBidException(e.getMessage(), e.getCause());
         }
 
-        if (StringUtils.isEmpty(params.getSiteId())) {
+        if (!isAppRequest && StringUtils.isEmpty(params.getSiteId())) {
             throw new PreBidException("Missing site id");
         }
 

--- a/src/main/java/org/prebid/server/bidder/conversant/ConversantAdapter.java
+++ b/src/main/java/org/prebid/server/bidder/conversant/ConversantAdapter.java
@@ -1,6 +1,7 @@
 package org.prebid.server.bidder.conversant;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
@@ -78,19 +79,19 @@ public class ConversantAdapter extends OpenrtbAdapter {
         final List<Imp> imps = makeImps(adUnitBidsWithParams, preBidRequestContext);
         validateImps(imps);
 
-        final Site site = makeSite(preBidRequestContext, adUnitBidsWithParams);
-        if (site == null) {
-            throw new PreBidException("Conversant doesn't support App requests");
+        final PreBidRequest preBidRequest = preBidRequestContext.getPreBidRequest();
+        final App app = preBidRequest.getApp();
+        if (app != null && StringUtils.isBlank(app.getId())) {
+            throw new PreBidException("Missing app id");
         }
 
-        final PreBidRequest preBidRequest = preBidRequestContext.getPreBidRequest();
         return BidRequest.builder()
                 .id(preBidRequest.getTid())
                 .at(1)
                 .tmax(preBidRequest.getTimeoutMillis())
                 .imp(imps)
-                .app(preBidRequest.getApp())
-                .site(site)
+                .app(app)
+                .site(makeSite(preBidRequestContext, adUnitBidsWithParams))
                 .device(deviceBuilder(preBidRequestContext).build())
                 .user(makeUser(preBidRequestContext))
                 .source(makeSource(preBidRequestContext))

--- a/src/main/java/org/prebid/server/bidder/conversant/ConversantBidder.java
+++ b/src/main/java/org/prebid/server/bidder/conversant/ConversantBidder.java
@@ -1,26 +1,52 @@
 package org.prebid.server.bidder.conversant;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Site;
 import com.iab.openrtb.request.Video;
+import com.iab.openrtb.response.BidResponse;
+import com.iab.openrtb.response.SeatBid;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.prebid.server.bidder.OpenrtbBidder;
-import org.prebid.server.bidder.model.ImpWithExt;
+import org.prebid.server.bidder.Bidder;
+import org.prebid.server.bidder.BidderUtil;
+import org.prebid.server.bidder.model.BidderBid;
+import org.prebid.server.bidder.model.BidderError;
+import org.prebid.server.bidder.model.HttpCall;
+import org.prebid.server.bidder.model.HttpRequest;
+import org.prebid.server.bidder.model.Result;
 import org.prebid.server.exception.PreBidException;
+import org.prebid.server.proto.openrtb.ext.ExtPrebid;
 import org.prebid.server.proto.openrtb.ext.request.conversant.ExtImpConversant;
 import org.prebid.server.proto.openrtb.ext.response.BidType;
+import org.prebid.server.util.HttpUtil;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class ConversantBidder extends OpenrtbBidder<ExtImpConversant> {
+/**
+ * Conversant {@link Bidder} implementation.
+ */
+public class ConversantBidder implements Bidder<BidRequest> {
+
+    private static final TypeReference<ExtPrebid<?, ExtImpConversant>> CONVERSANT_EXT_TYPE_REFERENCE = new
+            TypeReference<ExtPrebid<?, ExtImpConversant>>() {
+            };
 
     // List of API frameworks supported by the publisher
     private static final Set<Integer> APIS = IntStream.range(1, 7).boxed().collect(Collectors.toSet());
@@ -31,34 +57,97 @@ public class ConversantBidder extends OpenrtbBidder<ExtImpConversant> {
     // Position of the ad as a relative measure of visibility or prominence
     private static final Set<Integer> AD_POSITIONS = IntStream.range(0, 8).boxed().collect(Collectors.toSet());
 
+    private static final String DEFAULT_BID_CURRENCY = "USD";
     private static final String DISPLAY_MANAGER = "prebid-s2s";
     private static final String DISPLAY_MANAGER_VER = "1.0.1";
 
+    private final String endpointUrl;
+
     public ConversantBidder(String endpointUrl) {
-        super(endpointUrl, RequestCreationStrategy.SINGLE_REQUEST, ExtImpConversant.class);
+        this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
     }
 
     @Override
-    protected void validateRequest(BidRequest bidRequest) throws PreBidException {
-        if (bidRequest.getApp() != null) {
-            throw new PreBidException("Conversant doesn't support App requests");
+    public Result<List<HttpRequest<BidRequest>>> makeHttpRequests(BidRequest bidRequest) {
+        final App app = bidRequest.getApp();
+        if (app != null && StringUtils.isBlank(app.getId())) {
+            return Result.emptyWithError(BidderError.badInput("Missing app id"));
         }
+
+        final List<BidderError> errors = new ArrayList<>();
+        final BidRequest outgoingRequest;
+        try {
+            outgoingRequest = createBidRequest(bidRequest, errors);
+        } catch (PreBidException e) {
+            errors.add(BidderError.badInput(e.getMessage()));
+            return Result.of(Collections.emptyList(), errors);
+        }
+
+        final String body = Json.encode(outgoingRequest);
+
+        return Result.of(Collections.singletonList(
+                HttpRequest.<BidRequest>builder()
+                        .method(HttpMethod.POST)
+                        .uri(endpointUrl)
+                        .body(body)
+                        .headers(BidderUtil.headers())
+                        .payload(outgoingRequest)
+                        .build()),
+                errors);
     }
 
-    @Override
-    protected Imp modifyImp(Imp imp, ExtImpConversant impExt) throws PreBidException {
-        // imp validation
+    private static BidRequest createBidRequest(BidRequest bidRequest, List<BidderError> errors) {
+        final List<Imp> modifiedImps = new ArrayList<>();
+        Integer extMobile = null;
+        String extSiteId = null;
+        final boolean hasSite = bidRequest.getSite() != null;
+        for (Imp imp : bidRequest.getImp()) {
+            try {
+                validateImp(imp);
+                final ExtImpConversant impExt = parseAndValidateImpExt(imp, hasSite);
+                modifiedImps.add(modifyImp(imp, impExt));
+                extSiteId = impExt.getSiteId();
+                if (impExt.getMobile() != null) {
+                    extMobile = impExt.getMobile();
+                }
+            } catch (PreBidException e) {
+                errors.add(BidderError.badInput(e.getMessage()));
+            }
+        }
+        if (modifiedImps.isEmpty()) {
+            throw new PreBidException("No valid impressions");
+        }
+
+        return bidRequest.toBuilder()
+                .imp(modifiedImps)
+                .site(modifySite(bidRequest.getSite(), extSiteId, extMobile))
+                .build();
+    }
+
+    private static void validateImp(Imp imp) {
         if (imp.getBanner() == null && imp.getVideo() == null) {
             throw new PreBidException(String.format("Invalid MediaType. Conversant supports only Banner and Video. "
                     + "Ignoring ImpID=%s", imp.getId()));
         }
+    }
 
-        //imp.ext validation
-        if (StringUtils.isBlank(impExt.getSiteId())) {
+    private static ExtImpConversant parseAndValidateImpExt(Imp imp, boolean hasSite) {
+        final ExtImpConversant extImpConversant;
+        try {
+            extImpConversant = Json.mapper.<ExtPrebid<?, ExtImpConversant>>convertValue(imp.getExt(),
+                    CONVERSANT_EXT_TYPE_REFERENCE).getBidder();
+        } catch (IllegalArgumentException e) {
+            throw new PreBidException(e.getMessage(), e);
+        }
+
+        if (hasSite && StringUtils.isBlank(extImpConversant.getSiteId())) {
             throw new PreBidException("Missing site id");
         }
 
-        // imp transformations
+        return extImpConversant;
+    }
+
+    private static Imp modifyImp(Imp imp, ExtImpConversant impExt) {
         final BigDecimal extBidfloor = impExt.getBidfloor();
         final String extTagId = impExt.getTagId();
         final Integer extSecure = impExt.getSecure();
@@ -118,22 +207,6 @@ public class ConversantBidder extends OpenrtbBidder<ExtImpConversant> {
                 ? protocols.stream().filter(PROTOCOLS::contains).collect(Collectors.toList()) : videoProtocols;
     }
 
-    @Override
-    protected void modifyRequest(BidRequest bidRequest, BidRequest.BidRequestBuilder requestBuilder,
-                                 List<ImpWithExt<ExtImpConversant>> impsWithExts) {
-        final String extSiteId = impsWithExts.stream()
-                .map(ImpWithExt::getImpExt)
-                .map(ExtImpConversant::getSiteId)
-                .reduce((first, second) -> second).orElse(null);
-        final Integer extMobile = impsWithExts.stream()
-                .map(ImpWithExt::getImpExt)
-                .map(ExtImpConversant::getMobile)
-                .filter(Objects::nonNull)
-                .reduce((first, second) -> second).orElse(null);
-
-        requestBuilder.site(modifySite(bidRequest.getSite(), extSiteId, extMobile));
-    }
-
     private static Site modifySite(Site site, String extSiteId, Integer extMobile) {
         final Site.SiteBuilder siteBuilder = site == null ? Site.builder() : site.toBuilder();
         if (extMobile != null) {
@@ -145,12 +218,42 @@ public class ConversantBidder extends OpenrtbBidder<ExtImpConversant> {
     }
 
     @Override
-    protected BidType getBidType(String impId, List<Imp> imps) {
+    public Result<List<BidderBid>> makeBids(HttpCall<BidRequest> httpCall, BidRequest bidRequest) {
+        try {
+            final BidResponse bidResponse = Json.decodeValue(httpCall.getResponse().getBody(), BidResponse.class);
+            return Result.of(extractBids(httpCall.getRequest().getPayload(), bidResponse), Collections.emptyList());
+        } catch (DecodeException | PreBidException e) {
+            return Result.emptyWithError(BidderError.badServerResponse(e.getMessage()));
+        }
+    }
+
+    private static List<BidderBid> extractBids(BidRequest bidRequest, BidResponse bidResponse) {
+        return bidResponse == null || bidResponse.getSeatbid() == null
+                ? Collections.emptyList()
+                : bidsFromResponse(bidRequest, bidResponse);
+    }
+
+    private static List<BidderBid> bidsFromResponse(BidRequest bidRequest, BidResponse bidResponse) {
+        return bidResponse.getSeatbid().stream()
+                .filter(Objects::nonNull)
+                .map(SeatBid::getBid)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .map(bid -> BidderBid.of(bid, getType(bid.getImpid(), bidRequest.getImp()), DEFAULT_BID_CURRENCY))
+                .collect(Collectors.toList());
+    }
+
+    private static BidType getType(String impId, List<Imp> imps) {
         for (Imp imp : imps) {
             if (imp.getId().equals(impId) && imp.getVideo() != null) {
                 return BidType.video;
             }
         }
         return BidType.banner;
+    }
+
+    @Override
+    public Map<String, String> extractTargeting(ObjectNode ext) {
+        return Collections.emptyMap();
     }
 }

--- a/src/main/resources/bidder-config/conversant.yaml
+++ b/src/main/resources/bidder-config/conversant.yaml
@@ -8,6 +8,8 @@ adapters:
     meta-info:
       maintainer-email: mediapsr@conversantmedia.com
       app-media-types:
+        - banner
+        - video
       site-media-types:
         - banner
         - video

--- a/src/main/resources/static/bidder-params/conversant.json
+++ b/src/main/resources/static/bidder-params/conversant.json
@@ -55,6 +55,5 @@
     }
   },
   "required": [
-    "site_id"
   ]
 }

--- a/src/test/java/org/prebid/server/bidder/conversant/ConversantAdapterTest.java
+++ b/src/test/java/org/prebid/server/bidder/conversant/ConversantAdapterTest.java
@@ -370,7 +370,7 @@ public class ConversantAdapterTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldThrowPrebidExceptionIfAppIsPresentOnRequest() {
+    public void makeHttpRequestsShouldThrowPrebidExceptionIfAppHasBlankOrMissingId() {
         // given
         preBidRequestContext = givenPreBidRequestContext(identity(), builder -> builder
                 .app(App.builder().build()));
@@ -378,7 +378,7 @@ public class ConversantAdapterTest extends VertxTest {
         // when and then
         assertThatThrownBy(() -> adapter.makeHttpRequests(adapterRequest, preBidRequestContext))
                 .isExactlyInstanceOf(PreBidException.class)
-                .hasMessage("Conversant doesn't support App requests");
+                .hasMessage("Missing app id");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/conversant/ConversantBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/conversant/ConversantBidderTest.java
@@ -53,7 +53,7 @@ public class ConversantBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldReturnErrorIfRequestHasApp() {
+    public void makeHttpRequestsShouldReturnErrorIfRequestAppHasBlankOrMissingId() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .app(App.builder().build())
@@ -63,8 +63,7 @@ public class ConversantBidderTest extends VertxTest {
         final Result<List<HttpRequest<BidRequest>>> result = conversantBidder.makeHttpRequests(bidRequest);
 
         // then
-        assertThat(result.getErrors()).hasSize(1)
-                .containsOnly(BidderError.badInput("Conversant doesn't support App requests"));
+        assertThat(result.getErrors()).hasSize(1).containsOnly(BidderError.badInput("Missing app id"));
         assertThat(result.getValue()).isEmpty();
     }
 
@@ -97,15 +96,16 @@ public class ConversantBidderTest extends VertxTest {
         final Result<List<HttpRequest<BidRequest>>> result = conversantBidder.makeHttpRequests(bidRequest);
 
         // then
-        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors()).hasSize(2);
         assertThat(result.getErrors().get(0).getMessage()).startsWith("Cannot deserialize instance");
         assertThat(result.getValue()).isEmpty();
     }
 
     @Test
-    public void makeHttpRequestsShouldReturnErrorIfImpExtSiteIdIsNullOrEmpty() {
+    public void makeHttpRequestsShouldReturnErrorIfRequestHasSiteAndImpExtSiteIdIsNullOrEmpty() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
+                .site(Site.builder().build())
                 .imp(asList(
                         givenImp(identity(), builder -> builder.siteId(null)),
                         givenImp(identity(), builder -> builder.siteId(""))))
@@ -115,8 +115,9 @@ public class ConversantBidderTest extends VertxTest {
         final Result<List<HttpRequest<BidRequest>>> result = conversantBidder.makeHttpRequests(bidRequest);
 
         // then
-        assertThat(result.getErrors()).hasSize(2)
-                .containsOnly(BidderError.badInput("Missing site id"));
+        assertThat(result.getErrors()).hasSize(3)
+                .containsOnly(BidderError.badInput("Missing site id"),
+                        BidderError.badInput("No valid impressions"));
         assertThat(result.getValue()).isEmpty();
     }
 
@@ -135,6 +136,26 @@ public class ConversantBidderTest extends VertxTest {
                 .extracting(BidRequest::getSite)
                 .extracting(Site::getId)
                 .containsOnly("site id");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldPassRequestAppAsItIs() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                requestBuilder -> requestBuilder.app(App.builder().id("app_id").build()),
+                identity(),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = conversantBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .extracting(BidRequest::getApp)
+                .extracting(App::getId)
+                .containsOnly("app_id");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/conversant/ConversantBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/conversant/ConversantBidderTest.java
@@ -122,9 +122,12 @@ public class ConversantBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldSetSiteIdFromImpExt() {
+    public void makeHttpRequestsShouldSetSiteIdFromImpExtForSiteRequest() {
         // given
-        final BidRequest bidRequest = givenBidRequest(identity());
+        final BidRequest bidRequest = givenBidRequest(
+                requestBuilder -> requestBuilder.site(Site.builder().build()),
+                identity(),
+                identity());
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = conversantBidder.makeHttpRequests(bidRequest);
@@ -161,7 +164,9 @@ public class ConversantBidderTest extends VertxTest {
     @Test
     public void makeHttpRequestsShouldSetSiteMobileFromImpExtIfPresent() {
         // given
-        final BidRequest bidRequest = givenBidRequest(identity(), identity(),
+        final BidRequest bidRequest = givenBidRequest(
+                requestBuilder -> requestBuilder.site(Site.builder().build()),
+                identity(),
                 extBuilder -> extBuilder.mobile(1));
 
         // when


### PR DESCRIPTION
- Added support of app requests for Conversant adapter and bidder;
- Removed `site_id` from required params to ensure a correct logic when app request is received;
- Switch Conversant bidder from extending OpenrtbBidder abstract class back to implementing Bidder interface;
- Corrected existing unit tests and added couple of new ones.