### PR TITLE
Modify bidder info endpoint to be able to get all bidder details

### DIFF
--- a/docs/endpoints/info/bidders/bidderName.md
+++ b/docs/endpoints/info/bidders/bidderName.md
@@ -9,9 +9,8 @@ Legal values for `{bidderName}` can be retrieved from the [/info/bidders](../bid
 
 This endpoint returns JSON like:
 
-```
+```json
 {
-  "enabled": true,
   "maintainer": {
     "email": "info@prebid.org"
   },
@@ -29,23 +28,68 @@ This endpoint returns JSON like:
         "native"
       ]
     }
-  },
-  "vendors": [
-    "vendor1",
-    "vendor2",
-    "vendor3"
-  ]
+  }
 }
 ```
 
 The fields hold the following information:
 
-- `enabled`: A property to indicate the bidder should be active and takes part in auction. Can be `true` or `false`.
 - `maintainer.email`: A contact email for the Bidder's maintainer. In general, Bidder bugs should be logged as [issues](https://github.com/rubicon-project/prebid-server-java/issues)... but this contact email may be useful in case of emergency.
 - `capabilities.app.mediaTypes`: A list of media types this Bidder supports from Mobile Apps.
 - `capabilities.site.mediaTypes`: A list of media types this Bidder supports from Web pages.
-- `vendors` : A list of vendors this Bidder supports for viewability scores.
 
 If `capabilities.app` or `capabilities.site` do not exist, then this Bidder does not support that platform.
 OpenRTB Requests which define a `request.app` or `request.site` property will fail if a
 `request.imp[i].ext.{bidderName}` exists for a Bidder which doesn't support them.
+
+
+## `GET /info/bidders/all`
+
+This will respond with all possible bidders' details.
+
+### Sample Response
+
+This endpoint returns JSON like:
+
+```json
+{
+  "appnexus": {
+    "maintainer": {
+      "email": "info@prebid.org"
+    },
+    "capabilities": {
+      "app": {
+        "mediaTypes": [
+          "banner",
+          "native"
+        ]
+      },
+      "site": {
+        "mediaTypes": [
+          "banner",
+          "video",
+          "native"
+        ]
+      }
+    }
+  },
+  "rubicon": {
+    "maintainer": {
+      "email": "header-bidding@rubiconproject.com"
+    },
+    "capabilities": {
+      "app": {
+        "mediaTypes": [
+          "banner"
+        ]
+      },
+      "site": {
+        "mediaTypes": [
+          "banner",
+          "video"
+        ]
+      }
+    }
+  }
+}
+```

--- a/src/main/java/org/prebid/server/handler/info/BidderDetailsHandler.java
+++ b/src/main/java/org/prebid/server/handler/info/BidderDetailsHandler.java
@@ -6,72 +6,114 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
+import lombok.Value;
 import org.prebid.server.bidder.BidderCatalog;
+import org.prebid.server.proto.response.BidderInfo;
 import org.prebid.server.util.HttpUtil;
 
-import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class BidderDetailsHandler implements Handler<RoutingContext> {
 
-    private static final Logger logger = LoggerFactory.getLogger(BidderDetailsHandler.class);
+    private static final String BIDDER_NAME_PARAM = "bidderName";
+    private static final String ALL_PARAM_VALUE = "all";
 
     private final Map<String, String> bidderInfos;
 
-    private BidderCatalog bidderCatalog;
-
     public BidderDetailsHandler(BidderCatalog bidderCatalog) {
-        this.bidderCatalog = Objects.requireNonNull(bidderCatalog);
+        validateAliases(Objects.requireNonNull(bidderCatalog));
         bidderInfos = createBidderInfos(bidderCatalog);
     }
 
+    private static void validateAliases(BidderCatalog bidderCatalog) {
+        if (bidderCatalog.aliases().contains(ALL_PARAM_VALUE)) {
+            throw new IllegalArgumentException(
+                    String.format("The '%s' bidder has '%s' alias configured which is unacceptable.",
+                            bidderCatalog.nameByAlias(ALL_PARAM_VALUE), ALL_PARAM_VALUE));
+        }
+    }
+
     /**
-     * Returns a map with bidder name as a key and json-encoded bidder info as a value.
+     * Returns a {@link Map} with bidder name (or alias, or "all" keyword) as a key
+     * and json-encoded string of {@link BidderInfoResponseModel} as a value.
      */
     private static Map<String, String> createBidderInfos(BidderCatalog bidderCatalog) {
-        return bidderCatalog.names().stream()
-                .collect(Collectors.toMap(Function.identity(),
-                        bidderName -> Json.encode(bidderCatalog.bidderInfoByName(bidderName))));
+        final Map<String, ObjectNode> nameToInfo = bidderCatalog.names().stream()
+                .filter(bidderCatalog::isActive)
+                .collect(Collectors.toMap(Function.identity(), name -> bidderNode(bidderCatalog, name)));
+
+        final Map<String, ObjectNode> aliasToInfo = bidderCatalog.aliases().stream()
+                .filter(alias -> bidderCatalog.isActive(bidderCatalog.nameByAlias(alias)))
+                .collect(Collectors.toMap(Function.identity(), alias -> aliasNode(bidderCatalog, alias)));
+
+        final Map<String, ObjectNode> allToInfos = Collections.singletonMap(
+                ALL_PARAM_VALUE, allInfos(nameToInfo, aliasToInfo));
+
+        return Stream.of(nameToInfo, aliasToInfo, allToInfos)
+                .flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, map -> Json.encode(map.getValue())));
+    }
+
+    /**
+     * Returns bidder info as {@link ObjectNode}.
+     */
+    private static ObjectNode bidderNode(BidderCatalog bidderCatalog, String name) {
+        final BidderInfo bidderInfo = bidderCatalog.bidderInfoByName(name);
+        return Json.mapper.valueToTree(BidderInfoResponseModel.from(bidderInfo));
+    }
+
+    /**
+     * Returns alias info as {@link ObjectNode}.
+     */
+    private static ObjectNode aliasNode(BidderCatalog bidderCatalog, String alias) {
+        final String name = bidderCatalog.nameByAlias(alias);
+
+        final ObjectNode node = bidderNode(bidderCatalog, name);
+        node.set("aliasOf", new TextNode(name));
+        return node;
+    }
+
+    /**
+     * Returns a {@link Map} of all bidder's infos sorted by name (and alias) as {@link ObjectNode}.
+     */
+    private static ObjectNode allInfos(Map<String, ObjectNode> nameToInfo, Map<String, ObjectNode> aliasToInfo) {
+        final Map<String, ObjectNode> result = new TreeMap<>();
+        result.putAll(nameToInfo);
+        result.putAll(aliasToInfo);
+        return Json.mapper.valueToTree(result);
     }
 
     @Override
     public void handle(RoutingContext context) {
-        final String bidderName = context.request().getParam("bidderName");
+        final String bidderName = context.request().getParam(BIDDER_NAME_PARAM);
 
         if (bidderInfos.containsKey(bidderName)) {
-            final String bidderInfoAsString = bidderInfos.get(bidderName);
-            final String response;
-
-            if (bidderCatalog.isAlias(bidderName)) {
-                try {
-                    // Add alias to the existing json object
-                    final ObjectNode node = (ObjectNode) Json.mapper.readTree(bidderInfoAsString);
-                    node.set("aliasOf", new TextNode(bidderCatalog.nameByAlias(bidderName)));
-                    response = Json.encode(node);
-                } catch (IOException e) {
-                    logger.warn("Error occurred while parsing bidder info for {0}", e, bidderName);
-                    context.response()
-                            .setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
-                            .end("Parsing bidder info error");
-                    return;
-                }
-            } else {
-                response = bidderInfoAsString;
-            }
-
             context.response()
                     .putHeader(HttpUtil.CONTENT_TYPE_HEADER, HttpHeaderValues.APPLICATION_JSON)
-                    .end(response);
+                    .end(bidderInfos.get(bidderName));
         } else {
             context.response()
                     .setStatusCode(HttpResponseStatus.NOT_FOUND.code())
                     .end();
+        }
+    }
+
+    @Value
+    private static class BidderInfoResponseModel {
+
+        BidderInfo.MaintainerInfo maintainer;
+
+        BidderInfo.CapabilitiesInfo capabilities;
+
+        static BidderInfoResponseModel from(BidderInfo bidderInfo) {
+            return new BidderInfoResponseModel(bidderInfo.getMaintainer(), bidderInfo.getCapabilities());
         }
     }
 }

--- a/src/main/java/org/prebid/server/proto/response/BidderInfo.java
+++ b/src/main/java/org/prebid/server/proto/response/BidderInfo.java
@@ -34,9 +34,17 @@ public class BidderInfo {
     }
 
     @Value
-    private static class MaintainerInfo {
+    public static class MaintainerInfo {
 
         String email;
+    }
+
+    @Value
+    public static class CapabilitiesInfo {
+
+        PlatformInfo app;
+
+        PlatformInfo site;
     }
 
     @Value
@@ -44,14 +52,6 @@ public class BidderInfo {
 
         @JsonProperty("mediaTypes")
         List<String> mediaTypes;
-    }
-
-    @Value
-    private static class CapabilitiesInfo {
-
-        PlatformInfo app;
-
-        PlatformInfo site;
     }
 
     @Value

--- a/src/test/resources/org/prebid/server/it/info-bidders/test-info-bidder-details-response.json
+++ b/src/test/resources/org/prebid/server/it/info-bidders/test-info-bidder-details-response.json
@@ -1,5 +1,4 @@
 {
-  "enabled": true,
   "maintainer": {
     "email": "header-bidding@rubiconproject.com"
   },
@@ -15,19 +14,5 @@
         "video"
       ]
     }
-  },
-  "vendors": [
-    "activeview",
-    "adform",
-    "comscore",
-    "doubleverify",
-    "integralads",
-    "moat",
-    "sizemek",
-    "whiteops"
-  ],
-  "gdpr": {
-    "vendorId": 52,
-    "enforced": true
   }
 }


### PR DESCRIPTION
CL:
- Fixed `/info/bidders/<BIDDER_NAME>` to respond with bidder details for active only bidder.
- Fixed `/info/bidders/<BIDDER_ALIAS>` to respond with bidder details for active only bidder by alias.
- Added `/info/bidders/all` to respond with bidder details for all active bidders.