### PR TITLE
Upgrade com.fasterxml.jackson libraries to 2.9.9 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <commons.version>3.6</commons.version>
         <commons.collections.version>4.1</commons.collections.version>
         <commons.compress.version>1.18</commons.compress.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <json.schema.validator.version>0.1.7</json.schema.validator.version>
         <jsonpatch.version>1.9</jsonpatch.version>
         <mysql.version>6.0.6</mysql.version>


### PR DESCRIPTION
Fixed security alert:

> CVE-2019-12086
> 
> Vulnerable versions: >= 2.0.0, < 2.9.9
> Patched version: 2.9.9
> 
> A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.