### PR TITLE
Make GdprService use Account from AuctionContext

### DIFF
--- a/src/main/java/org/prebid/server/auction/PrivacyEnforcementService.java
+++ b/src/main/java/org/prebid/server/auction/PrivacyEnforcementService.java
@@ -59,12 +59,12 @@ public class PrivacyEnforcementService {
      */
     Future<Map<String, PrivacyEnforcementResult>> mask(Map<String, User> bidderToUser, ExtUser extUser,
                                                        List<String> bidders, Map<String, String> aliases,
-                                                       BidRequest bidRequest, String publisherId, Timeout timeout) {
+                                                       BidRequest bidRequest, Boolean isGdprEnforced, Timeout timeout) {
         final Regs regs = bidRequest.getRegs();
         final ExtRegs extRegs = extRegs(regs);
         final Device device = bidRequest.getDevice();
 
-        return getVendorsToGdprPermission(device, bidders, aliases, publisherId, extUser, extRegs, timeout)
+        return getVendorsToGdprPermission(device, bidders, aliases, extUser, extRegs, timeout, isGdprEnforced)
                 .map(vendorToGdprPermission -> getBidderToPrivacyEnforcementResult(bidderToUser, regs, extRegs, device,
                         aliases, vendorToGdprPermission));
     }
@@ -97,8 +97,8 @@ public class PrivacyEnforcementService {
      * it means that pbs not enforced particular bidder to follow pbs GDPR procedure.
      */
     private Future<Map<Integer, Boolean>> getVendorsToGdprPermission(
-            Device device, List<String> bidders, Map<String, String> aliases, String publisherId, ExtUser extUser,
-            ExtRegs extRegs, Timeout timeout) {
+            Device device, List<String> bidders, Map<String, String> aliases, ExtUser extUser, ExtRegs extRegs,
+            Timeout timeout, Boolean isGdprEnforced) {
 
         final Integer gdpr = extRegs != null ? extRegs.getGdpr() : null;
         final String gdprAsString = gdpr != null ? gdpr.toString() : null;
@@ -106,11 +106,10 @@ public class PrivacyEnforcementService {
         final String ipAddress = useGeoLocation && device != null ? device.getIp() : null;
         final Set<Integer> vendorIds = extractGdprEnforcedVendors(bidders, aliases);
 
-        return gdprService.isGdprEnforced(gdprAsString, publisherId, vendorIds, timeout)
-                .compose(gdprEnforced -> !gdprEnforced
-                        ? Future.succeededFuture(Collections.emptyMap())
-                        : gdprService.resultByVendor(vendorIds, gdprAsString, gdprConsent, ipAddress, timeout)
-                        .map(GdprResponse::getVendorsToGdpr));
+        return gdprService.isGdprEnforced(gdprAsString, isGdprEnforced, vendorIds)
+                ? gdprService.resultByVendor(vendorIds, gdprAsString, gdprConsent, ipAddress, timeout)
+                .map(GdprResponse::getVendorsToGdpr)
+                : Future.succeededFuture(Collections.emptyMap());
     }
 
     /**

--- a/src/main/java/org/prebid/server/gdpr/GdprService.java
+++ b/src/main/java/org/prebid/server/gdpr/GdprService.java
@@ -11,15 +11,12 @@ import lombok.Value;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.exception.InvalidRequestException;
-import org.prebid.server.exception.PreBidException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.gdpr.model.GdprPurpose;
 import org.prebid.server.gdpr.model.GdprResponse;
 import org.prebid.server.gdpr.vendorlist.VendorListService;
 import org.prebid.server.geolocation.GeoLocationService;
 import org.prebid.server.geolocation.model.GeoInfo;
-import org.prebid.server.settings.ApplicationSettings;
-import org.prebid.server.settings.model.Account;
 
 import java.util.HashMap;
 import java.util.List;
@@ -42,15 +39,13 @@ public class GdprService {
     private static final String GDPR_ZERO = "0";
     private static final String GDPR_ONE = "1";
 
-    private final ApplicationSettings applicationSettings;
     private final GeoLocationService geoLocationService;
     private final List<String> eeaCountries;
     private final VendorListService vendorListService;
     private final String gdprDefaultValue;
 
-    public GdprService(ApplicationSettings applicationSettings, GeoLocationService geoLocationService,
-                       VendorListService vendorListService, List<String> eeaCountries, String gdprDefaultValue) {
-        this.applicationSettings = Objects.requireNonNull(applicationSettings);
+    public GdprService(GeoLocationService geoLocationService, VendorListService vendorListService,
+                       List<String> eeaCountries, String gdprDefaultValue) {
         this.geoLocationService = geoLocationService;
         this.eeaCountries = Objects.requireNonNull(eeaCountries);
         this.vendorListService = Objects.requireNonNull(vendorListService);
@@ -64,32 +59,10 @@ public class GdprService {
      * - If GDPR doesn't enforced by account - returns FALSE.
      * - If there are no GDPR enforced vendors - returns FALSE.
      */
-    public Future<Boolean> isGdprEnforced(String gdpr, String accountId, Set<Integer> vendorIds, Timeout timeout) {
+    public boolean isGdprEnforced(String gdpr, Boolean isGdprEnforced, Set<Integer> vendorIds) {
         return isValidGdpr(gdpr)
-                ? Future.succeededFuture(gdpr.equals(GDPR_ONE))
-                : isGdprEnforcedByAccount(accountId, timeout)
-                .map(gdprEnforced -> ObjectUtils.defaultIfNull(gdprEnforced, !vendorIds.isEmpty()));
-    }
-
-    /**
-     * Returns enforce GDPR flag for the given account.
-     * <p>
-     * This data is not critical, so returns null if any error occurred.
-     */
-    private Future<Boolean> isGdprEnforcedByAccount(String accountId, Timeout timeout) {
-        return applicationSettings.getAccountById(accountId, timeout)
-                .map(Account::getEnforceGdpr)
-                .otherwise(GdprService::accountFallback);
-    }
-
-    /**
-     * Returns null if account is not found or any exception occurred.
-     */
-    private static Boolean accountFallback(Throwable exception) {
-        if (!(exception instanceof PreBidException)) {
-            logger.warn("Error occurred while fetching account", exception);
-        }
-        return null;
+                ? gdpr.equals(GDPR_ONE)
+                : ObjectUtils.defaultIfNull(isGdprEnforced, !vendorIds.isEmpty());
     }
 
     /**

--- a/src/main/java/org/prebid/server/gdpr/GdprService.java
+++ b/src/main/java/org/prebid/server/gdpr/GdprService.java
@@ -59,10 +59,10 @@ public class GdprService {
      * - If GDPR doesn't enforced by account - returns FALSE.
      * - If there are no GDPR enforced vendors - returns FALSE.
      */
-    public boolean isGdprEnforced(String gdpr, Boolean isGdprEnforced, Set<Integer> vendorIds) {
+    public boolean isGdprEnforced(String gdpr, Boolean isGdprEnforcedByAccount, Set<Integer> vendorIds) {
         return isValidGdpr(gdpr)
                 ? gdpr.equals(GDPR_ONE)
-                : ObjectUtils.defaultIfNull(isGdprEnforced, !vendorIds.isEmpty());
+                : ObjectUtils.defaultIfNull(isGdprEnforcedByAccount, !vendorIds.isEmpty());
     }
 
     /**

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -239,14 +239,13 @@ public class ServiceConfiguration {
 
     @Bean
     GdprService gdprService(
-            ApplicationSettings applicationSettings,
             @Autowired(required = false) GeoLocationService geoLocationService,
             VendorListService vendorListService,
             @Value("${gdpr.eea-countries}") String eeaCountriesAsString,
             @Value("${gdpr.default-value}") String defaultValue) {
 
         final List<String> eeaCountries = Arrays.asList(eeaCountriesAsString.trim().split(","));
-        return new GdprService(applicationSettings, geoLocationService, vendorListService, eeaCountries, defaultValue);
+        return new GdprService(geoLocationService, vendorListService, eeaCountries, defaultValue);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
@@ -79,8 +79,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     public void setUp() {
         given(bidderCatalog.bidderInfoByName(anyString())).willReturn(givenBidderInfo(15, true));
 
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(true));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(true);
         given(gdprService.resultByVendor(any(), any(), any(), any(), any()))
                 .willReturn(Future.succeededFuture(GdprResponse.of(true, singletonMap(15, false), null)));
 
@@ -99,11 +98,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
                         .regs(null));
 
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(emptyMap(), null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(emptyMap(), null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, true, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(true), eq(singleton(15)));
         verify(gdprService).resultByVendor(eq(singleton(15)), isNull(), any(), any(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
 
@@ -111,7 +110,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     }
 
     @Test
-    public void shouldNotMaskWhenDeviceLmtIsNullAndExtRegsGdprIsOneAndGdprServiceRespondIsGdprEnforcedWithTrueAndResultByVendorWithoutEnforcement() {
+    public void shouldNotMaskWhenDeviceLmtIsNullAndExtRegsGdprIsOneAndGdprEnforcedIsTrueAndResultByVendorWithoutEnforcement() {
         // given
         given(gdprService.resultByVendor(any(), any(), any(), any(), any()))
                 .willReturn(Future.succeededFuture(GdprResponse.of(true, singletonMap(15, true), null)));
@@ -131,11 +130,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, true, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(eq("1"), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(eq("1"), eq(true), eq(singleton(15)));
         verify(gdprService).resultByVendor(eq(singleton(15)), eq("1"), any(), any(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
 
@@ -147,8 +146,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     @Test
     public void shouldNotMaskWhenExtDeviceLmtIsNullAndGdprServiceRespondIsGdprEnforcedWithFalse() {
         // given
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(false));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(false);
 
         final User user = notMaskedUser();
         final Device device = notMaskedDevice();
@@ -162,11 +160,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, false, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(false), eq(singleton(15)));
         verifyNoMoreInteractions(gdprService);
 
         final PrivacyEnforcementResult expected = PrivacyEnforcementResult.of(user, device, null);
@@ -177,8 +175,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     @Test
     public void shouldNotMaskWhenExtRegsGdprIsOneDeviceLmtIsNullAndGdprServiceRespondIsGdprEnforcedWithFalse() {
         // given
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(false));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(false);
 
         final User user = notMaskedUser();
         final Device device = notMaskedDevice();
@@ -194,11 +191,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, false, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(eq("1"), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(eq("1"), eq(false), eq(singleton(15)));
         verifyNoMoreInteractions(gdprService);
 
         final PrivacyEnforcementResult expected = PrivacyEnforcementResult.of(user, device, regs);
@@ -207,10 +204,9 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     }
 
     @Test
-    public void shouldNotMaskWhenDeviceLmtIsZeroAndRegsCoppaIsZeroAndExtRegsGdprIsZeroGdprServiceRespondIsGdprEnforcedWithFalse() {
+    public void shouldNotMaskWhenDeviceLmtIsZeroAndRegsCoppaIsZeroAndExtRegsGdprIsZeroAndGdprEnforcedIsFalse() {
         // given
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(false));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(false);
 
         final Regs regs = Regs.of(0, mapper.valueToTree(ExtRegs.of(0)));
         final User user = notMaskedUser();
@@ -226,11 +222,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, false, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(eq("0"), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(eq("0"), eq(false), eq(singleton(15)));
         verifyNoMoreInteractions(gdprService);
 
         final PrivacyEnforcementResult expected = PrivacyEnforcementResult.of(user, device, regs);
@@ -257,13 +253,13 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, null, singletonList(BIDDER_NAME), aliases, bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, null, singletonList(BIDDER_NAME), aliases, bidRequest, true, timeout)
                 .result();
 
         // then
         verify(bidderCatalog, times(2)).bidderInfoByName(BIDDER_NAME);
         verifyNoMoreInteractions(bidderCatalog);
-        verify(gdprService).isGdprEnforced(eq("1"), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(eq("1"), eq(true), eq(singleton(15)));
         verify(gdprService).resultByVendor(eq(singleton(15)), eq("1"), any(), any(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
         verify(metrics).updateGdprMaskedMetric(BIDDER_NAME);
@@ -279,8 +275,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     @Test
     public void shouldMaskForCoppaWhenRegsCoppaIsOne() {
         // given
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(false));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(false);
 
         final Regs regs = Regs.of(1, null);
         final User user = notMaskedUser();
@@ -296,11 +291,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, false, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(false), eq(singleton(15)));
         verifyNoMoreInteractions(gdprService);
 
         final PrivacyEnforcementResult expected = PrivacyEnforcementResult.of(userCoppaMasked(), deviceCoppaMasked(),
@@ -310,7 +305,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     }
 
     @Test
-    public void shouldMaskForGdprWhenGdprServiceRespondIsGdprEnforcedWithTrueAndResultByVendorWithEnforcementResponse() {
+    public void shouldMaskForGdprWhenGdprEnforcedIsTrueAndResultByVendorWithEnforcementResponse() {
         // given
         final ExtUser extUser = ExtUser.builder().build();
         final User user = notMaskedUser();
@@ -326,11 +321,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, true, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(true), eq(singleton(15)));
         verify(gdprService).resultByVendor(eq(singleton(15)), isNull(), any(), any(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
         verify(metrics).updateGdprMaskedMetric(eq(BIDDER_NAME));
@@ -346,8 +341,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     @Test
     public void shouldMaskForGdprWhenGdprServiceRespondIsGdprEnforcedWithFalseAndDeviceLmtIsOne() {
         // given
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(false));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(false);
 
         final ExtUser extUser = ExtUser.builder().build();
         final User user = notMaskedUser();
@@ -364,11 +358,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, false, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(false), eq(singleton(15)));
         verifyNoMoreInteractions(gdprService);
         verify(metrics).updateGdprMaskedMetric(eq(BIDDER_NAME));
         verifyNoMoreInteractions(metrics);
@@ -382,10 +376,9 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     }
 
     @Test
-    public void shouldMaskForGdprAndCoppaWhenGdprServiceRespondIsGdprEnforcedWithFalseAndDeviceLmtIsOneAndRegsCoppaIsOne() {
+    public void shouldMaskForGdprAndCoppaWhenGdprEnforcedIsFalseAndDeviceLmtIsOneAndRegsCoppaIsOne() {
         // given
-        given(gdprService.isGdprEnforced(any(), any(), any(), any()))
-                .willReturn(Future.succeededFuture(false));
+        given(gdprService.isGdprEnforced(any(), any(), any())).willReturn(false);
 
         final ExtUser extUser = ExtUser.builder().build();
         final User user = notMaskedUser();
@@ -402,11 +395,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, false, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(false), eq(singleton(15)));
         verifyNoMoreInteractions(gdprService);
         verify(metrics).updateGdprMaskedMetric(eq(BIDDER_NAME));
         verifyNoMoreInteractions(metrics);
@@ -437,7 +430,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, null, singletonList(BIDDER_NAME), emptyMap(), bidRequest, true, timeout)
                 .result();
 
         // then
@@ -468,10 +461,10 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Future<Map<String, PrivacyEnforcementResult>> firstFuture = privacyEnforcementService
-                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout);
+                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, true, timeout);
 
         // then
-        verify(gdprService).isGdprEnforced(isNull(), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(isNull(), eq(true), eq(singleton(15)));
         verify(gdprService).resultByVendor(eq(singleton(15)), isNull(), any(), any(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
         verifyZeroInteractions(metrics);
@@ -491,7 +484,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
         // when and then
         assertThatExceptionOfType(PreBidException.class)
                 .isThrownBy(() -> privacyEnforcementService.mask(emptyMap(), null, singletonList(BIDDER_NAME),
-                        emptyMap(), bidRequest, PUBLISHER_ID, timeout))
+                        emptyMap(), bidRequest, true, timeout))
                 .withMessageStartingWith("Error decoding bidRequest.regs.ext:");
     }
 
@@ -513,11 +506,11 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, extUser, singletonList(BIDDER_NAME), emptyMap(), bidRequest, true, timeout)
                 .result();
 
         // then
-        verify(gdprService).isGdprEnforced(eq("1"), eq(PUBLISHER_ID), eq(singleton(15)), eq(timeout));
+        verify(gdprService).isGdprEnforced(eq("1"), eq(true), eq(singleton(15)));
         verify(gdprService).resultByVendor(eq(singleton(15)), eq("1"), any(), any(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
         verify(metrics).updateGdprMaskedMetric(eq(BIDDER_NAME));
@@ -569,7 +562,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
 
         // when
         final Map<String, PrivacyEnforcementResult> result = privacyEnforcementService
-                .mask(bidderToUser, extUser, bidders, emptyMap(), bidRequest, PUBLISHER_ID, timeout)
+                .mask(bidderToUser, extUser, bidders, emptyMap(), bidRequest, true, timeout)
                 .result();
 
         // then
@@ -579,7 +572,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
                 userGdprMasked(), deviceGdprMasked(), expectedRegs);
         final PrivacyEnforcementResult expectedNotMasked = PrivacyEnforcementResult.of(user, device, regs);
 
-        verify(gdprService).isGdprEnforced(eq("1"), eq(PUBLISHER_ID), anySet(), eq(timeout));
+        verify(gdprService).isGdprEnforced(eq("1"), eq(true), anySet());
         verify(gdprService).resultByVendor(anySet(), eq("1"), isNull(), isNull(), eq(timeout));
         verifyNoMoreInteractions(gdprService);
         verify(metrics).updateGdprMaskedMetric(bidder1Name);


### PR DESCRIPTION
- Changed GdprService to use `Boolean isGdprEnforced` value from AuctionContext's Account, instead of calling `ApplicationSettings.getAccountById` and retrieving `isGdprEnforced` from it;
- Corrected unit tests to reflect the changes.