### PR TITLE
Fix JdbcApplicationSettings result mapper while fetching account by ID

### DIFF
--- a/src/main/java/org/prebid/server/auction/PreBidRequestContextFactory.java
+++ b/src/main/java/org/prebid/server/auction/PreBidRequestContextFactory.java
@@ -43,6 +43,9 @@ public class PreBidRequestContextFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(PreBidRequestContextFactory.class);
 
+    private static final TypeReference<List<Bid>> LIST_OF_BIDS_TYPE_REFERENCE = new TypeReference<List<Bid>>() {
+    };
+
     private final TimeoutResolver timeoutResolver;
     private final ImplicitParametersExtractor paramsExtractor;
     private final ApplicationSettings applicationSettings;
@@ -153,14 +156,26 @@ public class PreBidRequestContextFactory {
         final String configId = unit.getConfigId();
         if (StringUtils.isNotBlank(configId)) {
             result = applicationSettings.getAdUnitConfigById(configId, timeout)
-                    .map(config -> Json.decodeValue(config, new TypeReference<List<Bid>>() {
-                    }))
+                    .map(config -> toBids(config, configId))
                     .otherwise(exception -> {
                         logger.warn("Failed to load config ''{0}'' from cache", exception, configId);
                         return Collections.emptyList();
                     });
         } else {
             result = Future.succeededFuture(unit.getBids());
+        }
+
+        return result;
+    }
+
+    private List<Bid> toBids(String config, String configId) {
+        final List<Bid> result;
+
+        if (config != null) {
+            result = Json.decodeValue(config, LIST_OF_BIDS_TYPE_REFERENCE);
+        } else {
+            logger.warn("AdUnit config not found by id ''{0}'' from cache", configId);
+            result = Collections.emptyList();
         }
 
         return result;
@@ -181,23 +196,25 @@ public class PreBidRequestContextFactory {
     }
 
     private Set<MediaType> makeBidMediaTypes(List<String> mediaTypes) {
-        final Set<MediaType> bidMediaTypes;
+        final Set<MediaType> result;
+
         if (mediaTypes != null && !mediaTypes.isEmpty()) {
-            bidMediaTypes = new HashSet<>();
+            result = new HashSet<>();
             for (String mediaType : mediaTypes) {
                 try {
-                    bidMediaTypes.add(MediaType.valueOf(mediaType.toLowerCase()));
+                    result.add(MediaType.valueOf(mediaType.toLowerCase()));
                 } catch (IllegalArgumentException e) {
                     logger.warn("Invalid mediaType: {0}", mediaType);
                 }
             }
-            if (bidMediaTypes.isEmpty()) {
-                bidMediaTypes.add(MediaType.banner);
+            if (result.isEmpty()) {
+                result.add(MediaType.banner);
             }
         } else {
-            bidMediaTypes = Collections.singleton(MediaType.banner);
+            result = Collections.singleton(MediaType.banner);
         }
-        return bidMediaTypes;
+
+        return result;
     }
 
     private PreBidRequest adjustRequestTimeout(PreBidRequest preBidRequest) {

--- a/src/main/java/org/prebid/server/settings/JdbcApplicationSettings.java
+++ b/src/main/java/org/prebid/server/settings/JdbcApplicationSettings.java
@@ -68,7 +68,7 @@ public class JdbcApplicationSettings implements ApplicationSettings {
 
     /**
      * Runs a process to get account by id from database
-     * and returns {@link Future&lt;{@link Account}&gt;}
+     * and returns {@link Future&lt;{@link Account}&gt;}.
      */
     @Override
     public Future<Account> getAccountById(String accountId, Timeout timeout) {
@@ -77,24 +77,48 @@ public class JdbcApplicationSettings implements ApplicationSettings {
                 Collections.singletonList(accountId),
                 result -> mapToModelOrError(result, row -> Account.of(row.getString(0), row.getString(1),
                         row.getInteger(2), row.getInteger(3), row.getBoolean(4))),
-                timeout);
+                timeout)
+                .compose(JdbcApplicationSettings::failedIfNull);
     }
 
     /**
      * Runs a process to get AdUnit config by id from database
-     * and returns {@link Future&lt;{@link String}&gt;}
+     * and returns {@link Future&lt;{@link String}&gt;}.
      */
     @Override
     public Future<String> getAdUnitConfigById(String adUnitConfigId, Timeout timeout) {
         return jdbcClient.executeQuery("SELECT config FROM s2sconfig_config where uuid = ? LIMIT 1",
                 Collections.singletonList(adUnitConfigId),
                 result -> mapToModelOrError(result, row -> row.getString(0)),
-                timeout);
+                timeout)
+                .compose(JdbcApplicationSettings::failedIfNull);
+    }
+
+    /**
+     * Transforms the first row of {@link ResultSet} to required object or returns null.
+     * <p>
+     * Note: mapper should never throws exception in case of using
+     * {@link org.prebid.server.vertx.jdbc.CircuitBreakerSecuredJdbcClient}.
+     */
+    private <T> T mapToModelOrError(ResultSet result, Function<JsonArray, T> mapper) {
+        return result != null && CollectionUtils.isNotEmpty(result.getResults())
+                ? mapper.apply(result.getResults().get(0))
+                : null;
+    }
+
+    /**
+     * Returns succeeded {@link Future} if given value is not equal to NULL,
+     * otherwise failed {@link Future} with {@link PreBidException}.
+     */
+    private static <T> Future<T> failedIfNull(T value) {
+        return value != null
+                ? Future.succeededFuture(value)
+                : Future.failedFuture(new PreBidException("Not found"));
     }
 
     /**
      * Runs a process to get stored requests by a collection of ids from database
-     * and returns {@link Future&lt;{@link StoredDataResult }&gt;}
+     * and returns {@link Future&lt;{@link StoredDataResult }&gt;}.
      */
     @Override
     public Future<StoredDataResult> getStoredData(Set<String> requestIds, Set<String> impIds, Timeout timeout) {
@@ -103,21 +127,11 @@ public class JdbcApplicationSettings implements ApplicationSettings {
 
     /**
      * Runs a process to get stored requests by a collection of amp ids from database
-     * and returns {@link Future&lt;{@link StoredDataResult }&gt;}
+     * and returns {@link Future&lt;{@link StoredDataResult }&gt;}.
      */
     @Override
     public Future<StoredDataResult> getAmpStoredData(Set<String> requestIds, Set<String> impIds, Timeout timeout) {
         return fetchStoredData(selectAmpQuery, requestIds, Collections.emptySet(), timeout);
-    }
-
-    /**
-     * Transforms the first row of {@link ResultSet} to required object.
-     */
-    private <T> T mapToModelOrError(ResultSet result, Function<JsonArray, T> mapper) {
-        if (result == null || result.getResults() == null || result.getResults().isEmpty()) {
-            throw new PreBidException("Not found");
-        }
-        return mapper.apply(result.getResults().get(0));
     }
 
     /**
@@ -157,7 +171,7 @@ public class JdbcApplicationSettings implements ApplicationSettings {
     }
 
     /**
-     * Returns string for parametrized placeholder
+     * Returns string for parametrized placeholder.
      */
     private static String parameterHolders(int paramsSize) {
         return paramsSize == 0

--- a/src/main/java/org/prebid/server/settings/mapper/JdbcStoredDataResultMapper.java
+++ b/src/main/java/org/prebid/server/settings/mapper/JdbcStoredDataResultMapper.java
@@ -33,6 +33,9 @@ public class JdbcStoredDataResultMapper {
      * @param requestIds - a specified set of stored requests' ids. Adds error for each ID missing in result set
      * @param impIds     - a specified set of stored imps' ids. Adds error for each ID missing in result set
      * @return - a {@link StoredDataResult} object
+     * <p>
+     * Note: mapper should never throws exception in case of using
+     * {@link org.prebid.server.vertx.jdbc.CircuitBreakerSecuredJdbcClient}.
      */
     public static StoredDataResult map(ResultSet resultSet, Set<String> requestIds, Set<String> impIds) {
         final Map<String, String> storedIdToRequest = new HashMap<>(requestIds.size());
@@ -48,7 +51,7 @@ public class JdbcStoredDataResultMapper {
                 final String separator = requestIds.isEmpty() || impIds.isEmpty() ? "" : " and ";
                 final String errorImps = impIds.isEmpty() ? "" : String.format("stored imps for ids %s", impIds);
 
-                errors.add(String.format("No %s%s%s was found", errorRequests, separator, errorImps));
+                errors.add(String.format("No %s%s%s were found", errorRequests, separator, errorImps));
             }
         } else {
             try {

--- a/src/test/java/org/prebid/server/settings/JdbcApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/JdbcApplicationSettingsTest.java
@@ -368,7 +368,7 @@ public class JdbcApplicationSettingsTest {
         final Async async = context.async();
         storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
             assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), emptyMap(),
-                    singletonList("No stored requests for ids [3, 4] and stored imps for ids [6, 7] was found")));
+                    singletonList("No stored requests for ids [3, 4] and stored imps for ids [6, 7] were found")));
             async.complete();
         }));
     }
@@ -383,7 +383,7 @@ public class JdbcApplicationSettingsTest {
         final Async async = context.async();
         storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
             assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), emptyMap(),
-                    singletonList("No stored requests for ids [3, 4] was found")));
+                    singletonList("No stored requests for ids [3, 4] were found")));
             async.complete();
         }));
     }

--- a/src/test/java/org/prebid/server/settings/mapper/JdbcStoredDataResultMapperTest.java
+++ b/src/test/java/org/prebid/server/settings/mapper/JdbcStoredDataResultMapperTest.java
@@ -55,7 +55,7 @@ public class JdbcStoredDataResultMapperTest {
         assertThat(result.getStoredIdToRequest()).isEmpty();
         assertThat(result.getStoredIdToImp()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("No stored requests for ids [reqId] and stored imps for ids [impId] was found");
+                .containsOnly("No stored requests for ids [reqId] and stored imps for ids [impId] were found");
     }
 
     @Test


### PR DESCRIPTION
Mapper used by JDBC Client should not throws exception if empty result obtained.
Otherwise, `CircuitBreakerSecuredJdbcClient` will fire up.