### PR TITLE
Set default request.user.ext.digitrust.perf value to 0 if not defined

### DIFF
--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -425,7 +425,7 @@ public class RequestValidator {
                 }
 
                 final ExtUserDigiTrust digitrust = extUser.getDigitrust();
-                if (digitrust != null && !Objects.equals(digitrust.getPref(), 0)) {
+                if (digitrust != null && digitrust.getPref() != null && digitrust.getPref() != 0) {
                     throw new ValidationException("request.user contains a digitrust object that is not valid");
                 }
 

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -28,6 +28,8 @@ import org.prebid.server.proto.openrtb.ext.request.ExtPriceGranularity;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestTargeting;
 import org.prebid.server.proto.openrtb.ext.request.ExtSite;
+import org.prebid.server.proto.openrtb.ext.request.ExtUser;
+import org.prebid.server.proto.openrtb.ext.request.ExtUserDigiTrust;
 import org.prebid.server.validation.RequestValidator;
 import org.prebid.server.validation.model.ValidationResult;
 
@@ -335,6 +337,29 @@ public class AuctionRequestFactoryTest extends VertxTest {
 
         // then
         assertThat(result.getUser()).isNull();
+    }
+
+    @Test
+    public void shouldSetUserExtDigitrustPerfIfNotDefined() {
+        // given
+        givenBidRequest(BidRequest.builder()
+                .user(User.builder()
+                        .ext(mapper.valueToTree(ExtUser.builder()
+                                .digitrust(ExtUserDigiTrust.of("id", 123, null))
+                                .build()))
+                        .build())
+                .build());
+
+        given(uidsCookieService.parseHostCookie(any())).willReturn(null);
+
+        // when
+        final BidRequest result = factory.fromRequest(routingContext).result();
+
+        // then
+        assertThat(result.getUser().getExt())
+                .isEqualTo(mapper.valueToTree(ExtUser.builder()
+                        .digitrust(ExtUserDigiTrust.of("id", 123, 0))
+                        .build()));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -1629,7 +1629,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder()
                 .user(User.builder()
                         .ext(mapper.valueToTree(ExtUser.builder()
-                                .digitrust(ExtUserDigiTrust.of(null, null, null)).build()))
+                                .digitrust(ExtUserDigiTrust.of(null, null, 1)).build()))
                         .build())
                 .build();
 

--- a/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-request.json
@@ -203,8 +203,7 @@
       "consent": "consentValue",
       "digitrust": {
         "id": "id",
-        "keyv": 123,
-        "pref": 0
+        "keyv": 123
       },
       "eids": [
         {


### PR DESCRIPTION
Example OpebRTB request:
```
{
...
  "user": {
    "ext": {
      "digitrust": {
        "id": "id",
        "keyv": 1
      }
    }
  }
...
}
```

will result in exchange request:
```
{
...
  "user": {
    "ext": {
      "digitrust": {
        "id": "id",
        "keyv": 1,
        "pref": 0
      }
    }
  }
...
}
```
