### PR TITLE
Fix host-bidder usersync-url

### DIFF
--- a/src/main/java/org/prebid/server/handler/SetuidHandler.java
+++ b/src/main/java/org/prebid/server/handler/SetuidHandler.java
@@ -32,6 +32,11 @@ public class SetuidHandler implements Handler<RoutingContext> {
     private static final Set<GdprPurpose> GDPR_PURPOSES =
             Collections.unmodifiableSet(EnumSet.of(GdprPurpose.informationStorageAndAccess));
 
+    private static final String BIDDER_PARAM = "bidder";
+    private static final String GDPR_PARAM = "gdpr";
+    private static final String GDPR_CONSENT_PARAM = "gdpr_consent";
+    private static final String UID_PARAM = "uid";
+
     private final long defaultTimeout;
     private final UidsCookieService uidsCookieService;
     private final GdprService gdprService;
@@ -65,7 +70,7 @@ public class SetuidHandler implements Handler<RoutingContext> {
             return;
         }
 
-        final String bidder = context.request().getParam("bidder");
+        final String bidder = context.request().getParam(BIDDER_PARAM);
         if (StringUtils.isBlank(bidder)) {
             final int status = HttpResponseStatus.BAD_REQUEST.code();
             context.response().setStatusCode(status).end("\"bidder\" query param is required");
@@ -74,8 +79,8 @@ public class SetuidHandler implements Handler<RoutingContext> {
             return;
         }
 
-        final String gdpr = context.request().getParam("gdpr");
-        final String gdprConsent = context.request().getParam("gdpr_consent");
+        final String gdpr = context.request().getParam(GDPR_PARAM);
+        final String gdprConsent = context.request().getParam(GDPR_CONSENT_PARAM);
         final String ip = useGeoLocation ? HttpUtil.ipFrom(context.request()) : null;
         gdprService.resultByVendor(GDPR_PURPOSES, gdprVendorIds, gdpr, gdprConsent, ip,
                 timeoutFactory.create(defaultTimeout))
@@ -123,7 +128,7 @@ public class SetuidHandler implements Handler<RoutingContext> {
     }
 
     private void respondWithCookie(RoutingContext context, String bidder, UidsCookie uidsCookie) {
-        final String uid = context.request().getParam("uid");
+        final String uid = context.request().getParam(UID_PARAM);
         final UidsCookie updatedUidsCookie;
         boolean successfullyUpdated = false;
 

--- a/src/main/java/org/prebid/server/proto/response/UsersyncInfo.java
+++ b/src/main/java/org/prebid/server/proto/response/UsersyncInfo.java
@@ -41,7 +41,7 @@ public class UsersyncInfo {
         static UsersyncInfoAssembler assembler(Usersyncer usersyncer) {
             final UsersyncInfoAssembler usersyncInfoAssembler = new UsersyncInfoAssembler();
             usersyncInfoAssembler.usersyncUrl = usersyncer.getUsersyncUrl();
-            usersyncInfoAssembler.redirectUrl = ObjectUtils.firstNonNull(usersyncer.getRedirectUrl(), "");
+            usersyncInfoAssembler.redirectUrl = ObjectUtils.defaultIfNull(usersyncer.getRedirectUrl(), "");
             usersyncInfoAssembler.type = usersyncer.getType();
             usersyncInfoAssembler.supportCORS = usersyncer.isSupportCORS();
             return usersyncInfoAssembler;
@@ -72,8 +72,8 @@ public class UsersyncInfo {
          * if the "gdpr" arg was empty, and the consent arg was "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw"
          */
         public UsersyncInfoAssembler withGdpr(String gdpr, String gdprConsent) {
-            final String nonNullGdpr = ObjectUtils.firstNonNull(gdpr, "");
-            final String nonNullGdprConsent = ObjectUtils.firstNonNull(gdprConsent, "");
+            final String nonNullGdpr = ObjectUtils.defaultIfNull(gdpr, "");
+            final String nonNullGdprConsent = ObjectUtils.defaultIfNull(gdprConsent, "");
 
             usersyncUrl = updateUrlWithGdpr(usersyncUrl, HttpUtil.encodeUrl(nonNullGdpr),
                     HttpUtil.encodeUrl(nonNullGdprConsent));

--- a/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
@@ -389,7 +389,7 @@ public class CookieSyncHandlerTest extends VertxTest {
     }
 
     @Test
-    public void shouldUpdateCookieSyncSetAndRejectByGdprMetricForEachRejectedAndSyncedBidder() throws IOException {
+    public void shouldUpdateCookieSyncSetAndRejectByGdprMetricForEachRejectedAndSyncedBidder() {
         // given
         given(routingContext.getBody())
                 .willReturn(givenRequestBody(CookieSyncRequest.of(asList(RUBICON, APPNEXUS), null, null, null)));
@@ -415,7 +415,7 @@ public class CookieSyncHandlerTest extends VertxTest {
     }
 
     @Test
-    public void shouldUpdateCookieSyncMatchesMetricForEachAlreadySyncedBidder() throws IOException {
+    public void shouldUpdateCookieSyncMatchesMetricForEachAlreadySyncedBidder() {
         // given
         given(uidsCookieService.parseFromRequest(any())).willReturn(new UidsCookie(
                 Uids.builder().uids(singletonMap(RUBICON, UidWithExpiry.live("J5VLCWQP-26-CWFT"))).build()));
@@ -544,7 +544,7 @@ public class CookieSyncHandlerTest extends VertxTest {
         givenGdprServiceReturningResult(singletonMap(RUBICON, 1));
 
         given(uidsCookieService.getHostCookieFamily()).willReturn(RUBICON);
-        given(uidsCookieService.parseHostCookie(any())).willReturn("host-cookie-value");
+        given(uidsCookieService.parseHostCookie(any())).willReturn("host/cookie/value");
         given(uidsCookieService.parseUids(any()))
                 .willReturn(Uids.builder().uids(singletonMap(RUBICON, UidWithExpiry.live("uid-cookie-value"))).build());
 
@@ -556,8 +556,8 @@ public class CookieSyncHandlerTest extends VertxTest {
         assertThat(cookieSyncResponse.getBidderStatus())
                 .extracting(BidderUsersyncStatus::getUsersync)
                 .containsOnly(
-                        UsersyncInfo.of("http://external-url/setuid?bidder=rubicon&gdpr=null&gdpr_consent=null"
-                                + "&uid=host-cookie-value", "redirect", false));
+                        UsersyncInfo.of("http://external-url/setuid?bidder=rubicon&gdpr=&gdpr_consent="
+                                + "&uid=host%2Fcookie%2Fvalue", "redirect", false));
     }
 
     @Test
@@ -908,7 +908,7 @@ public class CookieSyncHandlerTest extends VertxTest {
         return cookieSyncEventCaptor.getValue();
     }
 
-    @SuppressWarnings("all")
+    @SuppressWarnings("SameParameterValue")
     private static <K, V> Map<K, V> doubleMap(K key1, V value1, K key2, V value2) {
         final Map<K, V> map = new HashMap<>();
         map.put(key1, value1);


### PR DESCRIPTION
Fixes:
- Host-bidder cookie uid value must be url-encoded in `/setuid` url.
- GDPR macro must be properly handled.