### PR TITLE
Add configurable timeout for currency conversion

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -71,8 +71,9 @@ But feel free to add additional bidder's specific options.
 
 ## Currency Converter
 - `currency-converter.enabled` - if equals to `true` the currency conversion service will be enabled to fetch updated rates and convert bid currencies. Also enables `/currency-rates` endpoint on admin port.
-- `currency-converter.refresh-period-ms` - default refresh period for currency rates updates.
 - `currency-converter.url` - the url for Prebid.org’s currency file. [More details](http://prebid.org/dev-docs/modules/currency.html)
+- `currency-converter.default-timeout-ms` - default operation timeout for fetching currency rates.
+- `currency-converter.refresh-period-ms` - default refresh period for currency rates updates.
 
 ## Metrics
 - `metrics.metricType` - set the type of metric counter for [Dropwizard Metrics](http://metrics.dropwizard.io). Can be `flushingCounter` (default), `counter` or `meter`.

--- a/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
+++ b/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
@@ -30,7 +30,7 @@ public class CurrencyConversionService {
     private static final Logger logger = LoggerFactory.getLogger(CurrencyConversionService.class);
 
     private static final String DEFAULT_BID_CURRENCY = "USD";
-    //this number is chosen because of PriceGranularities default precision value of 2 + 1 for better accuracy
+    // This number is chosen because of PriceGranularities default precision value of 2 + 1 for better accuracy
     private static final int DEFAULT_PRICE_PRECISION = 3;
 
     private final String currencyServerUrl;
@@ -39,7 +39,7 @@ public class CurrencyConversionService {
     private final Vertx vertx;
     private final HttpClient httpClient;
 
-    private Map<String, Map<String, BigDecimal>> latestCurrencyRates = null;
+    private Map<String, Map<String, BigDecimal>> latestCurrencyRates;
     private ZonedDateTime lastUpdated;
 
     public CurrencyConversionService(String currencyServerUrl, long defaultTimeout, long refreshPeriod, Vertx vertx,
@@ -61,7 +61,7 @@ public class CurrencyConversionService {
      * Must be called on Vertx event loop thread.
      */
     public void initialize() {
-        vertx.setPeriodic(refreshPeriod, aLong -> populatesLatestCurrencyRates());
+        vertx.setPeriodic(refreshPeriod, ignored -> populatesLatestCurrencyRates());
         populatesLatestCurrencyRates();
     }
 
@@ -128,10 +128,8 @@ public class CurrencyConversionService {
      * Converts price from bidCurrency to adServerCurrency using rates defined in request or if absent, from
      * latest currency rates. Throws {@link PreBidException} in case conversion is not possible.
      */
-    public BigDecimal convertCurrency(BigDecimal price,
-                                      Map<String, Map<String, BigDecimal>> requestCurrencyRates,
-                                      String adServerCurrency,
-                                      String bidCurrency) {
+    public BigDecimal convertCurrency(BigDecimal price, Map<String, Map<String, BigDecimal>> requestCurrencyRates,
+                                      String adServerCurrency, String bidCurrency) {
         // use Default USD currency if bidder left this field empty. After, when bidder will implement multi currency
         // support it will be changed to throwing PrebidException.
         final String effectiveBidCurrency = bidCurrency != null ? bidCurrency : DEFAULT_BID_CURRENCY;

--- a/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
+++ b/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
@@ -33,6 +33,7 @@ public class CurrencyConversionService {
     //this number is chosen because of PriceGranularities default precision value of 2 + 1 for better accuracy
     private static final int DEFAULT_PRICE_PRECISION = 3;
 
+    private final long defaultTimeout;
     private final String currencyServerUrl;
     private final long refreshPeriod;
     private final Vertx vertx;
@@ -41,7 +42,9 @@ public class CurrencyConversionService {
     private Map<String, Map<String, BigDecimal>> latestCurrencyRates = null;
     private ZonedDateTime lastUpdated;
 
-    public CurrencyConversionService(String currencyServerUrl, long refreshPeriod, Vertx vertx, HttpClient httpClient) {
+    public CurrencyConversionService(String currencyServerUrl, long defaultTimeout, long refreshPeriod, Vertx vertx,
+                                     HttpClient httpClient) {
+        this.defaultTimeout = defaultTimeout;
         this.currencyServerUrl = HttpUtil.validateUrl(Objects.requireNonNull(currencyServerUrl));
         this.refreshPeriod = validateRefreshPeriod(refreshPeriod);
         this.vertx = Objects.requireNonNull(vertx);
@@ -76,7 +79,7 @@ public class CurrencyConversionService {
      * Updates latest currency rates by making a call to currency server.
      */
     private void populatesLatestCurrencyRates() {
-        httpClient.get(currencyServerUrl, 2000L)
+        httpClient.get(currencyServerUrl, defaultTimeout)
                 .compose(CurrencyConversionService::processResponse)
                 .compose(this::updateCurrencyRates)
                 .recover(CurrencyConversionService::failResponse);

--- a/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
+++ b/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
@@ -33,8 +33,8 @@ public class CurrencyConversionService {
     //this number is chosen because of PriceGranularities default precision value of 2 + 1 for better accuracy
     private static final int DEFAULT_PRICE_PRECISION = 3;
 
-    private final long defaultTimeout;
     private final String currencyServerUrl;
+    private final long defaultTimeout;
     private final long refreshPeriod;
     private final Vertx vertx;
     private final HttpClient httpClient;
@@ -44,8 +44,8 @@ public class CurrencyConversionService {
 
     public CurrencyConversionService(String currencyServerUrl, long defaultTimeout, long refreshPeriod, Vertx vertx,
                                      HttpClient httpClient) {
-        this.defaultTimeout = defaultTimeout;
         this.currencyServerUrl = HttpUtil.validateUrl(Objects.requireNonNull(currencyServerUrl));
+        this.defaultTimeout = defaultTimeout;
         this.refreshPeriod = validateRefreshPeriod(refreshPeriod);
         this.vertx = Objects.requireNonNull(vertx);
         this.httpClient = Objects.requireNonNull(httpClient);

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -381,12 +381,13 @@ public class ServiceConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "currency-converter", name = "enabled", havingValue = "true")
     CurrencyConversionService currencyConversionService(
-            @Value("${currency-converter.refresh-period-ms}") long refreshPeriod,
             @Value("${currency-converter.url}") String currencyServerUrl,
+            @Value("${currency-converter.default-timeout-ms}") long defaultTimeout,
+            @Value("${currency-converter.refresh-period-ms}") long refreshPeriod,
             Vertx vertx,
             HttpClient httpClient) {
 
-        return new CurrencyConversionService(currencyServerUrl, refreshPeriod, vertx, httpClient);
+        return new CurrencyConversionService(currencyServerUrl, defaultTimeout, refreshPeriod, vertx, httpClient);
     }
 
     @Configuration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ cookie-sync:
 currency-converter:
   enabled: true
   url: https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json
+  default-timeout-ms: 4000
   refresh-period-ms: 900000
 metrics:
   metricType: flushingCounter

--- a/src/test/java/org/prebid/server/auction/CurrencyConversionServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/CurrencyConversionServiceTest.java
@@ -153,7 +153,8 @@ public class CurrencyConversionServiceTest extends VertxTest {
         requestConversionRates.put(EUR, singletonMap(USD, BigDecimal.valueOf(0.5)));
 
         // when
-        final BigDecimal price = currencyService.convertCurrency(new BigDecimal("1.23"), requestConversionRates, EUR, USD);
+        final BigDecimal price = currencyService.convertCurrency(new BigDecimal("1.23"), requestConversionRates, EUR,
+                USD);
 
         // then
         assertThat(price.compareTo(BigDecimal.valueOf(2.460))).isEqualTo(0);
@@ -257,7 +258,7 @@ public class CurrencyConversionServiceTest extends VertxTest {
     private static CurrencyConversionService createAndInitService(String url, long refreshPeriod, Vertx vertx,
                                                                   HttpClient httpClient) {
         final CurrencyConversionService currencyService =
-                new CurrencyConversionService(url, refreshPeriod, vertx, httpClient);
+                new CurrencyConversionService(url, 1000L, refreshPeriod, vertx, httpClient);
         currencyService.initialize();
         return currencyService;
     }


### PR DESCRIPTION
CL:
- Added `currency-converter.default-timeout-ms` config property.