### PR TITLE
Replace request.test flag with request.ext.prebid.debug

### DIFF
--- a/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
@@ -51,7 +51,8 @@ public class HttpBidderRequester {
     /**
      * Executes given request to a given bidder.
      */
-    public <T> Future<BidderSeatBid> requestBids(Bidder<T> bidder, BidRequest bidRequest, Timeout timeout) {
+    public <T> Future<BidderSeatBid> requestBids(Bidder<T> bidder, BidRequest bidRequest, Timeout timeout,
+                                                 boolean debugEnabled) {
         final Result<List<HttpRequest<T>>> httpRequestsWithErrors = bidder.makeHttpRequests(bidRequest);
 
         final List<BidderError> bidderErrors = httpRequestsWithErrors.getErrors();
@@ -63,7 +64,7 @@ public class HttpBidderRequester {
                 .map(httpRequest -> doRequest(httpRequest, timeout))
                 .collect(Collectors.toList()))
                 .map(httpRequestsResult ->
-                        toBidderSeatBid(bidder, bidRequest, bidderErrors, httpRequestsResult.list()));
+                        toBidderSeatBid(bidder, bidRequest, httpRequestsResult.list(), debugEnabled, bidderErrors));
     }
 
     /**
@@ -118,6 +119,9 @@ public class HttpBidderRequester {
                 HttpResponse.of(statusCode, response.getHeaders(), response.getBody()), errorOrNull(statusCode)));
     }
 
+    /**
+     * Returns {@link BidderError} if HTTP status code is not successful, or null otherwise.
+     */
     private static BidderError errorOrNull(int statusCode) {
         if (statusCode != HttpResponseStatus.OK.code() && statusCode != HttpResponseStatus.NO_CONTENT.code()) {
             return BidderError.create(String.format(
@@ -133,10 +137,10 @@ public class HttpBidderRequester {
      * Transforms HTTP call results into single {@link BidderSeatBid} filled with debug information, bids and errors
      * happened along the way.
      */
-    private <T> BidderSeatBid toBidderSeatBid(Bidder<T> bidder, BidRequest bidRequest, List<BidderError> previousErrors,
-                                              List<HttpCall<T>> calls) {
-        // If this is a test bid, capture debugging info from the requests
-        final List<ExtHttpCall> httpCalls = Objects.equals(bidRequest.getTest(), 1)
+    private <T> BidderSeatBid toBidderSeatBid(Bidder<T> bidder, BidRequest bidRequest, List<HttpCall<T>> calls,
+                                              boolean debugEnabled, List<BidderError> previousErrors) {
+        // Capture debugging info from the requests
+        final List<ExtHttpCall> httpCalls = debugEnabled
                 ? calls.stream().map(HttpBidderRequester::toExt).collect(Collectors.toList())
                 : Collections.emptyList();
 

--- a/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
@@ -1,5 +1,6 @@
 package org.prebid.server.handler.openrtb2;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -39,6 +40,8 @@ import org.prebid.server.metric.MetricName;
 import org.prebid.server.metric.Metrics;
 import org.prebid.server.metric.model.MetricsContext;
 import org.prebid.server.proto.openrtb.ext.ExtPrebid;
+import org.prebid.server.proto.openrtb.ext.request.ExtBidRequest;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
 import org.prebid.server.proto.openrtb.ext.response.ExtBidPrebid;
 import org.prebid.server.proto.openrtb.ext.response.ExtBidResponse;
 import org.prebid.server.proto.openrtb.ext.response.ExtBidderError;
@@ -151,7 +154,7 @@ public class AmpHandler implements Handler<RoutingContext> {
     }
 
     private AmpResponse toAmpResponse(BidRequest bidRequest, BidResponse bidResponse) {
-        // fetch targeting information from response bids
+        // Fetch targeting information from response bids
         final List<SeatBid> seatBids = bidResponse.getSeatbid();
 
         final Map<String, JsonNode> targeting = seatBids == null ? Collections.emptyMap() : seatBids.stream()
@@ -163,15 +166,18 @@ public class AmpHandler implements Handler<RoutingContext> {
                 .map(entry -> Tuple2.of(entry.getKey(), TextNode.valueOf(entry.getValue())))
                 .collect(Collectors.toMap(Tuple2::getLeft, Tuple2::getRight));
 
-        final ExtBidResponse extBidResponse = extResponseFrom(bidResponse);
+        final ExtResponseDebug extResponseDebug;
+        final Map<String, List<ExtBidderError>> errors;
+        // Fetch debug and errors information from response if requested
+        if (isDebugEnabled(bidRequest)) {
+            final ExtBidResponse extBidResponse = extResponseFrom(bidResponse);
 
-        // fetch debug information from response if requested
-        final ExtResponseDebug extResponseDebug = Objects.equals(bidRequest.getTest(), 1)
-                ? extResponseDebugFrom(extBidResponse) : null;
-
-        // fetch errors information from response if requested
-        final Map<String, List<ExtBidderError>> errors = Objects.equals(bidRequest.getTest(), 1)
-                ? errorsFrom(extBidResponse) : null;
+            extResponseDebug = extResponseDebugFrom(extBidResponse);
+            errors = errorsFrom(extBidResponse);
+        } else {
+            extResponseDebug = null;
+            errors = null;
+        }
 
         return AmpResponse.of(targeting, extResponseDebug, errors);
     }
@@ -223,15 +229,38 @@ public class AmpHandler implements Handler<RoutingContext> {
         }
     }
 
-    private static ExtBidResponse extResponseFrom(BidResponse bidResponse) {
-        final ExtBidResponse extBidResponse;
+    /**
+     * Determines debug flag from {@link BidRequest}.
+     */
+    private static boolean isDebugEnabled(BidRequest bidRequest) {
+        if (Objects.equals(bidRequest.getTest(), 1)) {
+            return true;
+        }
+        final ExtBidRequest extBidRequest = extBidRequestFrom(bidRequest);
+        final ExtRequestPrebid extRequestPrebid = extBidRequest != null ? extBidRequest.getPrebid() : null;
+        return extRequestPrebid != null && Objects.equals(extRequestPrebid.getDebug(), true);
+    }
+
+    /**
+     * Extracts {@link ExtBidRequest} from {@link BidRequest}.
+     */
+    private static ExtBidRequest extBidRequestFrom(BidRequest bidRequest) {
         try {
-            extBidResponse = Json.mapper.convertValue(bidResponse.getExt(), EXT_BID_RESPONSE_TYPE_REFERENCE);
+            return bidRequest.getExt() != null
+                    ? Json.mapper.treeToValue(bidRequest.getExt(), ExtBidRequest.class)
+                    : null;
+        } catch (JsonProcessingException e) {
+            throw new PreBidException(String.format("Error decoding bidRequest.ext: %s", e.getMessage()), e);
+        }
+    }
+
+    private static ExtBidResponse extResponseFrom(BidResponse bidResponse) {
+        try {
+            return Json.mapper.convertValue(bidResponse.getExt(), EXT_BID_RESPONSE_TYPE_REFERENCE);
         } catch (IllegalArgumentException e) {
             throw new PreBidException(
                     String.format("Critical error while unpacking AMP bid response: %s", e.getMessage()), e);
         }
-        return extBidResponse;
     }
 
     private static ExtResponseDebug extResponseDebugFrom(ExtBidResponse extBidResponse) {
@@ -246,7 +275,7 @@ public class AmpHandler implements Handler<RoutingContext> {
                               RoutingContext context, long startTime) {
         final MetricName requestType = METRICS_CONTEXT.getRequestType();
 
-        // don't send the response if client has gone
+        // Don't send the response if client has gone
         if (context.response().closed()) {
             logger.warn("The client already closed connection, response will be skipped");
             metrics.updateRequestTypeMetric(requestType, MetricName.networkerr);

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebid.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebid.java
@@ -14,6 +14,11 @@ import java.util.Map;
 public class ExtRequestPrebid {
 
     /**
+     * Defines the contract for bidrequest.ext.prebid.debug
+     */
+    Boolean debug;
+
+    /**
      * Defines the contract for bidrequest.ext.prebid.aliases
      */
     Map<String, String> aliases;

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -104,6 +104,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -310,14 +311,14 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequest1Captor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder1), bidRequest1Captor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder1), bidRequest1Captor.capture(), any(), anyBoolean());
         final BidRequest capturedBidRequest1 = bidRequest1Captor.getValue();
         assertThat(capturedBidRequest1.getImp()).hasSize(2)
                 .extracting(imp -> imp.getExt().get("bidder").asInt())
                 .containsOnly(1, 3);
 
         final ArgumentCaptor<BidRequest> bidRequest2Captor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder2), bidRequest2Captor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder2), bidRequest2Captor.capture(), any(), anyBoolean());
         final BidRequest capturedBidRequest2 = bidRequest2Captor.getValue();
         assertThat(capturedBidRequest2.getImp()).hasSize(1)
                 .element(0).returns(2, imp -> imp.getExt().get("bidder").asInt());
@@ -358,7 +359,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any(), anyBoolean());
         final BidRequest capturedBidRequest = bidRequestCaptor.getValue();
         assertThat(capturedBidRequest.getUser()).isEqualTo(User.builder().buyeruid(null)
                 .ext(mapper.valueToTree(ExtUser.of(null, null, null, null, null)))
@@ -391,7 +392,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any(), anyBoolean());
         final BidRequest capturedBidRequest = bidRequestCaptor.getValue();
         assertThat(capturedBidRequest.getUser()).isEqualTo(User.builder().buyeruid("uidval")
                 .ext(mapper.valueToTree(ExtUser.of(null, null, null, null, null))).build());
@@ -450,7 +451,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any(), anyBoolean());
         final BidRequest capturedBidRequest = bidRequestCaptor.getValue();
         assertThat(capturedBidRequest.getUser()).isEqualTo(User.builder().buyeruid("uidval")
                 .ext(mapper.valueToTree(ExtUser.of(null, null, null, null, null))).build());
@@ -486,7 +487,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any(), anyBoolean());
         final BidRequest capturedBidRequest = bidRequestCaptor.getValue();
         assertThat(capturedBidRequest.getUser()).isEqualTo(User.builder().buyeruid(null)
                 .ext(mapper.valueToTree(ExtUser.of(null, null, null, null, null))).build());
@@ -525,7 +526,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester, times(3)).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester, times(3)).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
         verify(metrics).updateGdprMaskedMetric(eq("bidder3"));
         assertThat(bidRequestCaptor.getAllValues())
                 .extracting(BidRequest::getUser)
@@ -551,7 +552,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
 
         assertThat(bidRequestCaptor.getAllValues())
                 .extracting(BidRequest::getUser)
@@ -578,7 +579,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
 
         assertThat(bidRequestCaptor.getAllValues())
                 .extracting(BidRequest::getUser)
@@ -603,7 +604,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
 
         assertThat(bidRequestCaptor.getAllValues())
                 .extracting(BidRequest::getUser)
@@ -628,7 +629,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
 
         assertThat(bidRequestCaptor.getAllValues())
                 .extracting(BidRequest::getUser)
@@ -689,7 +690,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(same(bidder), bidRequestCaptor.capture(), any(), anyBoolean());
         assertThat(bidRequestCaptor.getValue().getImp()).hasSize(1)
                 .extracting(imp -> imp.getExt().get("bidder").asInt())
                 .contains(1);
@@ -711,7 +712,8 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester, times(2)).requestBids(same(bidder), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester, times(2)).requestBids(same(bidder), bidRequestCaptor.capture(), any(),
+                anyBoolean());
         final List<BidRequest> capturedBidRequests = bidRequestCaptor.getAllValues();
 
         assertThat(capturedBidRequests).hasSize(2)
@@ -803,7 +805,7 @@ public class ExchangeServiceTest extends VertxTest {
     @Test
     public void shouldReturnMultipleSeatBids() {
         // given
-        given(httpBidderRequester.requestBids(any(), any(), any()))
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(asList(
                         givenBid(Bid.builder().price(BigDecimal.ONE).build()),
                         givenBid(Bid.builder().price(BigDecimal.ONE).build())))))
@@ -828,13 +830,13 @@ public class ExchangeServiceTest extends VertxTest {
 
         given(httpBidderRequester.requestBids(any(), eq(givenBidRequest(givenSingleImp(singletonMap("bidder", 1)),
                 builder -> builder.ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
-                        .aliases(singletonMap("bidderAlias", "bidder")).build()))))), any()))
+                        .aliases(singletonMap("bidderAlias", "bidder")).build()))))), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(singletonList(
                         givenBid(Bid.builder().price(BigDecimal.ONE).build())))));
 
         given(httpBidderRequester.requestBids(any(), eq(givenBidRequest(givenSingleImp(singletonMap("bidder", 2)),
                 builder -> builder.ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
-                        .aliases(singletonMap("bidderAlias", "bidder")).build()))))), any()))
+                        .aliases(singletonMap("bidderAlias", "bidder")).build()))))), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(singletonList(
                         givenBid(Bid.builder().price(BigDecimal.ONE).build())))));
 
