### PR TITLE
Update IX adapter and bidder to no longed filter requests by ix.sizes

### DIFF
--- a/src/main/java/org/prebid/server/bidder/ix/IxAdapter.java
+++ b/src/main/java/org/prebid/server/bidder/ix/IxAdapter.java
@@ -84,12 +84,8 @@ public class IxAdapter extends OpenrtbAdapter {
                 continue;
             }
             final IxParams ixParams = parseAndValidateParams(adUnitBid);
-            final List<Integer> ixParamsSizes = ixParams.getSize();
             boolean isFirstSize = true;
             for (Format format : adUnitBid.getSizes()) {
-                if (CollectionUtils.isNotEmpty(ixParamsSizes) && !isValidIxSize(format, ixParamsSizes)) {
-                    continue;
-                }
                 final BidRequest bidRequest = createBidRequest(adUnitBid, ixParams, format, preBidRequestContext);
                 // prioritize slots over sizes
                 if (isFirstSize) {
@@ -126,15 +122,7 @@ public class IxAdapter extends OpenrtbAdapter {
             throw new PreBidException("Missing siteId param");
         }
 
-        final List<Integer> size = params.getSize();
-        if (size != null && size.size() < 2) {
-            throw new PreBidException("Incorrect Size param: expected at least 2 values");
-        }
         return params;
-    }
-
-    private static boolean isValidIxSize(Format format, List<Integer> sizes) {
-        return Objects.equals(format.getW(), sizes.get(0)) && Objects.equals(format.getH(), sizes.get(1));
     }
 
     private BidRequest createBidRequest(AdUnitBid adUnitBid, IxParams ixParams, Format size,

--- a/src/main/java/org/prebid/server/bidder/ix/IxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/ix/IxBidder.java
@@ -141,11 +141,6 @@ public class IxBidder implements Bidder<BidRequest> {
         if (StringUtils.isBlank(extImpIx.getSiteId())) {
             throw new PreBidException("Missing siteId param");
         }
-
-        final List<Integer> size = extImpIx.getSize();
-        if (size != null && size.size() < 2) {
-            throw new PreBidException("Incorrect Size, expected at least 2 values");
-        }
         return extImpIx;
     }
 
@@ -158,12 +153,8 @@ public class IxBidder implements Bidder<BidRequest> {
                 ? formats.subList(0, REQUEST_LIMIT)
                 : formats;
 
-        final List<Integer> sizes = extImpIx.getSize();
         final List<BidRequest> requests = new ArrayList<>();
         for (Format format : limitedFormats) {
-            if (CollectionUtils.isNotEmpty(sizes) && !isValidIxSize(format, sizes)) {
-                continue;
-            }
             bannerBuilder.format(Collections.singletonList(format))
                     .w(format.getW())
                     .h(format.getH());

--- a/src/main/java/org/prebid/server/bidder/ix/proto/IxParams.java
+++ b/src/main/java/org/prebid/server/bidder/ix/proto/IxParams.java
@@ -4,14 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
-import java.util.List;
-
 @AllArgsConstructor(staticName = "of")
 @Value
 public class IxParams {
 
     @JsonProperty("siteId")
     String siteId;
-
-    List<Integer> size;
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ix/ExtImpIx.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ix/ExtImpIx.java
@@ -4,14 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
-import java.util.List;
-
 @AllArgsConstructor(staticName = "of")
 @Value
 public class ExtImpIx {
 
     @JsonProperty("siteId")
     String siteId;
-
-    List<Integer> size;
 }

--- a/src/test/java/org/prebid/server/bidder/ix/IxAdapterTest.java
+++ b/src/test/java/org/prebid/server/bidder/ix/IxAdapterTest.java
@@ -145,25 +145,12 @@ public class IxAdapterTest extends VertxTest {
     @Test
     public void makeHttpRequestsShouldFailIfAdUnitBidParamPublisherIdIsMissing() {
         // given
-        adapterRequest = givenBidder(builder -> builder.params(
-                mapper.valueToTree(IxParams.of(null, null))));
+        adapterRequest = givenBidder(builder -> builder.params(mapper.valueToTree(IxParams.of(null))));
 
         // when and then
         assertThatThrownBy(() -> adapter.makeHttpRequests(adapterRequest, preBidRequestContext))
                 .isExactlyInstanceOf(PreBidException.class)
                 .hasMessage("Missing siteId param");
-    }
-
-    @Test
-    public void makeHttpRequestsShouldFailIfAdUnitBidParamSizeIsInvalid() {
-        // given
-        adapterRequest = givenBidder(builder -> builder.params(
-                mapper.valueToTree(IxParams.of("id", singletonList(33)))));
-
-        // when and then
-        assertThatThrownBy(() -> adapter.makeHttpRequests(adapterRequest, preBidRequestContext))
-                .isExactlyInstanceOf(PreBidException.class)
-                .hasMessage("Incorrect Size param: expected at least 2 values");
     }
 
     @Test
@@ -209,7 +196,7 @@ public class IxAdapterTest extends VertxTest {
                         .instl(1)
                         .topframe(1)
                         .sizes(singletonList(Format.builder().w(300).h(250).build()))
-                        .params(mapper.valueToTree(IxParams.of("486", asList(300, 250)))));
+                        .params(mapper.valueToTree(IxParams.of("486"))));
 
         preBidRequestContext = givenPreBidRequestContext(
                 builder -> builder
@@ -311,30 +298,6 @@ public class IxAdapterTest extends VertxTest {
                 .flatExtracting(Banner::getFormat)
                 .containsOnly(Format.builder().w(300).h(250).build(),
                         Format.builder().w(300).h(300).build());
-    }
-
-    @Test
-    public void makeHttpRequestsShouldReturnListWithOnlyOneRequestWithValidSizesFromParams() {
-        // given
-        adapterRequest = AdapterRequest.of(BIDDER, singletonList(
-                givenAdUnitBid(builder -> builder
-                        .adUnitCode("adUnitCode1")
-                        .sizes(asList(Format.builder().w(300).h(250).build(),
-                                Format.builder().w(300).h(300).build()))
-                        .params(mapper.valueToTree(IxParams.of("486", asList(300, 250))))
-                )));
-
-        // when
-        final List<AdapterHttpRequest<BidRequest>> httpRequests = adapter.makeHttpRequests(adapterRequest,
-                preBidRequestContext);
-
-        // then
-        assertThat(httpRequests).hasSize(1)
-                .extracting(AdapterHttpRequest::getPayload)
-                .flatExtracting(BidRequest::getImp)
-                .extracting(Imp::getBanner)
-                .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(300).h(250).build());
     }
 
     @Test
@@ -522,7 +485,7 @@ public class IxAdapterTest extends VertxTest {
     private static AdUnitBid givenAdUnitBid(Function<AdUnitBidBuilder, AdUnitBidBuilder> adUnitBidBuilderCustomizer) {
         final AdUnitBidBuilder adUnitBidBuilderMinimal = AdUnitBid.builder()
                 .sizes(singletonList(Format.builder().w(300).h(250).build()))
-                .params(mapper.valueToTree(IxParams.of("42", null)))
+                .params(mapper.valueToTree(IxParams.of("42")))
                 .mediaTypes(singleton(MediaType.banner));
 
         final AdUnitBidBuilder adUnitBidBuilderCustomized = adUnitBidBuilderCustomizer

--- a/src/test/java/org/prebid/server/bidder/ix/IxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/ix/IxBidderTest.java
@@ -108,9 +108,9 @@ public class IxBidderTest extends VertxTest {
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(asList(
                         givenImp(impBuilder -> impBuilder.ext(
-                                mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of(null, null))))),
+                                mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of(null))))),
                         givenImp(impBuilder -> impBuilder.ext(
-                                mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("", null)))))))
+                                mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("")))))))
                 .build();
 
         // when
