### PR TITLE
Fix ext.prebid.debug processing in Auction/Amp request factory

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconSize.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconSize.java
@@ -79,6 +79,9 @@ final class RubiconSize {
         return SIZES.getOrDefault(size(size.getW(), size.getH()), 0);
     }
 
+    /**
+     * Returns {@link Format}s corresponding to the given size IDs or empty if no one matched.
+     */
     static List<Format> idToSize(List<Integer> sizeIds) {
         final List<Format> result = new ArrayList<>();
         for (Integer id : sizeIds) {

--- a/src/test/java/org/prebid/server/auction/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AmpRequestFactoryTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,8 +184,7 @@ public class AmpRequestFactoryTest extends VertxTest {
     public void shouldReturnBidRequestWithDefaultPrebidValuesIfPrebidIsNull() {
         // given
         final ObjectNode extBidRequest = mapper.valueToTree(ExtBidRequest.of(null));
-        final BidRequest bidRequest = givenBidRequest(builder -> builder.ext(extBidRequest),
-                Imp.builder().build());
+        final BidRequest bidRequest = givenBidRequest(builder -> builder.ext(extBidRequest), Imp.builder().build());
         given(storedRequestProcessor.processAmpRequest(anyString())).willReturn(Future.succeededFuture(bidRequest));
         given(auctionRequestFactory.fillImplicitParameters(any(), any(), any())).willAnswer(answerWithFirstArgument());
         given(auctionRequestFactory.validateRequest(any())).willAnswer(answerWithFirstArgument());
@@ -203,8 +201,6 @@ public class AmpRequestFactoryTest extends VertxTest {
                 .extracting(ext -> Json.mapper.treeToValue(ext, ExtBidRequest.class)).isNotNull()
                 .extracting(ExtBidRequest::getPrebid)
                 .containsExactly(ExtRequestPrebid.builder()
-                        .aliases(emptyMap())
-                        .bidadjustmentfactors(emptyMap())
                         .targeting(ExtRequestTargeting.of(Json.mapper.valueToTree(ExtPriceGranularity.of(2,
                                 singletonList(ExtGranularityRange.of(BigDecimal.valueOf(20),
                                         BigDecimal.valueOf(0.1))))), null, null, true, true))
@@ -420,10 +416,11 @@ public class AmpRequestFactoryTest extends VertxTest {
         // given
         given(httpRequest.getParam("debug")).willReturn("1");
 
-        final BidRequest bidRequest = givenBidRequestWithExt(ExtRequestTargeting.of(null, null,
-                null, null, null),
-                ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null),
-                        ExtRequestPrebidCacheVastxml.of(null, null)));
+        final BidRequest bidRequest = givenBidRequest(
+                builder -> builder
+                        .test(0)
+                        .ext(mapper.valueToTree(ExtBidRequest.of(null))),
+                Imp.builder().build());
         given(storedRequestProcessor.processAmpRequest(anyString())).willReturn(Future.succeededFuture(bidRequest));
 
         // when
@@ -441,10 +438,10 @@ public class AmpRequestFactoryTest extends VertxTest {
         // given
         given(httpRequest.getParam("debug")).willReturn("1");
 
-        final BidRequest bidRequest = givenBidRequestWithExt(ExtRequestTargeting.of(null, null,
-                null, null, null),
-                ExtRequestPrebidCache.of(ExtRequestPrebidCacheBids.of(null, null),
-                        ExtRequestPrebidCacheVastxml.of(null, null)));
+        final BidRequest bidRequest = givenBidRequest(
+                builder -> builder
+                        .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder().debug(0).build()))),
+                Imp.builder().build());
         given(storedRequestProcessor.processAmpRequest(anyString())).willReturn(Future.succeededFuture(bidRequest));
 
         // when
@@ -1070,6 +1067,32 @@ public class AmpRequestFactoryTest extends VertxTest {
 
         // then
         assertThat(result.getTmax()).isEqualTo(1000L);
+    }
+
+    @Test
+    public void shouldPassExtPrebidDebugFlagIfPresent() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                builder -> builder
+                        .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
+                                .debug(1)
+                                .build()))),
+                Imp.builder().build());
+
+        given(storedRequestProcessor.processAmpRequest(anyString())).willReturn(Future.succeededFuture(bidRequest));
+        given(auctionRequestFactory.fillImplicitParameters(any(), any(), any())).willAnswer(answerWithFirstArgument());
+        given(auctionRequestFactory.validateRequest(any())).willAnswer(answerWithFirstArgument());
+
+        // when
+        final BidRequest result = factory.fromRequest(routingContext).result();
+
+        // then
+        assertThat(singletonList(result))
+                .extracting(BidRequest::getExt)
+                .extracting(ext -> mapper.treeToValue(ext, ExtBidRequest.class))
+                .extracting(ExtBidRequest::getPrebid)
+                .extracting(ExtRequestPrebid::getDebug)
+                .containsOnly(1);
     }
 
     private static BidRequest givenBidRequest(

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -557,6 +557,28 @@ public class AuctionRequestFactoryTest extends VertxTest {
     }
 
     @Test
+    public void shouldPassExtPrebidDebugFlagIfPresent() {
+        // given
+        givenBidRequest(BidRequest.builder()
+                .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
+                .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
+                        .debug(1)
+                        .build())))
+                .build());
+
+        // when
+        final BidRequest result = factory.fromRequest(routingContext).result();
+
+        // then
+        assertThat(singletonList(result))
+                .extracting(BidRequest::getExt)
+                .extracting(ext -> mapper.treeToValue(ext, ExtBidRequest.class))
+                .extracting(ExtBidRequest::getPrebid)
+                .extracting(ExtRequestPrebid::getDebug)
+                .containsOnly(1);
+    }
+
+    @Test
     public void shouldReturnFailedFutureIfRequestValidationFailed() {
         // given
         given(routingContext.getBody()).willReturn(Buffer.buffer("{}"));


### PR DESCRIPTION
CL:
- Fixed http request query string `debug` param processing for AMP.
- Fixed setting of `ext.prebid.debug` when dealing with `ExtRequestPrebid` through builder.