@@ -847,7 +849,7 @@ public class ExchangeServiceTest extends VertxTest {
                 exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
 
         // then
-        verify(httpBidderRequester, times(2)).requestBids(any(), any(), any());
+        verify(httpBidderRequester, times(2)).requestBids(any(), any(), any(), anyBoolean());
         assertThat(bidResponse.getSeatbid()).hasSize(2)
                 .extracting(seatBid -> seatBid.getBid().size()).containsOnly(1, 1);
     }
@@ -912,6 +914,70 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(
                 givenSingleImp(doubleMap("bidder1", 1, "bidder2", 2)),
                 builder -> builder.test(1));
+
+        // when
+        final BidResponse bidResponse =
+                exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null).result();
+
+        // then
+        final ExtBidResponse ext = mapper.treeToValue(bidResponse.getExt(), ExtBidResponse.class);
+        assertThat(ext.getDebug()).isNotNull();
+        assertThat(ext.getDebug().getHttpcalls()).hasSize(2).containsOnly(
+                entry("bidder1", singletonList(ExtHttpCall.builder()
+                        .uri("bidder1_uri1")
+                        .requestbody("bidder1_requestBody1")
+                        .status(200)
+                        .responsebody("bidder1_responseBody1")
+                        .build())),
+                entry("bidder2", asList(
+                        ExtHttpCall.builder()
+                                .uri("bidder2_uri1")
+                                .requestbody("bidder2_requestBody1")
+                                .status(200)
+                                .responsebody("bidder2_responseBody1")
+                                .build(),
+                        ExtHttpCall.builder()
+                                .uri("bidder2_uri2")
+                                .requestbody("bidder2_requestBody2")
+                                .status(404)
+                                .responsebody("bidder2_responseBody2")
+                                .build())));
+        assertThat(ext.getDebug().getResolvedrequest()).isEqualTo(bidRequest);
+    }
+
+    @Test
+    public void shouldPopulateBidResponseDebugExtensionIfExtPrebidDebugIsTrue() throws JsonProcessingException {
+        // given
+        givenBidder("bidder1", mock(Bidder.class), BidderSeatBid.of(
+                singletonList(givenBid(Bid.builder().price(BigDecimal.ONE).build())),
+                singletonList(ExtHttpCall.builder()
+                        .uri("bidder1_uri1")
+                        .requestbody("bidder1_requestBody1")
+                        .status(200)
+                        .responsebody("bidder1_responseBody1")
+                        .build()),
+                emptyList()));
+        givenBidder("bidder2", mock(Bidder.class), BidderSeatBid.of(
+                singletonList(givenBid(Bid.builder().price(BigDecimal.ONE).build())),
+                asList(
+                        ExtHttpCall.builder()
+                                .uri("bidder2_uri1")
+                                .requestbody("bidder2_requestBody1")
+                                .status(200)
+                                .responsebody("bidder2_responseBody1")
+                                .build(),
+                        ExtHttpCall.builder()
+                                .uri("bidder2_uri2")
+                                .requestbody("bidder2_requestBody2")
+                                .status(404)
+                                .responsebody("bidder2_responseBody2")
+                                .build()),
+                emptyList()));
+
+        final BidRequest bidRequest = givenBidRequest(
+                givenSingleImp(doubleMap("bidder1", 1, "bidder2", 2)),
+                builder -> builder.ext(
+                        mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder().debug(true).build()))));
 
         // when
         final BidResponse bidResponse =
