### PR TITLE
Fix NPE occurring when updating metrics for disabled bidder

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -580,7 +580,7 @@ public class ExchangeService {
         for (BidderRequest bidderRequest : bidderRequests) {
             final String bidder = resolveBidder(bidderRequest.getBidder(), aliases);
             final boolean isApp = bidderRequest.getBidRequest().getApp() != null;
-            final boolean noBuyerId = !bidderCatalog.isValidName(bidder) || StringUtils.isBlank(
+            final boolean noBuyerId = !bidderCatalog.isActive(bidder) || StringUtils.isBlank(
                     uidsCookie.uidFrom(bidderCatalog.usersyncerByName(bidder).getCookieFamilyName()));
 
             metrics.updateAdapterRequestTypeAndNoCookieMetrics(bidder, requestType, !isApp && noBuyerId);

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -1895,8 +1895,6 @@ public class ExchangeServiceTest extends VertxTest {
     @Test
     public void shouldIncrementCommonMetrics() {
         // given
-        given(bidderCatalog.isValidName(anyString())).willReturn(true);
-
         given(httpBidderRequester.requestBids(any(), any(), any()))
                 .willReturn(Future.succeededFuture(givenSeatBid(singletonList(
                         givenBid(Bid.builder().price(TEN).build())))));
@@ -1914,6 +1912,22 @@ public class ExchangeServiceTest extends VertxTest {
         verify(metrics).updateAdapterResponseTime(eq("somebidder"), eq("accountId"), anyInt());
         verify(metrics).updateAdapterRequestGotbidsMetrics(eq("somebidder"), eq("accountId"));
         verify(metrics).updateAdapterBidMetrics(eq("somebidder"), eq("accountId"), eq(10000L), eq(false), eq("banner"));
+    }
+
+    @Test
+    public void shouldCallUpdateCookieMetricsWithExpectedValue() {
+        // given
+        given(bidderCatalog.isActive(any())).willReturn(false);
+
+        final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("somebidder", 1)),
+                builder -> builder.app(App.builder().build()));
+
+        // when
+        exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
+
+        // then
+        verify(metrics).updateAdapterRequestTypeAndNoCookieMetrics(
+                eq("somebidder"), eq(MetricName.openrtb2web), eq(false));
     }
 
     @Test


### PR DESCRIPTION
- Fixed NPE occurring when a bid request contains a bidder that is disabled on server. Now a corresponding error message will be added to bid response to signal bidder configuration issue.