### PR TITLE
Add support for per-account enforce-GDPR flag

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -343,10 +343,10 @@ public class ExchangeService {
      * <p>
      * - bidrequest.user.buyeruid will be set to that Bidder's ID.
      * <p>
-     * - bidrequest.ext.prebid.data.bidders will be removed
+     * - bidrequest.ext.prebid.data.bidders will be removed.
      * <p>
      * - bidrequest.user.ext.data, bidrequest.app.ext.data and bidrequest.site.ext.data will be removed for bidders
-     * that don't have first party data allowed
+     * that don't have first party data allowed.
      */
     private List<BidderRequest> makeBidderRequests(List<String> bidders, ExtBidRequest requestExt,
                                                    BidRequest bidRequest, Map<String, String> uidsBody,
@@ -720,7 +720,7 @@ public class ExchangeService {
     }
 
     /**
-     * Updates 'account.*.request', 'request' and 'no_cookie_requests' metrics for each {@link BidderRequest}
+     * Updates 'account.*.request', 'request' and 'no_cookie_requests' metrics for each {@link BidderRequest}.
      */
     private List<BidderRequest> updateRequestMetric(List<BidderRequest> bidderRequests, UidsCookie uidsCookie,
                                                     Map<String, String> aliases, String publisherId,

--- a/src/main/java/org/prebid/server/settings/FileApplicationSettings.java
+++ b/src/main/java/org/prebid/server/settings/FileApplicationSettings.java
@@ -48,11 +48,12 @@ public class FileApplicationSettings implements ApplicationSettings {
                                     Map<String, String> storedIdToImp) {
         accounts = toMap(settingsFile.getAccounts(),
                 Account::getId,
-                account -> Account.of(account.getId(), null, account.getBannerCacheTtl(), account.getVideoCacheTtl(),
-                        account.getEventsEnabled()));
+                Function.identity());
+
         configs = toMap(settingsFile.getConfigs(),
                 AdUnitConfig::getId,
                 config -> ObjectUtils.firstNonNull(config.getConfig(), StringUtils.EMPTY));
+
         this.storedIdToRequest = Objects.requireNonNull(storedIdToRequest);
         this.storedIdToImp = Objects.requireNonNull(storedIdToImp);
     }

--- a/src/main/java/org/prebid/server/settings/JdbcApplicationSettings.java
+++ b/src/main/java/org/prebid/server/settings/JdbcApplicationSettings.java
@@ -73,10 +73,16 @@ public class JdbcApplicationSettings implements ApplicationSettings {
     @Override
     public Future<Account> getAccountById(String accountId, Timeout timeout) {
         return jdbcClient.executeQuery("SELECT uuid, price_granularity, banner_cache_ttl, video_cache_ttl,"
-                        + " events_enabled FROM accounts_account where uuid = ? LIMIT 1",
+                        + " events_enabled, enforce_gdpr FROM accounts_account where uuid = ? LIMIT 1",
                 Collections.singletonList(accountId),
-                result -> mapToModelOrError(result, row -> Account.of(row.getString(0), row.getString(1),
-                        row.getInteger(2), row.getInteger(3), row.getBoolean(4))),
+                result -> mapToModelOrError(result, row -> Account.builder()
+                        .id(row.getString(0))
+                        .priceGranularity(row.getString(1))
+                        .bannerCacheTtl(row.getInteger(2))
+                        .videoCacheTtl(row.getInteger(3))
+                        .eventsEnabled(row.getBoolean(4))
+                        .enforceGdpr(row.getBoolean(5))
+                        .build()),
                 timeout)
                 .compose(JdbcApplicationSettings::failedIfNull);
     }

--- a/src/main/java/org/prebid/server/settings/model/Account.java
+++ b/src/main/java/org/prebid/server/settings/model/Account.java
@@ -1,9 +1,9 @@
 package org.prebid.server.settings.model;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@AllArgsConstructor(staticName = "of")
+@Builder
 @Value
 public class Account {
 
@@ -16,4 +16,6 @@ public class Account {
     Integer videoCacheTtl;
 
     Boolean eventsEnabled;
+
+    Boolean enforceGdpr;
 }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -270,13 +270,14 @@ public class ServiceConfiguration {
 
     @Bean
     GdprService gdprService(
+            ApplicationSettings applicationSettings,
             @Autowired(required = false) GeoLocationService geoLocationService,
             VendorListService vendorListService,
             @Value("${gdpr.eea-countries}") String eeaCountriesAsString,
             @Value("${gdpr.default-value}") String defaultValue) {
 
         final List<String> eeaCountries = Arrays.asList(eeaCountriesAsString.trim().split(","));
-        return new GdprService(geoLocationService, vendorListService, eeaCountries, defaultValue);
+        return new GdprService(applicationSettings, geoLocationService, vendorListService, eeaCountries, defaultValue);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -153,6 +153,7 @@ public class ExchangeServiceTest extends VertxTest {
     private ExchangeService exchangeService;
 
     private Timeout timeout;
+
     private MetricsContext metricsContext;
 
     @Before
@@ -168,6 +169,8 @@ public class ExchangeServiceTest extends VertxTest {
 
         given(currencyService.convertCurrency(any(), any(), any(), any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        given(gdprService.isGdprEnforced(any(), any(), any(), any())).willReturn(Future.succeededFuture(true));
         given(gdprService.resultByVendor(any(), any(), any(), any(), any()))
                 .willReturn(Future.succeededFuture(GdprResponse.of(true, singletonMap(1, true), null)));
 
@@ -424,6 +427,7 @@ public class ExchangeServiceTest extends VertxTest {
         givenBidder("someBidder", bidder, givenEmptySeatBid());
 
         given(bidderCatalog.bidderInfoByName(anyString())).willReturn(givenBidderInfo(15, false));
+        given(gdprService.isGdprEnforced(any(), any(), any(), any())).willReturn(Future.succeededFuture(false));
         given(gdprService.resultByVendor(any(), any(), any(), any(), any()))
                 .willReturn(Future.succeededFuture(GdprResponse.of(true, singletonMap(15, false), null)));
 
@@ -461,7 +465,6 @@ public class ExchangeServiceTest extends VertxTest {
                 .ifa("ifa").macsha1("macsha1").macmd5("macmd5").didsha1("didsha1").didmd5("didmd5").dpidsha1("dpidsha1")
                 .dpidmd5("dpidmd5")
                 .build());
-        verifyZeroInteractions(gdprService);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -271,7 +271,7 @@ public class CacheServiceTest extends VertxTest {
         final com.iab.openrtb.response.Bid bid2 = givenBidOpenrtb(builder -> builder.impid("impId1").nurl("adm2"));
         final Imp imp1 = givenImp(builder -> builder.id("impId1").video(Video.builder().build()));
         cacheService.cacheBidsOpenrtb(
-                asList(bid1, bid2), asList(imp1),
+                asList(bid1, bid2), singletonList(imp1),
                 CacheContext.of(true, null, true, null), null, timeout);
 
         // then
@@ -430,7 +430,7 @@ public class CacheServiceTest extends VertxTest {
         givenHttpClientReturnsResponse(200, null);
 
         given(applicationSettings.getAccountById(any(), any()))
-                .willReturn(Future.succeededFuture(Account.of(null, null, 10, null, null)));
+                .willReturn(Future.succeededFuture(Account.builder().bannerCacheTtl(10).build()));
 
         // when
         cacheService.cacheBidsOpenrtb(

--- a/src/test/java/org/prebid/server/events/EventsServiceTest.java
+++ b/src/test/java/org/prebid/server/events/EventsServiceTest.java
@@ -31,15 +31,13 @@ public class EventsServiceTest {
     @Mock
     private ApplicationSettings applicationSettings;
 
-    private Clock clock;
-
     private Timeout timeout;
 
     private EventsService eventsService;
 
     @Before
     public void setUp() {
-        clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
         timeout = new TimeoutFactory(clock).create(500);
         eventsService = new EventsService(applicationSettings, "http://external.org");
     }
@@ -48,7 +46,7 @@ public class EventsServiceTest {
     public void isEventEnabledShouldReturnFalseWhenAccountsEventEnabledIsFalse() {
         // given
         given(applicationSettings.getAccountById(anyString(), any()))
-                .willReturn(Future.succeededFuture(Account.of(null, null, null, null, false)));
+                .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(false).build()));
 
         // when
         final Future<Boolean> events = eventsService.isEventsEnabled("publisherId", timeout);
@@ -62,7 +60,7 @@ public class EventsServiceTest {
     public void isEventEnabledShouldReturnFalseWhenAccountsEventEnabledIsTrue() {
         // given
         given(applicationSettings.getAccountById(anyString(), any()))
-                .willReturn(Future.succeededFuture(Account.of(null, null, null, null, true)));
+                .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));
 
         // when
         final Future<Boolean> events = eventsService.isEventsEnabled("publisherId", timeout);

--- a/src/test/java/org/prebid/server/gdpr/GdprServiceTest.java
+++ b/src/test/java/org/prebid/server/gdpr/GdprServiceTest.java
@@ -7,11 +7,14 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.prebid.server.exception.PreBidException;
 import org.prebid.server.gdpr.model.GdprPurpose;
 import org.prebid.server.gdpr.model.GdprResponse;
 import org.prebid.server.gdpr.vendorlist.VendorListService;
 import org.prebid.server.geolocation.GeoLocationService;
 import org.prebid.server.geolocation.model.GeoInfo;
+import org.prebid.server.settings.ApplicationSettings;
+import org.prebid.server.settings.model.Account;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -34,6 +37,8 @@ public class GdprServiceTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
+    private ApplicationSettings applicationSettings;
+    @Mock
     private GeoLocationService geoLocationService;
     @Mock
     private VendorListService vendorListService;
@@ -45,14 +50,53 @@ public class GdprServiceTest {
         given(vendorListService.forVersion(anyInt())).willReturn(Future.succeededFuture(
                 singletonMap(1, singleton(GdprPurpose.informationStorageAndAccess.getId()))));
 
-        gdprService = new GdprService(null, vendorListService, emptyList(), "1");
+        gdprService = new GdprService(applicationSettings, null, vendorListService, emptyList(), "1");
+    }
+
+    @Test
+    public void isGdprEnforcedShouldConsiderRequestValue() {
+        // when
+        final Future<Boolean> future = gdprService.isGdprEnforced("1", null, emptySet(), null);
+
+        // then
+        assertThat(future.succeeded()).isTrue();
+        assertThat(future.result()).isTrue();
+    }
+
+    @Test
+    public void isGdprEnforcedShouldConsiderAccountConfigValue() {
+        // given
+        given(applicationSettings.getAccountById(any(), any()))
+                .willReturn(Future.succeededFuture(Account.builder().enforceGdpr(true).build()));
+
+        // when
+        final Future<Boolean> future = gdprService.isGdprEnforced(null, "publisherId", emptySet(), null);
+
+        // then
+        assertThat(future.succeeded()).isTrue();
+        assertThat(future.result()).isTrue();
+    }
+
+    @Test
+    public void isGdprEnforcedShouldConsiderGdprEnforcedVendors() {
+        // given
+        given(applicationSettings.getAccountById(any(), any()))
+                .willReturn(Future.failedFuture(new PreBidException("Not found")));
+
+        // when
+        final Future<Boolean> future = gdprService.isGdprEnforced(null, null, singleton(1), null);
+
+        // then
+        assertThat(future.succeeded()).isTrue();
+        assertThat(future.result()).isTrue();
     }
 
     @Test
     public void shouldReturnGdprFromGeoLocationServiceIfGdprFromRequestIsNotValid() {
         // given
         given(geoLocationService.lookup(anyString(), any())).willReturn(Future.succeededFuture(GeoInfo.of("country1")));
-        gdprService = new GdprService(geoLocationService, vendorListService, singletonList("country1"), "1");
+        gdprService = new GdprService(applicationSettings, geoLocationService, vendorListService,
+                singletonList("country1"), "1");
 
         // when
         final Future<?> future = gdprService.resultByVendor(singleton(GdprPurpose.informationStorageAndAccess),
@@ -179,7 +223,7 @@ public class GdprServiceTest {
     public void shouldReturnAllowedResultIfNoGdprParamAndCountryIsNotFoundButDefaultGdprIsZero() {
         // given
         given(geoLocationService.lookup(anyString(), any())).willReturn(Future.failedFuture("country not found"));
-        gdprService = new GdprService(geoLocationService, vendorListService, emptyList(), "0");
+        gdprService = new GdprService(applicationSettings, geoLocationService, vendorListService, emptyList(), "0");
 
         // when
         final Future<?> future =
@@ -194,7 +238,7 @@ public class GdprServiceTest {
     public void shouldReturnAllowedResultIfNoGdprParamAndCountryIsNotInEEA() {
         // given
         given(geoLocationService.lookup(anyString(), any())).willReturn(Future.succeededFuture(GeoInfo.of("country1")));
-        gdprService = new GdprService(geoLocationService, vendorListService, emptyList(), "1");
+        gdprService = new GdprService(applicationSettings, geoLocationService, vendorListService, emptyList(), "1");
 
         // when
         final Future<?> future =
@@ -225,7 +269,8 @@ public class GdprServiceTest {
     public void shouldReturnAllowedResultIfNoGdprParamAndConsentParamIsValidAndCountryIsInEEA() {
         // given
         given(geoLocationService.lookup(anyString(), any())).willReturn(Future.succeededFuture(GeoInfo.of("country1")));
-        gdprService = new GdprService(geoLocationService, vendorListService, singletonList("country1"), "1");
+        gdprService = new GdprService(applicationSettings, geoLocationService, vendorListService,
+                singletonList("country1"), "1");
 
         // when
         final Future<?> future =
@@ -240,7 +285,7 @@ public class GdprServiceTest {
     @Test
     public void shouldReturnAllowedResultIfNoGdprParamAndNoIpButGdprDefaultValueIsZero() {
         // given
-        gdprService = new GdprService(null, vendorListService, emptyList(), "0");
+        gdprService = new GdprService(applicationSettings, null, vendorListService, emptyList(), "0");
 
         // when
         final Future<?> future =

--- a/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
@@ -126,7 +126,7 @@ public class AuctionHandlerTest extends VertxTest {
     @Before
     public void setUp() {
         given(applicationSettings.getAccountById(any(), any()))
-                .willReturn(Future.succeededFuture(Account.of(null, null, null, null, null)));
+                .willReturn(Future.succeededFuture(Account.builder().build()));
 
         given(bidderCatalog.isValidAdapterName(eq(RUBICON))).willReturn(true);
         given(bidderCatalog.isValidName(eq(RUBICON))).willReturn(true);
@@ -554,7 +554,6 @@ public class AuctionHandlerTest extends VertxTest {
         verify(metrics).updateAdapterBidMetrics(eq(RUBICON), eq("accountId"), eq(5670L), eq(false), eq("banner"));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldIncrementNoBidMetrics() {
         // given

--- a/src/test/java/org/prebid/server/settings/CachingApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/CachingApplicationSettingsTest.java
@@ -57,8 +57,9 @@ public class CachingApplicationSettingsTest {
     @Test
     public void getAccountByIdShouldReturnResultFromCacheOnSuccessiveCalls() {
         // given
+        final Account account = Account.builder().id("accountId").priceGranularity("med").build();
         given(applicationSettings.getAccountById(eq("accountId"), same(timeout)))
-                .willReturn(Future.succeededFuture(Account.of("accountId", "med", null, null, null)));
+                .willReturn(Future.succeededFuture(account));
 
         // when
         final Future<Account> future = cachingApplicationSettings.getAccountById("accountId", timeout);
@@ -66,7 +67,7 @@ public class CachingApplicationSettingsTest {
 
         // then
         assertThat(future.succeeded()).isTrue();
-        assertThat(future.result()).isEqualTo(Account.of("accountId", "med", null, null, null));
+        assertThat(future.result()).isSameAs(account);
         verify(applicationSettings).getAccountById(eq("accountId"), same(timeout));
         verifyNoMoreInteractions(applicationSettings);
     }

--- a/src/test/java/org/prebid/server/settings/CompositeApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/CompositeApplicationSettingsTest.java
@@ -59,7 +59,7 @@ public class CompositeApplicationSettingsTest {
     @Test
     public void getAccountByIdShouldReturnAccountFromFirstDelegateIfPresent() {
         // given
-        final Account account = Account.of("accountId1", "low", null, null, null);
+        final Account account = Account.builder().id("accountId").priceGranularity("low").build();
         given(delegate1.getAccountById(anyString(), any())).willReturn(Future.succeededFuture(account));
 
         // when
@@ -77,7 +77,7 @@ public class CompositeApplicationSettingsTest {
         given(delegate1.getAccountById(anyString(), any()))
                 .willReturn(Future.failedFuture(new PreBidException("error1")));
 
-        final Account account = Account.of("accountId1", "low", null, null, null);
+        final Account account = Account.builder().id("accountId").priceGranularity("low").build();
         given(delegate2.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(account));
 

--- a/src/test/java/org/prebid/server/settings/FileApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/FileApplicationSettingsTest.java
@@ -60,8 +60,8 @@ public class FileApplicationSettingsTest {
     public void getAccountByIdShouldReturnPresentAccount() {
         // given
         given(fileSystem.readFileBlocking(anyString()))
-                .willReturn(Buffer.buffer("accounts: [ { id: '123', bannerCacheTtl: '100', videoCacheTtl : '100'," +
-                        " eventsEnabled: 'true'} ]"));
+                .willReturn(Buffer.buffer("accounts: [ { id: '123', priceGranularity: 'low', bannerCacheTtl: '100',"
+                        + " videoCacheTtl : '100', eventsEnabled: 'true', enforceGdpr: 'true'} ]"));
 
         final FileApplicationSettings applicationSettings =
                 FileApplicationSettings.create(fileSystem, "ignore", "ignore", "ignore");
@@ -71,7 +71,14 @@ public class FileApplicationSettingsTest {
 
         // then
         assertThat(account.succeeded()).isTrue();
-        assertThat(account.result()).isEqualTo(Account.of("123", null, 100, 100, true));
+        assertThat(account.result()).isEqualTo(Account.builder()
+                .id("123")
+                .priceGranularity("low")
+                .bannerCacheTtl(100)
+                .videoCacheTtl(100)
+                .eventsEnabled(true)
+                .enforceGdpr(true)
+                .build());
     }
 
     @Test

--- a/src/test/resources/org/prebid/server/it/test-app-settings.yaml
+++ b/src/test/resources/org/prebid/server/it/test-app-settings.yaml
@@ -8,17 +8,18 @@ accounts:
   - id: 2763
   - id: 5001
     eventsEnabled: true
+    enforceGdpr: true
 configs:
   - id: 14062
     config: >
-              [{"bid_id": "bidId2",
-               "bidder": "rubicon",
-                "params": {
-                  "accountId": 5001,
-                  "siteId": 6001,
-                  "zoneId": 7001
-                }
-              }]
+      [{"bid_id": "bidId2",
+       "bidder": "rubicon",
+        "params": {
+          "accountId": 5001,
+          "siteId": 6001,
+          "zoneId": 7001
+        }
+      }]
   - id: 1001
   - id: 2763
 domains:


### PR DESCRIPTION
(!) Breaking changes: `Account` is extended with `enforceGdpr` flag.

So, SQL scheme for `jdbc` application settings should be updated.
The `file` and `http` application settings can be used safely.