### PR TITLE
Add support for COPPA

### DIFF
--- a/src/main/java/com/iab/openrtb/request/Geo.java
+++ b/src/main/java/com/iab/openrtb/request/Geo.java
@@ -18,10 +18,14 @@ import lombok.Value;
 @Value
 public class Geo {
 
-    /** Latitude from -90.0 to +90.0, where negative is south. */
+    /**
+     * Latitude from -90.0 to +90.0, where negative is south.
+     */
     Float lat;
 
-    /** Longitude from -180.0 to +180.0, where negative is west. */
+    /**
+     * Longitude from -180.0 to +180.0, where negative is west.
+     */
     Float lon;
 
     /**
@@ -51,10 +55,14 @@ public class Geo {
      */
     Integer ipservice;
 
-    /** Country code using ISO-3166-1-alpha-3. */
+    /**
+     * Country code using ISO-3166-1-alpha-3.
+     */
     String country;
 
-    /** Region code using ISO-3166-2; 2-letter state code if USA. */
+    /**
+     * Region code using ISO-3166-2; 2-letter state code if USA.
+     */
     String region;
 
     /**
@@ -75,12 +83,25 @@ public class Geo {
      */
     String city;
 
-    /** Zip or postal code. */
+    /**
+     * Zip or postal code.
+     */
     String zip;
 
-    /** Local time as the number +/- of minutes from UTC. */
+    /**
+     * Local time as the number +/- of minutes from UTC.
+     */
     Integer utcoffset;
 
-    /** Placeholder for exchange-specific extensions to OpenRTB. */
+    /**
+     * Placeholder for exchange-specific extensions to OpenRTB.
+     */
     ObjectNode ext;
+
+    /**
+     * Return true if all fields are not defined.
+     */
+    public boolean isEmpty() {
+        return this.equals(Geo.builder().build());
+    }
 }