@@ -119,27 +119,6 @@ public class IxBidderTest extends VertxTest {
         // then
         assertThat(result.getErrors()).hasSize(3)
                 .containsOnly(BidderError.badInput("Missing siteId param"),
-                        BidderError.badInput("No valid impressions in the bid request"));
-        assertThat(result.getValue()).isEmpty();
-    }
-
-    @Test
-    public void makeHttpRequestsShouldReturnErrorIfImpExtSizeIsInvalid() {
-        // given
-        final BidRequest bidRequest = BidRequest.builder()
-                .imp(asList(
-                        givenImp(impBuilder -> impBuilder.ext(
-                                mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("siteId", emptyList()))))),
-                        givenImp(impBuilder -> impBuilder.ext(
-                                mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("siteId", singletonList(1))))))))
-                .build();
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = ixBidder.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).hasSize(3)
-                .containsOnly(BidderError.badInput("Incorrect Size, expected at least 2 values"),
                         BidderError.badInput("No valid impressions in the bid request"));
         assertThat(result.getValue()).isEmpty();
     }
@@ -276,30 +255,6 @@ public class IxBidderTest extends VertxTest {
                 .extracting(Publisher::getId)
                 // both from same imp (same imp.ext.siteId)
                 .containsOnly("site id");
-    }
-
-    @Test
-    public void makeHttpRequestsShouldCreateOnlyOneRequestWithValidSizesFromImpExt() {
-        // given
-        final BidRequest bidRequest = givenBidRequest(
-                impBuilder -> impBuilder
-                        .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("site id", asList(600, 400)))))
-                        .banner(Banner.builder()
-                                .format(asList(Format.builder().w(300).h(200).build(),
-                                        Format.builder().w(600).h(400).build()))
-                                .build()));
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = ixBidder.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).isEmpty();
-        assertThat(result.getValue()).hasSize(1)
-                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
-                .flatExtracting(BidRequest::getImp)
-                .extracting(Imp::getBanner)
-                .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(600).h(400).build());
     }
 
     @Test
@@ -480,7 +435,7 @@ public class IxBidderTest extends VertxTest {
         return impCustomizer.apply(Imp.builder()
                 .id("123")
                 .banner(Banner.builder().build())
-                .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("site id", null)))))
+                .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpIx.of("site id")))))
                 .build();
     }
 


### PR DESCRIPTION
- Updated IX adapter and bidder not to filter requests by ix.sizes (removed field and validation check);
- Updated and removed some unit tests to reflect the changes.