@@ -1560,7 +1626,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester, times(2)).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester, times(2)).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
         final List<BidRequest> capturedBidRequests = bidRequestCaptor.getAllValues();
 
         assertThat(capturedBidRequests)
@@ -1591,7 +1657,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester, times(2)).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester, times(2)).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
         final List<BidRequest> capturedBidRequests = bidRequestCaptor.getAllValues();
 
         assertThat(capturedBidRequests)
@@ -1621,7 +1687,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester, times(2)).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester, times(2)).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
         final List<BidRequest> capturedBidRequests = bidRequestCaptor.getAllValues();
 
         assertThat(capturedBidRequests)
@@ -1676,7 +1742,7 @@ public class ExchangeServiceTest extends VertxTest {
         exchangeService.holdAuction(bidRequest, uidsCookie, timeout, metricsContext, null);
 
         // then
-        verify(httpBidderRequester).requestBids(any(), any(), same(timeout));
+        verify(httpBidderRequester).requestBids(any(), any(), same(timeout), anyBoolean());
     }
 
     @Test
@@ -1706,7 +1772,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         // then
         final ArgumentCaptor<Timeout> timeoutCaptor = ArgumentCaptor.forClass(Timeout.class);
-        verify(httpBidderRequester).requestBids(any(), any(), timeoutCaptor.capture());
+        verify(httpBidderRequester).requestBids(any(), any(), timeoutCaptor.capture(), anyBoolean());
         assertThat(timeoutCaptor.getValue().remaining()).isEqualTo(400L);
         verify(cacheService).cacheBidsOpenrtb(anyList(), anyList(), any(), any(), same(timeout));
     }
