### PR TITLE
Fix Pulsepoint usersync-url

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -49,9 +49,6 @@ This parameter affects how many CPU cores will be utilized by the application. R
 ## Setuid
 - `setuid.default-timeout-ms` - default operation timeout for requests to `/setuid` endpoint.
 
-## Events
-- `events.accounts-enabled` - a list of accounts supporting event notifications.   
-
 ## Cookie Sync
 - `cookie-sync.default-timeout-ms` - default operation timeout for requests to `/cookie_sync` endpoint.
 

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -390,6 +390,7 @@ public class ServiceConfiguration {
     }
 
     @Configuration
+    @ConditionalOnProperty("status-response")
     @ConditionalOnExpression("'${status-response}' != ''")
     static class HealthCheckerService {
 

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -392,16 +392,14 @@ public class ServiceConfiguration {
     @Configuration
     @ConditionalOnProperty("status-response")
     @ConditionalOnExpression("'${status-response}' != ''")
-    static class HealthCheckerService {
-
-        @Autowired
-        Vertx vertx;
+    static class HealthCheckerConfiguration {
 
         @Bean
         @ConditionalOnProperty(prefix = "health-check.database", name = "enabled", havingValue = "true")
         HealthChecker databaseChecker(
-                @Value("${health-check.database.refresh-period-ms}") long refreshPeriod,
-                JDBCClient jdbcClient) {
+                Vertx vertx,
+                JDBCClient jdbcClient,
+                @Value("${health-check.database.refresh-period-ms}") long refreshPeriod) {
 
             return new DatabaseHealthChecker(vertx, jdbcClient, refreshPeriod);
         }

--- a/src/main/java/org/prebid/server/util/HttpUtil.java
+++ b/src/main/java/org/prebid/server/util/HttpUtil.java
@@ -78,26 +78,25 @@ public final class HttpUtil {
      * <p>
      * The result can be safety used as the query string.
      */
-    public static String encodeUrl(String format, Object... args) {
-        final String uri = String.format(format, args);
+    public static String encodeUrl(String value) {
         try {
-            return URLEncoder.encode(uri, "UTF-8");
+            return URLEncoder.encode(value, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(String.format("Cannot encode uri: %s", uri));
+            throw new IllegalArgumentException(String.format("Cannot encode url: %s", value));
         }
     }
 
     /**
-     * Returns decoded input value if supplied input not null, otherwise returns null.
+     * Returns decoded value if supplied is not null, otherwise returns null.
      */
-    public static String decodeUrl(String input) {
-        if (StringUtils.isBlank(input)) {
+    public static String decodeUrl(String value) {
+        if (StringUtils.isBlank(value)) {
             return null;
         }
         try {
-            return URLDecoder.decode(input, "UTF-8");
+            return URLDecoder.decode(value, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(String.format("Cannot decode input: %s", input));
+            throw new IllegalArgumentException(String.format("Cannot decode url: %s", value));
         }
     }
 

--- a/src/test/java/org/prebid/server/util/HttpUtilTest.java
+++ b/src/test/java/org/prebid/server/util/HttpUtilTest.java
@@ -61,7 +61,7 @@ public class HttpUtilTest {
     @Test
     public void encodeUrlShouldReturnExpectedValue() {
         // when
-        final String url = HttpUtil.encodeUrl("//domain.org/%s", "query-string?a=1");
+        final String url = HttpUtil.encodeUrl("//domain.org/query-string?a=1");
 
         // then
         assertThat(url).isNotNull();


### PR DESCRIPTION
CL:
- The Pulsepoint bidder usersync-url contains doubled percent symbol `%%`. This caused the problem in `HttpUtil.encodeUrl(...)`. The `String.format(...)` method was used there and it interprets `%` as escape symbol (even no `args` given).
So, `encodeUrl` was simplified since the second argument was never used it is removed from its signature.
- Fixed `status-response` config property handling for `HealthChecker`s configuration.
- Removed `events.accounts-enabled` config property from documentation since it is not used anymore.