### PR TITLE
Fix currency rates handler test in application test

### DIFF
--- a/src/test/java/org/prebid/server/auction/CpmRangeTest.java
+++ b/src/test/java/org/prebid/server/auction/CpmRangeTest.java
@@ -21,8 +21,9 @@ public class CpmRangeTest {
     @Test
     public void fromCpmShouldReturnPriceWithCorrectPrecision() {
         // given
-        final PriceGranularity priceGranularity = PriceGranularity.createFromExtPriceGranularity(ExtPriceGranularity.of(1, singletonList(
-                ExtGranularityRange.of(BigDecimal.valueOf(10), BigDecimal.valueOf(0.1)))));
+        final PriceGranularity priceGranularity = PriceGranularity.createFromExtPriceGranularity(
+                ExtPriceGranularity.of(1, singletonList(
+                        ExtGranularityRange.of(BigDecimal.valueOf(10), BigDecimal.valueOf(0.1)))));
 
         // when
         final String cpm = CpmRange.fromCpm(BigDecimal.valueOf(5.1245), priceGranularity);
@@ -109,8 +110,9 @@ public class CpmRangeTest {
     @Test
     public void fromCpmAsNumberShouldReturnExpectedResult() {
         // given
-        final PriceGranularity priceGranularity = PriceGranularity.createFromExtPriceGranularity(ExtPriceGranularity.of(null,
-                singletonList(ExtGranularityRange.of(BigDecimal.valueOf(3), BigDecimal.valueOf(0.01)))));
+        final PriceGranularity priceGranularity = PriceGranularity.createFromExtPriceGranularity(
+                ExtPriceGranularity.of(null,
+                        singletonList(ExtGranularityRange.of(BigDecimal.valueOf(3), BigDecimal.valueOf(0.01)))));
 
         // when
         final BigDecimal result = CpmRange.fromCpmAsNumber(BigDecimal.valueOf(2.333), priceGranularity);

--- a/src/test/java/org/prebid/server/bidder/UsersyncerTest.java
+++ b/src/test/java/org/prebid/server/bidder/UsersyncerTest.java
@@ -10,15 +10,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class UsersyncerTest {
 
     @Test
-    public void newUsersyncerShouldReturnUsersyncerWithConcatenatedExternalAndRedirectUrl(){
+    public void newUsersyncerShouldReturnUsersyncerWithConcatenatedExternalAndRedirectUrl() {
         // given, when and then
-        assertThat(new Usersyncer("rubicon", "//usersync-url", "/redicret-url", "http://localhost:8000", "redirect", true))
+        assertThat(
+                new Usersyncer("rubicon", "//usersync-url", "/redicret-url", "http://localhost:8000", "redirect", true))
                 .extracting(Usersyncer::getRedirectUrl)
                 .containsOnly("http://localhost:8000/redicret-url");
     }
 
     @Test
-    public void newUsersyncerShouldReturnUsersyncerWithEmptyRedirectUrlWhenItWasNotDefined(){
+    public void newUsersyncerShouldReturnUsersyncerWithEmptyRedirectUrlWhenItWasNotDefined() {
         // given, when and then
         assertThat(new Usersyncer("rubicon", "//usersync-url", null, null, "redirect", true))
                 .extracting(Usersyncer::getRedirectUrl)
@@ -26,7 +27,7 @@ public class UsersyncerTest {
     }
 
     @Test
-    public void newUsersyncerShouldValidateExtenalUrl(){
+    public void newUsersyncerShouldValidateExtenalUrl() {
         // given, when and then
         assertThatThrownBy(() -> new Usersyncer(null, "//usersync-url", "not-valid-url", null, "redirect", true))
                 .hasCauseExactlyInstanceOf(MalformedURLException.class)

--- a/src/test/java/org/prebid/server/bidder/adtelligent/AdtelligentBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/adtelligent/AdtelligentBidderTest.java
@@ -78,10 +78,13 @@ public class AdtelligentBidderTest extends VertxTest {
                         tuple(HttpUtil.ACCEPT_HEADER.toString(), HttpHeaderValues.APPLICATION_JSON.toString()));
         assertThat(result.getValue()).extracting(HttpRequest::getBody).containsExactly(Json.mapper.writeValueAsString(
                 BidRequest.builder()
-                        .imp(singletonList(Imp.builder().banner(Banner.builder().build()).bidfloor(BigDecimal.valueOf(3))
-                                .ext(Json.mapper.valueToTree(
-                                        AdtelligentImpExt.of(ExtImpAdtelligent.of(15, 1, 2, BigDecimal.valueOf(3)))))
-                                .build()))
+                        .imp(singletonList(
+                                Imp.builder()
+                                        .banner(Banner.builder().build())
+                                        .bidfloor(BigDecimal.valueOf(3))
+                                        .ext(Json.mapper.valueToTree(AdtelligentImpExt.of(
+                                                ExtImpAdtelligent.of(15, 1, 2, BigDecimal.valueOf(3)))))
+                                        .build()))
                         .user(User.builder().ext(Json.mapper.valueToTree(ExtUser.of(
                                 null, "consent", null, null, null))).build())
                         .regs(Regs.of(0, Json.mapper.valueToTree(ExtRegs.of(1))))

--- a/src/test/java/org/prebid/server/bidder/beachfront/BeachfrontBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/beachfront/BeachfrontBidderTest.java
@@ -156,8 +156,10 @@ public class BeachfrontBidderTest extends VertxTest {
     public void makeHttpRequestsShouldReturnErrorMessageIfNoValidVideoImpInReasonOfNotValidExt() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(Imp.builder().id("impId").video(Video.builder().build()).ext(Json.mapper.createObjectNode()
-                        .put("bidder", 4))
+                .imp(singletonList(Imp.builder()
+                        .id("impId")
+                        .video(Video.builder().build())
+                        .ext(Json.mapper.createObjectNode().put("bidder", 4))
                         .build())).build();
 
         // when
@@ -391,8 +393,10 @@ public class BeachfrontBidderTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .id("request id")
-                .imp(singletonList(Imp.builder().id("impId1").bidfloor(BigDecimal.valueOf(1.0)).banner(Banner.builder().format(asList(
-                        Format.builder().w(100).h(200).build(), Format.builder().w(300).h(400).build())).build())
+                .imp(singletonList(Imp.builder().id("impId1").bidfloor(BigDecimal.valueOf(1.0)).banner(
+                        Banner.builder().format(asList(
+                                Format.builder().w(100).h(200).build(),
+                                Format.builder().w(300).h(400).build())).build())
                         .ext(Json.mapper.valueToTree(ExtPrebid.of(null, ExtImpBeachfront.of("appIdExt", 1f))))
                         .secure(1).build()))
                 .device(Device.builder().ip("127.0.0.1").model("model").os("os").dnt(5).ua("ua").build())
@@ -588,7 +592,8 @@ public class BeachfrontBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).extracting(HttpRequest::getBody).containsOnly(Json.mapper.writeValueAsString(
                 BeachfrontBannerRequest.builder().slots(singletonList(BeachfrontSlot.of(null, "appIdExt", null,
-                        singletonList(BeachfrontSize.of(null, null))))).domain("rubiconapp.com").page("appId").adapterName("BF_PREBID_S2S")
+                        singletonList(BeachfrontSize.of(null, null))))).domain("rubiconapp.com").page(
+                        "appId").adapterName("BF_PREBID_S2S")
                         .adapterVersion("0.2.2").build()));
     }
 
@@ -642,7 +647,8 @@ public class BeachfrontBidderTest extends VertxTest {
                         .build())).build())).build());
 
         final BeachfrontVideoRequest beachfrontVideoRequest = BeachfrontVideoRequest.builder()
-                .imp(singletonList(BeachfrontVideoImp.of(BeachfrontSize.of(300, 400), null, null, "impIdReq", 1))).build();
+                .imp(singletonList(
+                        BeachfrontVideoImp.of(BeachfrontSize.of(300, 400), null, null, "impIdReq", 1))).build();
 
         final BidRequest bidRequest = BidRequest.builder().id("bidRequestId")
                 .imp(singletonList(Imp.builder().video(Video.builder().build()).build())).build();
@@ -664,7 +670,8 @@ public class BeachfrontBidderTest extends VertxTest {
         final String response = mapper.writeValueAsString(BidResponse.builder().seatbid(emptyList()).build());
 
         final BeachfrontVideoRequest beachfrontVideoRequest = BeachfrontVideoRequest.builder()
-                .imp(singletonList(BeachfrontVideoImp.of(BeachfrontSize.of(300, 400), null, null, "impIdReq", 1))).build();
+                .imp(singletonList(
+                        BeachfrontVideoImp.of(BeachfrontSize.of(300, 400), null, null, "impIdReq", 1))).build();
 
         final BidRequest bidRequest = BidRequest.builder().imp(singletonList(Imp.builder().video(Video.builder()
                 .build()).build())).build();

--- a/src/test/java/org/prebid/server/bidder/brightroll/BrightrollBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/brightroll/BrightrollBidderTest.java
@@ -298,7 +298,8 @@ public class BrightrollBidderTest extends VertxTest {
                 .imp(asList(
                         Imp.builder()
                                 .banner(Banner.builder().build())
-                                .ext(Json.mapper.valueToTree(ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build(),
+                                .ext(Json.mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build(),
                         Imp.builder().id("impId2").build()))
                 .build();
 
@@ -318,7 +319,8 @@ public class BrightrollBidderTest extends VertxTest {
                 .imp(singletonList(
                         Imp.builder()
                                 .banner(Banner.builder().build())
-                                .ext(Json.mapper.valueToTree(ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
+                                .ext(Json.mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
                 .device(Device.builder().ip("192.168.0.1").language("en").dnt(1).build())
                 .build();
 
@@ -338,7 +340,8 @@ public class BrightrollBidderTest extends VertxTest {
                 .imp(singletonList(
                         Imp.builder()
                                 .banner(Banner.builder().build())
-                                .ext(Json.mapper.valueToTree(ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
+                                .ext(Json.mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
                 .device(Device.builder().ua("ua").language("en").dnt(1).build())
                 .build();
 
@@ -358,7 +361,8 @@ public class BrightrollBidderTest extends VertxTest {
                 .imp(singletonList(
                         Imp.builder()
                                 .banner(Banner.builder().build())
-                                .ext(Json.mapper.valueToTree(ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
+                                .ext(Json.mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
                 .device(Device.builder().ua("ua").ip("192.168.0.1").dnt(1).build())
                 .build();
 
@@ -378,7 +382,8 @@ public class BrightrollBidderTest extends VertxTest {
                 .imp(singletonList(
                         Imp.builder()
                                 .banner(Banner.builder().build())
-                                .ext(Json.mapper.valueToTree(ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
+                                .ext(Json.mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpBrightroll.of("publisher")))).build()))
                 .device(Device.builder().ua("ua").ip("192.168.0.1").language("en").build())
                 .build();
 

--- a/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
@@ -330,8 +330,10 @@ public class ConsumableBidderTest extends VertxTest {
                 .build();
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/conversant/ConversantBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/conversant/ConversantBidderTest.java
@@ -81,7 +81,8 @@ public class ConversantBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly(BidderError.badInput("Invalid MediaType. Conversant supports only Banner and Video. Ignoring ImpID=123"));
+                .containsOnly(BidderError.badInput(
+                        "Invalid MediaType. Conversant supports only Banner and Video. Ignoring ImpID=123"));
         assertThat(result.getValue()).hasSize(1);
     }
 
@@ -540,9 +541,10 @@ public class ConversantBidderTest extends VertxTest {
         assertThat(conversantBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer,
-                                              Function<ExtImpConversant.ExtImpConversantBuilder, ExtImpConversant.ExtImpConversantBuilder> extCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer,
+            Function<ExtImpConversant.ExtImpConversantBuilder, ExtImpConversant.ExtImpConversantBuilder> extCustomizer) {
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer, extCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/eplanning/EplanningBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/eplanning/EplanningBidderTest.java
@@ -185,7 +185,8 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
-                .containsOnly("http://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1");
+                .containsOnly(
+                        "http://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1");
     }
 
     @Test
@@ -203,8 +204,9 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
-                .containsOnly("http://eplanning.com/clientId/1/DOMAIN/ROS?ct=1&r=pbs&ncb=1&ur=http%3A%2F%2Fwww.example.com"
-                        + "&e=testadun_itco_de:1x1");
+                .containsOnly(
+                        "http://eplanning.com/clientId/1/DOMAIN/ROS?ct=1&r=pbs&ncb=1&ur=http%3A%2F%2Fwww.example.com"
+                                + "&e=testadun_itco_de:1x1");
     }
 
     @Test
@@ -336,7 +338,7 @@ public class EplanningBidderTest extends VertxTest {
                                         .build()))))));
 
         final BidRequest bidRequest = givenBidRequest(impBuilder -> impBuilder.ext(mapper.valueToTree(ExtPrebid.of(null,
-                    ExtImpEplanning.of("clientId", null)))));
+                ExtImpEplanning.of("clientId", null)))));
 
         // when
         final Result<List<BidderBid>> result = eplanningBidder.makeBids(httpCall, bidRequest);

--- a/src/test/java/org/prebid/server/bidder/gamoshi/GamoshiBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/gamoshi/GamoshiBidderTest.java
@@ -306,8 +306,10 @@ public class GamoshiBidderTest extends VertxTest {
         assertThat(gamoshiBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/gumgum/GumgumBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/gumgum/GumgumBidderTest.java
@@ -265,8 +265,10 @@ public class GumgumBidderTest extends VertxTest {
         assertThat(gumgumBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/ix/IxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/ix/IxBidderTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
@@ -81,7 +80,8 @@ public class IxBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(2)
-                .containsOnly(BidderError.badInput("Invalid MediaType. Ix supports only Banner type. Ignoring ImpID=123"),
+                .containsOnly(
+                        BidderError.badInput("Invalid MediaType. Ix supports only Banner type. Ignoring ImpID=123"),
                         BidderError.badInput("No valid impressions in the bid request"));
         assertThat(result.getValue()).isEmpty();
     }
@@ -420,8 +420,9 @@ public class IxBidderTest extends VertxTest {
         assertThat(ixBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/lifestreet/LifestreetBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/lifestreet/LifestreetBidderTest.java
@@ -62,7 +62,8 @@ public class LifestreetBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly(BidderError.badInput("Invalid MediaType. Lifestreet supports only Banner and Video. Ignoring ImpID=123"));
+                .containsOnly(BidderError.badInput(
+                        "Invalid MediaType. Lifestreet supports only Banner and Video. Ignoring ImpID=123"));
         assertThat(result.getValue()).isEmpty();
     }
 
@@ -304,8 +305,9 @@ public class LifestreetBidderTest extends VertxTest {
         assertThat(lifestreetBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/pubmatic/PubmaticAdapterTest.java
+++ b/src/test/java/org/prebid/server/bidder/pubmatic/PubmaticAdapterTest.java
@@ -408,7 +408,8 @@ public class PubmaticAdapterTest extends VertxTest {
                 .flatExtracting(r -> r.getPayload().getImp())
                 .containsOnly(
                         Imp.builder()
-                                .banner(Banner.builder().w(300).h(250).format(singletonList(Format.builder().w(480).h(320).build())).build())
+                                .banner(Banner.builder().w(300).h(250)
+                                        .format(singletonList(Format.builder().w(480).h(320).build())).build())
                                 .tagid("slot1")
                                 .video(com.iab.openrtb.request.Video.builder().w(480).h(320)
                                         .mimes(singletonList("Mime1")).playbackmethod(singletonList(1)).build())

--- a/src/test/java/org/prebid/server/bidder/pulsepoint/PulsepointBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/pulsepoint/PulsepointBidderTest.java
@@ -63,7 +63,8 @@ public class PulsepointBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1)
-                .containsOnly(BidderError.badInput("Invalid MediaType. Pulsepoint supports only Banner type. Ignoring ImpID=123"));
+                .containsOnly(BidderError.badInput(
+                        "Invalid MediaType. Pulsepoint supports only Banner type. Ignoring ImpID=123"));
         assertThat(result.getValue()).hasSize(1);
     }
 
@@ -331,8 +332,9 @@ public class PulsepointBidderTest extends VertxTest {
         assertThat(pulsepointBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/somoaudience/SomoaudienceBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/somoaudience/SomoaudienceBidderTest.java
@@ -138,11 +138,13 @@ public class SomoaudienceBidderTest extends VertxTest {
                 .ext(mapper.valueToTree(SomoaudienceReqExt.of("hb_pbs_1.0.0")))
                 .build());
         final String expectedVideoSting = mapper.writeValueAsString(BidRequest.builder()
-                .imp(singletonList(Imp.builder().video(Video.builder().build()).bidfloor(BigDecimal.valueOf(1.97)).build()))
+                .imp(singletonList(
+                        Imp.builder().video(Video.builder().build()).bidfloor(BigDecimal.valueOf(1.97)).build()))
                 .ext(mapper.valueToTree(SomoaudienceReqExt.of("hb_pbs_1.0.0")))
                 .build());
         final String expectedNativeString = mapper.writeValueAsString(BidRequest.builder()
-                .imp(singletonList(Imp.builder().xNative(Native.builder().build()).bidfloor(BigDecimal.valueOf(2.52)).build()))
+                .imp(singletonList(
+                        Imp.builder().xNative(Native.builder().build()).bidfloor(BigDecimal.valueOf(2.52)).build()))
                 .ext(mapper.valueToTree(SomoaudienceReqExt.of("hb_pbs_1.0.0")))
                 .build());
 

--- a/src/test/java/org/prebid/server/bidder/ttx/TtxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/ttx/TtxBidderTest.java
@@ -198,8 +198,10 @@ public class TtxBidderTest extends VertxTest {
         assertThat(ttxBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
@@ -127,8 +127,10 @@ public class YieldmoBidderTest extends VertxTest {
         assertThat(yieldmoBidder.extractTargeting(mapper.createObjectNode())).isEqualTo(emptyMap());
     }
 
-    private static BidRequest givenBidRequest(Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
-                                              Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+    private static BidRequest givenBidRequest(
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> bidRequestCustomizer,
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+
         return bidRequestCustomizer.apply(BidRequest.builder()
                 .imp(singletonList(givenImp(impCustomizer))))
                 .build();

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -222,7 +222,8 @@ public class CacheServiceTest extends VertxTest {
         givenHttpClientReturnsResponse(200, null);
 
         cacheService = new CacheService(applicationSettings, mediaTypeCacheTtl, httpClient,
-                new URL("https://cache-service-host:8888/cache"), "https://cache-service-host:8080/cache?uuid=%PBS_CACHE_UUID%");
+                new URL("https://cache-service-host:8888/cache"),
+                "https://cache-service-host:8080/cache?uuid=%PBS_CACHE_UUID%");
 
         // when
         cacheService.cacheBids(singleBidList(), timeout);
@@ -469,7 +470,7 @@ public class CacheServiceTest extends VertxTest {
         // given
         cacheService = new CacheService(applicationSettings, CacheTtl.of(10, null), httpClient,
                 new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=%PBS_CACHE_UUID%");
-        given(applicationSettings.getAccountById(anyString(),any()))
+        given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.failedFuture(new PreBidException("Not Found")));
 
         givenHttpClientReturnsResponse(200, null);

--- a/src/test/java/org/prebid/server/geolocation/CircuitBreakerSecuredGeoLocationServiceTest.java
+++ b/src/test/java/org/prebid/server/geolocation/CircuitBreakerSecuredGeoLocationServiceTest.java
@@ -218,11 +218,11 @@ public class CircuitBreakerSecuredGeoLocationServiceTest {
     }
 
     private void doWaitForOpeningInterval(TestContext context) {
-        doWait(context, 200L);
+        doWait(context, 150L);
     }
 
     private void doWaitForClosingInterval(TestContext context) {
-        doWait(context, 300L);
+        doWait(context, 250L);
     }
 
     private void doWait(TestContext context, long timeout) {

--- a/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
@@ -56,6 +56,7 @@ public class NotificationEventHandlerTest extends VertxTest {
         given(httpRequest.headers()).willReturn(new CaseInsensitiveHeaders());
         given(httpResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).willReturn(httpResponse);
         given(httpResponse.setStatusCode(anyInt())).willReturn(httpResponse);
+
         notificationHandler = NotificationEventHandler.create(analyticsReporter);
     }
 
@@ -106,7 +107,8 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldReturnBadRequestWhenBidderWasNotDefined() throws JsonProcessingException {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "id"));
+        given(httpRequest.params())
+                .willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "id"));
 
         // when
         notificationHandler.handle(routingContext);
@@ -120,8 +122,9 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldPassEventObjectToAnalyticReporter() throws JsonProcessingException {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
-                .add("bidder", "rubicon"));
+        given(httpRequest.params())
+                .willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
+                        .add("bidder", "rubicon"));
 
         // when
         notificationHandler.handle(routingContext);
@@ -133,8 +136,9 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldRespondWithBadRequestWhenFormatParameterIsNotJPGOrPNG() throws JsonProcessingException {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
-                .add("bidder", "rubicon").add("format", "invalid"));
+        given(httpRequest.params())
+                .willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
+                        .add("bidder", "rubicon").add("format", "invalid"));
 
         // when
         notificationHandler.handle(routingContext);
@@ -148,8 +152,9 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldRespondWithPixelTrackingPngByteAndContentTypePngHeader() throws IOException {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
-                .add("bidder", "rubicon").add("format", "png"));
+        given(httpRequest.params())
+                .willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
+                        .add("bidder", "rubicon").add("format", "png"));
 
         // when
         notificationHandler.handle(routingContext);
@@ -165,8 +170,9 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldRespondWithPixelTrackingJpgByteAndContentTypeJpgHeader() throws IOException {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
-                .add("bidder", "rubicon").add("format", "jpg"));
+        given(httpRequest.params())
+                .willReturn(MultiMap.caseInsensitiveMultiMap().add("type", "win").add("bidid", "bidId")
+                        .add("bidder", "rubicon").add("format", "jpg"));
 
         // when
         notificationHandler.handle(routingContext);

--- a/src/test/java/org/prebid/server/it/AdformTest.java
+++ b/src/test/java/org/prebid/server/it/AdformTest.java
@@ -1,0 +1,135 @@
+package org.prebid.server.it;
+
+import io.restassured.response.Response;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.restassured.RestAssured.given;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+public class AdformTest extends IntegrationTest {
+
+    @Test
+    public void openrtb2AuctionShouldRespondWithBidsFromAdform() throws IOException, JSONException {
+        // given
+        // adform bid response for imp 12
+        wireMockRule.stubFor(get(urlPathEqualTo("/adform-exchange"))
+                .withQueryParam("CC", equalTo("1"))
+                .withQueryParam("rp", equalTo("4"))
+                .withQueryParam("fd", equalTo("1"))
+                .withQueryParam("stid", equalTo("tid"))
+                .withQueryParam("pt", equalTo("gross"))
+                .withQueryParam("ip", equalTo("192.168.244.1"))
+                .withQueryParam("adid", equalTo("ifaId"))
+                .withQueryParam("gdpr", equalTo("0"))
+                .withQueryParam("gdpr_consent", equalTo("consentValue"))
+                // bWlkPTE1JnJjdXI9VVNE is Base64 encoded "mid=15&rcur=USD"
+                .withQueryParam("bWlkPTE1JnJjdXI9VVNE", equalTo(""))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json;charset=utf-8"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("User-Agent", equalTo("userAgent"))
+                .withHeader("X-Request-Agent", equalTo("PrebidAdapter 0.1.3"))
+                .withHeader("X-Forwarded-For", equalTo("192.168.244.1"))
+                .withHeader("Cookie", equalTo(
+                        "uid=AF-UID;DigiTrust.v1.identity="
+                                // Base 64 encoded {"id":"id","version":1,"keyv":123,"privacy":{"optout":false}}
+                                + "eyJpZCI6ImlkIiwidmVyc2lvbiI6MSwia2V5diI6MTIzLCJwcml2YWN5Ijp7Im9wdG91dCI6ZmFsc2V9fQ"))
+                .withRequestBody(equalTo(""))
+                .willReturn(aResponse().withBody(jsonFrom("openrtb2/adform/test-adform-bid-response-1.json"))));
+
+        // pre-bid cache
+        wireMockRule.stubFor(post(urlPathEqualTo("/cache"))
+                .withRequestBody(equalToJson(jsonFrom("openrtb2/adform/test-cache-adform-request.json")))
+                .willReturn(aResponse().withBody(jsonFrom("openrtb2/adform/test-cache-adform-response.json"))));
+
+        // when
+        final Response response = given(spec)
+                .header("Referer", "http://www.example.com")
+                .header("X-Forwarded-For", "192.168.244.1")
+                .header("User-Agent", "userAgent")
+                .header("Origin", "http://www.example.com")
+                // this uids cookie value stands for {"uids":{"adform":"AF-UID"}}
+                .cookie("uids", "eyJ1aWRzIjp7ImFkZm9ybSI6IkFGLVVJRCJ9fQ==")
+                .body(jsonFrom("openrtb2/adform/test-auction-adform-request.json"))
+                .post("/openrtb2/auction");
+
+        // then
+        final String expectedAuctionResponse = openrtbAuctionResponseFrom(
+                "openrtb2/adform/test-auction-adform-response.json",
+                response, singletonList("adform"));
+
+        JSONAssert.assertEquals(expectedAuctionResponse, response.asString(), JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void auctionShouldRespondWithBidsFromAdform() throws IOException {
+        // given
+        // adform bid response for ad unit 12
+        wireMockRule.stubFor(get(urlPathEqualTo("/adform-exchange"))
+                .withQueryParam("CC", equalTo("1"))
+                .withQueryParam("rp", equalTo("4"))
+                .withQueryParam("fd", equalTo("1"))
+                .withQueryParam("stid", equalTo("tid"))
+                .withQueryParam("ip", equalTo("192.168.244.1"))
+                .withQueryParam("adid", equalTo("ifaId"))
+                .withQueryParam("gdpr", equalTo("1"))
+                .withQueryParam("gdpr_consent", equalTo("consent1"))
+                .withQueryParam("pt", equalTo("gross"))
+                // bWlkPTE1JnJjdXI9VVNE is Base64 encoded "mid=15&rcur=USD"
+                .withQueryParam("bWlkPTE1JnJjdXI9VVNE", equalTo(""))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json;charset=utf-8"))
+                .withHeader("Accept", equalTo("application/json"))
+                .withHeader("User-Agent", equalTo("userAgent"))
+                .withHeader("X-Request-Agent", equalTo("PrebidAdapter 0.1.3"))
+                .withHeader("X-Forwarded-For", equalTo("192.168.244.1"))
+                .withHeader("Cookie", equalTo("uid=AF-UID;DigiTrust.v1.identity"
+                        //{"id":"id","version":1,"keyv":123,"privacy":{"optout":true}}
+                        + "=eyJpZCI6ImlkIiwidmVyc2lvbiI6MSwia2V5diI6MTIzLCJwcml2YWN5Ijp7Im9wdG91dCI6dHJ1ZX19"))
+                .withRequestBody(equalTo(""))
+                .willReturn(aResponse().withBody(jsonFrom("auction/adform/test-adform-bid-response-1.json"))));
+
+        // pre-bid cache
+        wireMockRule.stubFor(post(urlPathEqualTo("/cache"))
+                .withRequestBody(equalToJson(jsonFrom("auction/adform/test-cache-adform-request.json")))
+                .willReturn(aResponse().withBody(jsonFrom("auction/adform/test-cache-adform-response.json"))));
+
+        // when
+        final Response response = given(spec)
+                .header("Referer", "http://www.example.com")
+                .header("X-Forwarded-For", "192.168.244.1")
+                .header("User-Agent", "userAgent")
+                .header("Origin", "http://www.example.com")
+                //this uids cookie value stands for {"uids":{"adform":"AF-UID"}}
+                .cookie("uids", "eyJ1aWRzIjp7ImFkZm9ybSI6IkFGLVVJRCJ9fQ==")
+                .queryParam("debug", "1")
+                .body(jsonFrom("auction/adform/test-auction-adform-request.json"))
+                .post("/auction");
+
+        // then
+        assertThat(response.header("Cache-Control")).isEqualTo("no-cache, no-store, must-revalidate");
+        assertThat(response.header("Pragma")).isEqualTo("no-cache");
+        assertThat(response.header("Expires")).isEqualTo("0");
+        assertThat(response.header("Access-Control-Allow-Credentials")).isEqualTo("true");
+        assertThat(response.header("Access-Control-Allow-Origin")).isEqualTo("http://www.example.com");
+
+        final String expectedAuctionResponse = legacyAuctionResponseFrom(
+                "auction/adform/test-auction-adform-response.json",
+                response, singletonList("adform"));
+        assertThat(response.asString()).isEqualTo(expectedAuctionResponse);
+    }
+}

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -14,6 +14,7 @@ import io.restassured.internal.mapping.Jackson2Mapper;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import org.hamcrest.Matchers;
@@ -47,7 +48,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.restassured.RestAssured.given;
@@ -73,58 +73,6 @@ public class ApplicationTest extends IntegrationTest {
             .setConfig(RestAssuredConfig.config()
                     .objectMapperConfig(new ObjectMapperConfig(new Jackson2Mapper((aClass, s) -> mapper))))
             .build();
-
-    @Test
-    public void openrtb2AuctionShouldRespondWithBidsFromAdform() throws IOException, JSONException {
-        // given
-        // adform bid response for imp 12
-        wireMockRule.stubFor(get(urlPathEqualTo("/adform-exchange"))
-                .withQueryParam("CC", equalTo("1"))
-                .withQueryParam("rp", equalTo("4"))
-                .withQueryParam("fd", equalTo("1"))
-                .withQueryParam("stid", equalTo("tid"))
-                .withQueryParam("pt", equalTo("gross"))
-                .withQueryParam("ip", equalTo("192.168.244.1"))
-                .withQueryParam("adid", equalTo("ifaId"))
-                .withQueryParam("gdpr", equalTo("0"))
-                .withQueryParam("gdpr_consent", equalTo("consentValue"))
-                // bWlkPTE1JnJjdXI9VVNE is Base64 encoded "mid=15&rcur=USD"
-                .withQueryParam("bWlkPTE1JnJjdXI9VVNE", equalTo(""))
-                .withHeader("Content-Type", equalToIgnoreCase("application/json;charset=utf-8"))
-                .withHeader("Accept", equalTo("application/json"))
-                .withHeader("User-Agent", equalTo("userAgent"))
-                .withHeader("X-Request-Agent", equalTo("PrebidAdapter 0.1.3"))
-                .withHeader("X-Forwarded-For", equalTo("192.168.244.1"))
-                .withHeader("Cookie", equalTo(
-                        "uid=AF-UID;DigiTrust.v1.identity="
-                                // Base 64 encoded {"id":"id","version":1,"keyv":123,"privacy":{"optout":false}}
-                                + "eyJpZCI6ImlkIiwidmVyc2lvbiI6MSwia2V5diI6MTIzLCJwcml2YWN5Ijp7Im9wdG91dCI6ZmFsc2V9fQ"))
-                .withRequestBody(equalTo(""))
-                .willReturn(aResponse().withBody(jsonFrom("openrtb2/adform/test-adform-bid-response-1.json"))));
-
-        // pre-bid cache
-        wireMockRule.stubFor(post(urlPathEqualTo("/cache"))
-                .withRequestBody(equalToJson(jsonFrom("openrtb2/adform/test-cache-adform-request.json")))
-                .willReturn(aResponse().withBody(jsonFrom("openrtb2/adform/test-cache-adform-response.json"))));
-
-        // when
-        final Response response = given(spec)
-                .header("Referer", "http://www.example.com")
-                .header("X-Forwarded-For", "192.168.244.1")
-                .header("User-Agent", "userAgent")
-                .header("Origin", "http://www.example.com")
-                // this uids cookie value stands for {"uids":{"adform":"AF-UID"}}
-                .cookie("uids", "eyJ1aWRzIjp7ImFkZm9ybSI6IkFGLVVJRCJ9fQ==")
-                .body(jsonFrom("openrtb2/adform/test-auction-adform-request.json"))
-                .post("/openrtb2/auction");
-
-        // then
-        final String expectedAuctionResponse = openrtbAuctionResponseFrom(
-                "openrtb2/adform/test-auction-adform-response.json",
-                response, singletonList(ADFORM));
-
-        JSONAssert.assertEquals(expectedAuctionResponse, response.asString(), JSONCompareMode.NON_EXTENSIBLE);
-    }
 
     @Test
     public void openrtb2AuctionShouldRespondWithBidsFromRubiconAndAppnexus() throws IOException, JSONException {
@@ -187,49 +135,6 @@ public class ApplicationTest extends IntegrationTest {
     }
 
     @Test
-    public void ampShouldReturnTargeting() throws IOException, JSONException {
-        // given
-        // rubicon exchange
-        wireMockRule.stubFor(post(urlPathEqualTo("/rubicon-exchange"))
-                .withRequestBody(equalToJson(jsonFrom("amp/test-rubicon-bid-request.json")))
-                .willReturn(aResponse().withBody(jsonFrom("amp/test-rubicon-bid-response.json"))));
-
-        // appnexus exchange
-        wireMockRule.stubFor(post(urlPathEqualTo("/appnexus-exchange"))
-                .withRequestBody(equalToJson(jsonFrom("amp/test-appnexus-bid-request.json")))
-                .willReturn(aResponse().withBody(jsonFrom("amp/test-appnexus-bid-response.json"))));
-
-        // pre-bid cache
-        wireMockRule.stubFor(post(urlPathEqualTo("/cache"))
-                .withRequestBody(equalToJson(jsonFrom("amp/test-cache-request.json"), true, false))
-                .willReturn(aResponse()
-                        .withTransformers("cache-response-transformer")
-                        .withTransformerParameter("matcherName", "amp/test-cache-matcher-amp.json")
-                ));
-
-        // when
-        final Response response = given(spec)
-                .header("Referer", "http://www.example.com")
-                .header("X-Forwarded-For", "192.168.244.1")
-                .header("User-Agent", "userAgent")
-                .header("Origin", "http://www.example.com")
-                // this uids cookie value stands for {"uids":{"rubicon":"J5VLCWQP-26-CWFT"}}
-                .cookie("uids", "eyJ1aWRzIjp7InJ1Ymljb24iOiJKNVZMQ1dRUC0yNi1DV0ZUIn19")
-                .when()
-                .get("/openrtb2/amp" +
-                        "?tag_id=test-amp-stored-request" +
-                        "&ow=980" +
-                        "&oh=120" +
-                        "&timeout=10000000" +
-                        "&slot=overwrite-tagId" +
-                        "&curl=https%3A%2F%2Fgoogle.com");
-
-        // then
-        JSONAssert.assertEquals(jsonFrom("amp/test-amp-response.json"), response.asString(),
-                JSONCompareMode.NON_EXTENSIBLE);
-    }
-
-    @Test
     public void auctionShouldRespondWithBidsFromAppnexusAlias() throws IOException {
         // given
         // appnexus bid response for ad unit 4
@@ -264,63 +169,6 @@ public class ApplicationTest extends IntegrationTest {
         final String expectedAuctionResponse = legacyAuctionResponseFrom(
                 "auction/districtm/test-auction-districtm-response.json",
                 response, asList(APPNEXUS, APPNEXUS_CONFIGURED_ALIAS));
-        assertThat(response.asString()).isEqualTo(expectedAuctionResponse);
-    }
-
-    @Test
-    public void auctionShouldRespondWithBidsFromAdform() throws IOException {
-        // given
-        // adform bid response for ad unit 12
-        wireMockRule.stubFor(get(urlPathEqualTo("/adform-exchange"))
-                .withQueryParam("CC", equalTo("1"))
-                .withQueryParam("rp", equalTo("4"))
-                .withQueryParam("fd", equalTo("1"))
-                .withQueryParam("stid", equalTo("tid"))
-                .withQueryParam("ip", equalTo("192.168.244.1"))
-                .withQueryParam("adid", equalTo("ifaId"))
-                .withQueryParam("gdpr", equalTo("1"))
-                .withQueryParam("gdpr_consent", equalTo("consent1"))
-                .withQueryParam("pt", equalTo("gross"))
-                // bWlkPTE1JnJjdXI9VVNE is Base64 encoded "mid=15&rcur=USD"
-                .withQueryParam("bWlkPTE1JnJjdXI9VVNE", equalTo(""))
-                .withHeader("Content-Type", equalToIgnoreCase("application/json;charset=utf-8"))
-                .withHeader("Accept", equalTo("application/json"))
-                .withHeader("User-Agent", equalTo("userAgent"))
-                .withHeader("X-Request-Agent", equalTo("PrebidAdapter 0.1.3"))
-                .withHeader("X-Forwarded-For", equalTo("192.168.244.1"))
-                .withHeader("Cookie", equalTo("uid=AF-UID;DigiTrust.v1.identity"
-                        //{"id":"id","version":1,"keyv":123,"privacy":{"optout":true}}
-                        + "=eyJpZCI6ImlkIiwidmVyc2lvbiI6MSwia2V5diI6MTIzLCJwcml2YWN5Ijp7Im9wdG91dCI6dHJ1ZX19"))
-                .withRequestBody(equalTo(""))
-                .willReturn(aResponse().withBody(jsonFrom("auction/adform/test-adform-bid-response-1.json"))));
-
-        // pre-bid cache
-        wireMockRule.stubFor(post(urlPathEqualTo("/cache"))
-                .withRequestBody(equalToJson(jsonFrom("auction/adform/test-cache-adform-request.json")))
-                .willReturn(aResponse().withBody(jsonFrom("auction/adform/test-cache-adform-response.json"))));
-
-        // when
-        final Response response = given(spec)
-                .header("Referer", "http://www.example.com")
-                .header("X-Forwarded-For", "192.168.244.1")
-                .header("User-Agent", "userAgent")
-                .header("Origin", "http://www.example.com")
-                //this uids cookie value stands for {"uids":{"adform":"AF-UID"}}
-                .cookie("uids", "eyJ1aWRzIjp7ImFkZm9ybSI6IkFGLVVJRCJ9fQ==")
-                .queryParam("debug", "1")
-                .body(jsonFrom("auction/adform/test-auction-adform-request.json"))
-                .post("/auction");
-
-        // then
-        assertThat(response.header("Cache-Control")).isEqualTo("no-cache, no-store, must-revalidate");
-        assertThat(response.header("Pragma")).isEqualTo("no-cache");
-        assertThat(response.header("Expires")).isEqualTo("0");
-        assertThat(response.header("Access-Control-Allow-Credentials")).isEqualTo("true");
-        assertThat(response.header("Access-Control-Allow-Origin")).isEqualTo("http://www.example.com");
-
-        final String expectedAuctionResponse = legacyAuctionResponseFrom(
-                "auction/adform/test-auction-adform-response.json",
-                response, singletonList(ADFORM));
         assertThat(response.asString()).isEqualTo(expectedAuctionResponse);
     }
 
@@ -386,6 +234,49 @@ public class ApplicationTest extends IntegrationTest {
                 "auction/rubicon_appnexus/test-auction-rubicon-appnexus-response.json",
                 response, asList(RUBICON, APPNEXUS, APPNEXUS_ALIAS));
         assertThat(response.asString()).isEqualTo(expectedAuctionResponse);
+    }
+
+    @Test
+    public void ampShouldReturnTargeting() throws IOException, JSONException {
+        // given
+        // rubicon exchange
+        wireMockRule.stubFor(post(urlPathEqualTo("/rubicon-exchange"))
+                .withRequestBody(equalToJson(jsonFrom("amp/test-rubicon-bid-request.json")))
+                .willReturn(aResponse().withBody(jsonFrom("amp/test-rubicon-bid-response.json"))));
+
+        // appnexus exchange
+        wireMockRule.stubFor(post(urlPathEqualTo("/appnexus-exchange"))
+                .withRequestBody(equalToJson(jsonFrom("amp/test-appnexus-bid-request.json")))
+                .willReturn(aResponse().withBody(jsonFrom("amp/test-appnexus-bid-response.json"))));
+
+        // pre-bid cache
+        wireMockRule.stubFor(post(urlPathEqualTo("/cache"))
+                .withRequestBody(equalToJson(jsonFrom("amp/test-cache-request.json"), true, false))
+                .willReturn(aResponse()
+                        .withTransformers("cache-response-transformer")
+                        .withTransformerParameter("matcherName", "amp/test-cache-matcher-amp.json")
+                ));
+
+        // when
+        final Response response = given(spec)
+                .header("Referer", "http://www.example.com")
+                .header("X-Forwarded-For", "192.168.244.1")
+                .header("User-Agent", "userAgent")
+                .header("Origin", "http://www.example.com")
+                // this uids cookie value stands for {"uids":{"rubicon":"J5VLCWQP-26-CWFT"}}
+                .cookie("uids", "eyJ1aWRzIjp7InJ1Ymljb24iOiJKNVZMQ1dRUC0yNi1DV0ZUIn19")
+                .when()
+                .get("/openrtb2/amp" +
+                        "?tag_id=test-amp-stored-request" +
+                        "&ow=980" +
+                        "&oh=120" +
+                        "&timeout=10000000" +
+                        "&slot=overwrite-tagId" +
+                        "&curl=https%3A%2F%2Fgoogle.com");
+
+        // then
+        JSONAssert.assertEquals(jsonFrom("amp/test-amp-response.json"), response.asString(),
+                JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -603,7 +494,8 @@ public class ApplicationTest extends IntegrationTest {
 
         assertThat(response.getStatusCode()).isEqualTo(200);
         assertThat(response.getHeaders()).contains(new Header("content-type", "image/jpeg"));
-        assertThat(response.getBody().asByteArray()).isEqualTo(ResourceUtil.readByteArrayFromClassPath("static/tracking-pixel.jpg"));
+        assertThat(response.getBody().asByteArray())
+                .isEqualTo(ResourceUtil.readByteArrayFromClassPath("static/tracking-pixel.jpg"));
     }
 
     @Test
@@ -658,13 +550,16 @@ public class ApplicationTest extends IntegrationTest {
         // given
         final Instant testTime = Instant.now();
 
-        // when
-        final Response response = given(adminSpec).get("/currency-rates");
+        // ask endpoint after some time to ensure currency rates have already been fetched
+        Vertx.vertx().setTimer(1000L, id -> {
+            // when
+            final Response response = given(adminSpec).get("/currency-rates");
 
-        // then
-        final String lastUpdateValue = response.jsonPath().getString("last_update");
-        final Instant lastUpdateTime = Instant.parse(lastUpdateValue);
-        assertThat(testTime).isAfter(lastUpdateTime);
+            // then
+            final String lastUpdateValue = response.jsonPath().getString("last_update");
+            final Instant lastUpdateTime = Instant.parse(lastUpdateValue);
+            assertThat(testTime).isAfter(lastUpdateTime);
+        });
     }
 
     @Test

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -548,17 +548,17 @@ public class ApplicationTest extends IntegrationTest {
     @Test
     public void currencyRatesHandlerShouldRespondWithLastUpdateDate() {
         // given
-        final Instant testTime = Instant.now();
+        final Instant currentTime = Instant.now();
 
         // ask endpoint after some time to ensure currency rates have already been fetched
-        Vertx.vertx().setTimer(1000L, id -> {
+        Vertx.vertx().setTimer(1000L, ignored -> {
             // when
             final Response response = given(adminSpec).get("/currency-rates");
 
             // then
             final String lastUpdateValue = response.jsonPath().getString("last_update");
             final Instant lastUpdateTime = Instant.parse(lastUpdateValue);
-            assertThat(testTime).isAfter(lastUpdateTime);
+            assertThat(currentTime).isAfter(lastUpdateTime);
         });
     }
 

--- a/src/test/java/org/prebid/server/settings/FileApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/FileApplicationSettingsTest.java
@@ -77,7 +77,8 @@ public class FileApplicationSettingsTest {
     @Test
     public void getAccountByIdShouldReturnEmptyForUnknownAccount() {
         // given
-        given(fileSystem.readFileBlocking(anyString())).willReturn(Buffer.buffer("accounts: [ {id: '123'}, {id: '456'} ]"));
+        given(fileSystem.readFileBlocking(anyString()))
+                .willReturn(Buffer.buffer("accounts: [ {id: '123'}, {id: '456'} ]"));
 
         final FileApplicationSettings applicationSettings =
                 FileApplicationSettings.create(fileSystem, "ignore", "ignore", "ignore");

--- a/src/test/java/org/prebid/server/settings/HttpApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/HttpApplicationSettingsTest.java
@@ -137,7 +137,8 @@ public class HttpApplicationSettingsTest extends VertxTest {
                 timeout);
 
         // then
-        verify(httpClient).get(eq("http://stored-requests?request-ids=[\"id2\",\"id1\"]&imp-ids=[\"id4\",\"id3\"]"), any(), anyLong());
+        verify(httpClient).get(eq("http://stored-requests?request-ids=[\"id2\",\"id1\"]&imp-ids=[\"id4\",\"id3\"]"),
+                any(), anyLong());
     }
 
     @Test
@@ -151,7 +152,8 @@ public class HttpApplicationSettingsTest extends VertxTest {
         httpApplicationSettings.getStoredData(singleton("id1"), singleton("id2"), timeout);
 
         // then
-        verify(httpClient).get(eq("http://some-domain?param1=value1&request-ids=[\"id1\"]&imp-ids=[\"id2\"]"), any(), anyLong());
+        verify(httpClient).get(eq("http://some-domain?param1=value1&request-ids=[\"id1\"]&imp-ids=[\"id2\"]"), any(),
+                anyLong());
     }
 
     @Test

--- a/src/test/java/org/prebid/server/settings/service/JdbcPeriodicRefreshServiceTest.java
+++ b/src/test/java/org/prebid/server/settings/service/JdbcPeriodicRefreshServiceTest.java
@@ -37,7 +37,8 @@ import static org.mockito.Mockito.verify;
 
 public class JdbcPeriodicRefreshServiceTest {
 
-    private static TimeoutFactory timeoutFactory = new TimeoutFactory(Clock.fixed(Instant.now(), ZoneId.systemDefault()));
+    private static TimeoutFactory timeoutFactory = new TimeoutFactory(
+            Clock.fixed(Instant.now(), ZoneId.systemDefault()));
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/src/test/java/org/prebid/server/vertx/CircuitBreakerTest.java
+++ b/src/test/java/org/prebid/server/vertx/CircuitBreakerTest.java
@@ -156,11 +156,11 @@ public class CircuitBreakerTest {
     }
 
     private void waitForOpeningInterval(TestContext context) {
-        waitForInterval(context, 101L);
+        waitForInterval(context, 150L);
     }
 
     private void waitForClosingInterval(TestContext context) {
-        waitForInterval(context, 201L);
+        waitForInterval(context, 250L);
     }
 
     private void waitForInterval(TestContext context, long timeout) {

--- a/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
+++ b/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
@@ -47,7 +47,7 @@ public class CircuitBreakerSecuredHttpClientTest {
     @Before
     public void setUp() {
         vertx = Vertx.vertx();
-        httpClient = new CircuitBreakerSecuredHttpClient(vertx, wrappedHttpClient, metrics, 0, 100L, 200L);
+        httpClient = new CircuitBreakerSecuredHttpClient(vertx, wrappedHttpClient, metrics, 1, 100L, 200L);
     }
 
     @After
@@ -245,11 +245,11 @@ public class CircuitBreakerSecuredHttpClientTest {
     }
 
     private void doWaitForOpeningInterval(TestContext context) {
-        doWait(context, 101L);
+        doWait(context, 150L);
     }
 
     private void doWaitForClosingInterval(TestContext context) {
-        doWait(context, 201L);
+        doWait(context, 250L);
     }
 
     private void doWait(TestContext context, long timeout) {


### PR DESCRIPTION
CL:
- Added delay while calling `/currency-rates` admin endpoint in `currencyRatesHandlerShouldRespondWithLastUpdateDate` test.
- The `Adform` application test moved to the separate class.
- Tunned waiting time in `CircuitBreaker` related tests.
- Applied code formatting to all tests.