@@ -1927,7 +1993,7 @@ public class ExchangeServiceTest extends VertxTest {
         // given
         given(bidderCatalog.isValidName(anyString())).willReturn(true);
 
-        given(httpBidderRequester.requestBids(any(), any(), any()))
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(asList(
                         BidderBid.of(Bid.builder().price(TEN).build(), BidType.banner, "EUR"),
                         BidderBid.of(Bid.builder().price(TEN).build(), BidType.banner, "USD")))));
@@ -2062,7 +2128,7 @@ public class ExchangeServiceTest extends VertxTest {
     @Test
     public void shouldIncrementCommonMetrics() {
         // given
-        given(httpBidderRequester.requestBids(any(), any(), any()))
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(singletonList(
                         givenBid(Bid.builder().price(TEN).build())))));
 
@@ -2101,7 +2167,7 @@ public class ExchangeServiceTest extends VertxTest {
     public void shouldUseEmptyStringIfPublisherIdIsNull() {
         // given
         given(bidderCatalog.isValidName(anyString())).willReturn(true);
-        given(httpBidderRequester.requestBids(any(), any(), any()))
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(singletonList(
                         givenBid(Bid.builder().price(TEN).build())))));
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("somebidder", 1)),
@@ -2117,7 +2183,7 @@ public class ExchangeServiceTest extends VertxTest {
     @Test
     public void shouldIncrementNoBidRequestsMetric() {
         // given
-        given(httpBidderRequester.requestBids(any(), any(), any()))
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(givenSeatBid(emptyList())));
 
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("somebidder", 1)),
@@ -2133,7 +2199,7 @@ public class ExchangeServiceTest extends VertxTest {
     @Test
     public void shouldIncrementGotBidsAndErrorMetricsIfBidderReturnsBidAndDifferentErrors() {
         // given
-        given(httpBidderRequester.requestBids(any(), any(), any()))
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean()))
                 .willReturn(Future.succeededFuture(BidderSeatBid.of(
                         singletonList(givenBid(Bid.builder().price(TEN).build())),
                         emptyList(),
@@ -2349,7 +2415,7 @@ public class ExchangeServiceTest extends VertxTest {
 
     private BidRequest captureBidRequest() {
         final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
-        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any());
+        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
         return bidRequestCaptor.getValue();
     }
 
@@ -2372,13 +2438,15 @@ public class ExchangeServiceTest extends VertxTest {
 
     private void givenBidder(BidderSeatBid response) {
         given(bidderCatalog.isValidName(anyString())).willReturn(true);
-        given(httpBidderRequester.requestBids(any(), any(), any())).willReturn(Future.succeededFuture(response));
+        given(httpBidderRequester.requestBids(any(), any(), any(), anyBoolean())).willReturn(
+                Future.succeededFuture(response));
     }
 
     private void givenBidder(String bidderName, Bidder<?> bidder, BidderSeatBid response) {
         given(bidderCatalog.isValidName(eq(bidderName))).willReturn(true);
         doReturn(bidder).when(bidderCatalog).bidderByName(eq(bidderName));
-        given(httpBidderRequester.requestBids(same(bidder), any(), any())).willReturn(Future.succeededFuture(response));
+        given(httpBidderRequester.requestBids(same(bidder), any(), any(), anyBoolean())).willReturn(
+                Future.succeededFuture(response));
     }
 
     private static BidderSeatBid givenSeatBid(List<BidderBid> bids) {

--- a/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
+++ b/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
@@ -12,6 +12,7 @@ import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.prebid.server.VertxTest;
 import org.prebid.server.bidder.model.BidderBid;
 import org.prebid.server.bidder.model.BidderError;
 import org.prebid.server.bidder.model.BidderSeatBid;
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class HttpBidderRequesterTest {
+public class HttpBidderRequesterTest extends VertxTest {
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -76,7 +77,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, false).result();
 
         // then
         assertThat(bidderSeatBid.getBids()).isEmpty();
@@ -94,7 +95,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, false).result();
 
         // then
         assertThat(bidderSeatBid.getBids()).isEmpty();
@@ -121,7 +122,7 @@ public class HttpBidderRequesterTest {
         headers.add("header2", "value2");
 
         // when
-        bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout);
+        bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, false);
 
         // then
         verify(httpClient).request(eq(HttpMethod.POST), eq("uri"), eq(headers), eq("requestBody"), eq(500L));
@@ -140,7 +141,7 @@ public class HttpBidderRequesterTest {
                 emptyList()));
 
         // when
-        bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout);
+        bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, false);
 
         // then
         verify(httpClient).request(any(), anyString(), any(), isNull(), anyLong());
@@ -167,7 +168,7 @@ public class HttpBidderRequesterTest {
                 emptyList()));
 
         // when