--- a/src/main/java/com/iab/openrtb/request/Geo.java
+++ b/src/main/java/com/iab/openrtb/request/Geo.java
@@ -18,6 +18,8 @@ import lombok.Value;
 @Value
 public class Geo {
 
+    private static final Geo EMPTY = Geo.builder().build();
+
     /**
      * Latitude from -90.0 to +90.0, where negative is south.
      */
@@ -101,7 +103,7 @@ public class Geo {
     /**
      * Return true if all fields are not defined.
      */
-    public boolean isEmpty() {
-        return this.equals(Geo.builder().build());
+    public static boolean isEmpty(Geo geo) {
+        return geo == null || geo.equals(EMPTY);
     }
 }

--- a/src/main/java/com/iab/openrtb/request/Geo.java
+++ b/src/main/java/com/iab/openrtb/request/Geo.java
@@ -18,7 +18,7 @@ import lombok.Value;
 @Value
 public class Geo {
 
-    private static final Geo EMPTY = Geo.builder().build();
+    public static final Geo EMPTY = Geo.builder().build();
 
     /**
      * Latitude from -90.0 to +90.0, where negative is south.
@@ -99,11 +99,4 @@ public class Geo {
      * Placeholder for exchange-specific extensions to OpenRTB.
      */
     ObjectNode ext;
-
-    /**
-     * Return true if all fields are not defined.
-     */
-    public static boolean isEmpty(Geo geo) {
-        return geo == null || geo.equals(EMPTY);
-    }
 }

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -660,7 +660,7 @@ public class ExchangeService {
         final Geo updatedGeo = geo != null
                 ? geo.toBuilder().lat(null).lon(null).metro(null).city(null).zip(null).build()
                 : null;
-        return updatedGeo == null || updatedGeo.isEmpty() ? null : updatedGeo;
+        return Geo.isEmpty(updatedGeo) ? null : updatedGeo;
     }
 
     /**

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -660,7 +660,7 @@ public class ExchangeService {
         final Geo updatedGeo = geo != null
                 ? geo.toBuilder().lat(null).lon(null).metro(null).city(null).zip(null).build()
                 : null;
-        return Geo.isEmpty(updatedGeo) ? null : updatedGeo;
+        return updatedGeo == null || updatedGeo.equals(Geo.EMPTY) ? null : updatedGeo;
     }
 
     /**

--- a/src/main/java/org/prebid/server/bidder/adkerneladn/AdkernelAdnBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adkerneladn/AdkernelAdnBidder.java
@@ -39,6 +39,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * AdkernelAdn {@link Bidder} implementation.
+ */
 public class AdkernelAdnBidder implements Bidder<BidRequest> {
 
     private static final TypeReference<ExtPrebid<?, ExtImpAdkernelAdn>> ADKERNELADN_EXT_TYPE_REFERENCE =
@@ -96,7 +99,9 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         return adkernelAdnExt;
     }
 
-    // Group impressions by AdKernel-specific parameters `pubId` & `host`.
+    /**
+     * Group impressions by AdKernel-specific parameters `pubId` & `host`.
+     */
     private static Map<ExtImpAdkernelAdn, List<Imp>> dispatchImpressions(List<Imp> imps,
                                                                          List<ExtImpAdkernelAdn> impExts) {
         final Map<ExtImpAdkernelAdn, List<Imp>> result = new HashMap<>();
@@ -110,7 +115,9 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         return result;
     }
 
-    // Alter impression info to comply with adkernel platform requirements.
+    /**
+     * Alter impression info to comply with adkernel platform requirements.
+     */
     private static Imp compatImpression(Imp imp) {
         final Imp.ImpBuilder impBuilder = imp.toBuilder();
         final Banner compatBanner = imp.getBanner();
@@ -118,7 +125,7 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         impBuilder.ext(null); // do not forward ext to adkernel platform
 
         if (compatBanner != null && compatBanner.getW() == null && compatBanner.getH() == null) {
-            //As banner.w/h are required fields for adkernel adn platform - take the first format entry
+            // As banner.w/h are required fields for adkernel adn platform - take the first format entry
             final List<Format> compatBannerFormat = compatBanner.getFormat();
 
             if (CollectionUtils.isEmpty(compatBannerFormat)) {
@@ -188,7 +195,9 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
         return bidRequestBuilder.build();
     }
 
-    // Builds endpoint url based on adapter-specific pub settings from imp.ext
+    /**
+     * Builds endpoint url based on adapter-specific pub settings from imp.ext.
+     */
     private static String buildEndpoint(ExtImpAdkernelAdn impExt, String endpointUrl) {
         final String updatedEndpointUrl;
 
@@ -237,7 +246,9 @@ public class AdkernelAdnBidder implements Bidder<BidRequest> {
                 .collect(Collectors.toList());
     }
 
-    // Figures out which media type this bid is for.
+    /**
+     * Figures out which media type this bid is for.
+     */
     private static BidType getType(String impId, List<Imp> imps) {
         for (Imp imp : imps) {
             if (imp.getId().equals(impId) && imp.getVideo() != null) {

--- a/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
+++ b/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
@@ -413,7 +413,7 @@ public class BeachfrontBidder implements Bidder<BeachfrontRequests> {
             return Result.emptyWithError(BidderError.badServerResponse("Received a null response from beachfront"));
         }
 
-        //Beachfront sending an empty array and 200 as their "no results" response.
+        // Beachfront sending an empty array and 200 as their "no results" response.
         if (bodyString.equals("[]")) {
             return Result.of(Collections.emptyList(), Collections.emptyList());
         }

--- a/src/main/java/org/prebid/server/bidder/brightroll/BrightrollBidder.java
+++ b/src/main/java/org/prebid/server/bidder/brightroll/BrightrollBidder.java
@@ -135,7 +135,7 @@ public class BrightrollBidder implements Bidder<BidRequest> {
     private static BidRequest updateBidRequest(BidRequest bidRequest, String firstImpExtPublisher,
                                                List<BidderError> errors) {
         final BidRequest.BidRequestBuilder builder = bidRequest.toBuilder();
-        //Defaulting to first price auction for all prebid requests
+        // Defaulting to first price auction for all prebid requests
         builder.at(1);
 
         final boolean isAdthrivePublisher = Objects.equals(firstImpExtPublisher, "adthrive");

--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -456,11 +456,11 @@ public class RequestValidator {
      * bidrequest.regs.ext and its gdpr value has different value to 0 or 1.
      */
     private void validateRegs(Regs regs) throws ValidationException {
-        if (regs != null) {
+        if (regs != null && regs.getExt() != null) {
             try {
                 final ExtRegs extRegs = Json.mapper.treeToValue(regs.getExt(), ExtRegs.class);
                 final Integer gdpr = extRegs == null ? null : extRegs.getGdpr();
-                if (gdpr != null && (gdpr < 0 || gdpr > 1)) {
+                if (gdpr != null && gdpr != 0 && gdpr != 1) {
                     throw new ValidationException("request.regs.ext.gdpr must be either 0 or 1");
                 }
             } catch (JsonProcessingException e) {

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -492,9 +492,11 @@ public class ExchangeServiceTest extends VertxTest {
                 .ext(mapper.valueToTree(ExtUser.of(null, null, null, null, null)))
                 .geo(Geo.builder().lon(-85.12F).lat(189.95F).build())
                 .build());
-        assertThat(capturedBidRequest.getDevice()).isEqualTo(Device.builder().ip("192.168.0.0")
+        assertThat(capturedBidRequest.getDevice()).isEqualTo(Device.builder()
+                .ip("192.168.0.0")
                 .ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:0")
-                .geo(Geo.builder().lon(-85.34F).lat(189.34F).build()).build());
+                .geo(Geo.builder().lon(-85.34F).lat(189.34F).build())
+                .build());
         assertThat(capturedBidRequest.getRegs()).isEqualTo(Regs.of(null, mapper.valueToTree(ExtRegs.of(1))));
     }
 
@@ -666,7 +668,7 @@ public class ExchangeServiceTest extends VertxTest {
                         .device(Device.builder()
                                 .ip("192.168.0.10")
                                 .ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
-                                .geo(Geo.builder().lon(-85.34321F).lat(189.342323F)
+                                .geo(Geo.builder().country("US").lon(-85.34321F).lat(189.342323F)
                                         .metro("metro").city("city").zip("zip").build())
                                 .ifa("ifa")
                                 .macsha1("macsha1")
@@ -687,11 +689,13 @@ public class ExchangeServiceTest extends VertxTest {
         final BidRequest capturedBidRequest = bidRequestCaptor.getValue();
         assertThat(capturedBidRequest.getUser()).isEqualTo(User.builder().buyeruid(null)
                 .ext(mapper.valueToTree(ExtUser.of(null, null, null, null, null)))
-                .geo(Geo.builder().lon(-85.12F).lat(189.95F).build())
+                .geo(null)
                 .build());
-        assertThat(capturedBidRequest.getDevice()).isEqualTo(Device.builder().ip("192.168.0.0")
+        assertThat(capturedBidRequest.getDevice()).isEqualTo(Device.builder()
+                .ip("192.168.0.0")
                 .ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:0")
-                .geo(Geo.builder().lon(-85.34F).lat(189.34F).build()).build());
+                .geo(Geo.builder().country("US").build())
+                .build());
         assertThat(capturedBidRequest.getRegs()).isEqualTo(Regs.of(1, mapper.valueToTree(ExtRegs.of(0))));
     }
 

--- a/src/test/resources/org/prebid/server/it/openrtb2/adkerneladn/test-auction-adkerneladn-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/adkerneladn/test-auction-adkerneladn-request.json
@@ -95,12 +95,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/adtelligent/test-auction-adtelligent-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/adtelligent/test-auction-adtelligent-request.json
@@ -75,12 +75,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/beachfront/test-auction-beachfront-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/beachfront/test-auction-beachfront-request.json
@@ -75,12 +75,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/brightroll/test-auction-brightroll-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/brightroll/test-auction-brightroll-request.json
@@ -78,12 +78,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/consumable/test-auction-consumable-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/consumable/test-auction-consumable-request.json
@@ -75,12 +75,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/conversant/alias/test-auction-conversant-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/conversant/alias/test-auction-conversant-request.json
@@ -77,12 +77,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/conversant/test-auction-conversant-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/conversant/test-auction-conversant-request.json
@@ -89,12 +89,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/eplanning/test-auction-eplanning-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/eplanning/test-auction-eplanning-request.json
@@ -77,12 +77,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/facebook/test-auction-facebook-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/facebook/test-auction-facebook-request.json
@@ -78,12 +78,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/gamoshi/test-auction-gamoshi-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/gamoshi/test-auction-gamoshi-request.json
@@ -95,12 +95,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/grid/test-auction-grid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/grid/test-auction-grid-request.json
@@ -74,12 +74,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/gumgum/test-auction-gumgum-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/gumgum/test-auction-gumgum-request.json
@@ -109,12 +109,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/improvedigital/test-auction-improvedigital-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/improvedigital/test-auction-improvedigital-request.json
@@ -80,12 +80,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/ix/test-auction-ix-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/ix/test-auction-ix-request.json
@@ -82,12 +82,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/lifestreet/test-auction-lifestreet-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/lifestreet/test-auction-lifestreet-request.json
@@ -93,12 +93,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/openx/test-auction-openx-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/openx/test-auction-openx-request.json
@@ -149,12 +149,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/pubmatic/test-auction-pubmatic-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/pubmatic/test-auction-pubmatic-request.json
@@ -117,12 +117,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/pulsepoint/test-auction-pulsepoint-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/pulsepoint/test-auction-pulsepoint-request.json
@@ -100,12 +100,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/rhythmone/test-auction-rhythmone-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rhythmone/test-auction-rhythmone-request.json
@@ -95,12 +95,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-request.json
@@ -200,12 +200,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
       },
-      "consent": "consentValue",
       "tpid": [
         {
           "source": "tdid",

--- a/src/test/resources/org/prebid/server/it/openrtb2/somoaudience/test-auction-somoaudience-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/somoaudience/test-auction-somoaudience-request.json
@@ -130,12 +130,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/sonobi/test-auction-sonobi-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/sonobi/test-auction-sonobi-request.json
@@ -87,12 +87,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/sovrn/test-auction-sovrn-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/sovrn/test-auction-sovrn-request.json
@@ -78,12 +78,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/ttx/test-auction-ttx-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/ttx/test-auction-ttx-request.json
@@ -78,12 +78,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/yieldmo/test-auction-yieldmo-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yieldmo/test-auction-yieldmo-request.json
@@ -72,12 +72,12 @@
   },
   "user": {
     "ext": {
+      "consent": "consentValue",
       "digitrust": {
         "id": "id",
         "keyv": 123,
         "pref": 0
-      },
-      "consent": "consentValue"
+      }
     }
   },
   "regs": {


### PR DESCRIPTION
This PR involves COPPA ([Children's Online Privacy Protection](http://www.coppa.org/)) support for Prebid Server.
It means if `request.regs.coppa == 1` the next updates will be applied:

For `request.device`:
- Removed `device.ifa`, `device.macsha1`, `device.macmd5`, `device.dpidsha1`, `device.dpidmd5`, `device.didsha1`, `device.didmd5` fields.
- Removed `device.geo.metro`, `device.geo.city` and `device.geo.zip` fields.
- Masked `device.geo.lat` and `device.geo.lon` fields (rounded values to two decimals).
- Rounded IP addresses for `device.ip` (remove lowest 8 bits) and `device.ipv6` (remove lowest 32 bits) fields.

For `request.user`:
- Removed `user.id`, `user.buyeruid`, `user.yob` and `user.gender` fields.
- Masked `user.geo.lat` and `user.geo.lon` fields (rounded values to two decimals).

Please, see https://github.com/prebid/prebid-server/issues/929 for more info.