-        bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout);
+        bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, false);
 
         // then
         verify(httpClient, times(2)).request(any(), anyString(), any(), any(), anyLong());
@@ -192,14 +193,14 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, false).result();
 
         // then
         assertThat(bidderSeatBid.getBids()).containsOnlyElementsOf(bids);
     }
 
     @Test
-    public void shouldReturnFullDebugInfoIfTestFlagIsOn() {
+    public void shouldReturnFullDebugInfoIfDebugEnabled() {
         // given
         given(bidder.makeHttpRequests(any())).willReturn(Result.of(asList(
                 HttpRequest.<BidRequest>builder()
@@ -224,7 +225,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().test(1).build(), timeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, true).result();
 
         // then
         assertThat(bidderSeatBid.getHttpCalls()).hasSize(2).containsOnly(
@@ -235,7 +236,7 @@ public class HttpBidderRequesterTest {
     }
 
     @Test
-    public void shouldReturnPartialDebugInfoIfTestFlagIsOnAndGlobalTimeoutAlreadyExpired() {
+    public void shouldReturnPartialDebugInfoIfDebugEnabledAndGlobalTimeoutAlreadyExpired() {
         // given
         given(bidder.makeHttpRequests(any())).willReturn(Result.of(singletonList(
                 HttpRequest.<BidRequest>builder()
@@ -248,7 +249,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().test(1).build(), expiredTimeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), expiredTimeout, true).result();
 
         // then
         assertThat(bidderSeatBid.getHttpCalls()).hasSize(1).containsOnly(
@@ -256,7 +257,7 @@ public class HttpBidderRequesterTest {
     }
 
     @Test
-    public void shouldReturnPartialDebugInfoIfTestFlagIsOnAndHttpErrorOccurs() {
+    public void shouldReturnPartialDebugInfoIfDebugEnabledAndHttpErrorOccurs() {
         // given
         given(bidder.makeHttpRequests(any())).willReturn(Result.of(singletonList(
                 HttpRequest.<BidRequest>builder()
@@ -271,7 +272,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().test(1).build(), timeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, true).result();
 
         // then
         assertThat(bidderSeatBid.getHttpCalls()).hasSize(1).containsOnly(
@@ -279,7 +280,7 @@ public class HttpBidderRequesterTest {
     }
 
     @Test
-    public void shouldReturnFullDebugInfoIfTestFlagIsOnAndErrorStatus() {
+    public void shouldReturnFullDebugInfoIfDebugEnabledAndErrorStatus() {
         // given
         given(bidder.makeHttpRequests(any())).willReturn(Result.of(singletonList(
                 HttpRequest.<BidRequest>builder()
@@ -294,7 +295,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().test(1).build(), timeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), timeout, true).result();
 
         // then
         assertThat(bidderSeatBid.getHttpCalls()).hasSize(1).containsOnly(
@@ -319,7 +320,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid =
-                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), expiredTimeout).result();
+                bidderHttpConnector.requestBids(bidder, BidRequest.builder().build(), expiredTimeout, false).result();
 
         // then
         assertThat(bidderSeatBid.getErrors()).hasSize(1)
@@ -397,7 +398,7 @@ public class HttpBidderRequesterTest {
 
         // when
         final BidderSeatBid bidderSeatBid = bidderHttpConnector
-                .requestBids(bidder, BidRequest.builder().test(1).build(), timeout)
+                .requestBids(bidder, BidRequest.builder().test(1).build(), timeout, false)
                 .result();
 
         // then

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -61,7 +61,10 @@ import java.util.LinkedHashSet;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;


### PR DESCRIPTION
CL:
- The `request.test` flag is replaced with `request.ext.prebid.debug`
- For backward compatibility on transition period `request.test` left working as well.