### PR TITLE
Omit request.user.ext.rp.target if empty in Rubicon bidder

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconAdapter.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconAdapter.java
@@ -214,7 +214,7 @@ public class RubiconAdapter extends OpenrtbAdapter {
 
     private static JsonNode makeInventory(RubiconParams rubiconParams) {
         final JsonNode inventory = rubiconParams.getInventory();
-        return !inventory.isNull() ? inventory : null;
+        return !inventory.isNull() && inventory.size() != 0 ? inventory : null;
     }
 
     private static RubiconImpExtRpTrack makeImpExtRpTrack(PreBidRequestContext preBidRequestContext) {
@@ -333,7 +333,7 @@ public class RubiconAdapter extends OpenrtbAdapter {
     private static RubiconUserExt makeUserExt(RubiconParams rubiconParams, User user, ExtUser extUser) {
         final ExtUserDigiTrust digiTrust = extUser != null ? extUser.getDigitrust() : null; // will be removed
         final JsonNode visitorNode = rubiconParams.getVisitor();
-        final JsonNode visitor = !visitorNode.isNull() ? visitorNode : null;
+        final JsonNode visitor = !visitorNode.isNull() && visitorNode.size() != 0 ? visitorNode : null;
         final String gender = user != null ? user.getGender() : null;
         final Integer yob = user != null ? user.getYob() : null;
         final Geo geo = user != null ? user.getGeo() : null;

--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
@@ -267,7 +267,8 @@ public class RubiconBidder implements Bidder<BidRequest> {
     private static JsonNode makeTarget(Imp imp, ExtImpRubicon rubiconImpExt, Site site, App app,
                                        boolean useFirstPartyData) {
         final JsonNode inventory = rubiconImpExt.getInventory();
-        final ObjectNode inventoryNode = inventory.isNull() ? Json.mapper.createObjectNode() : (ObjectNode) inventory;
+        final ObjectNode inventoryNode = inventory.isNull() || inventory.size() == 0 ? Json.mapper.createObjectNode()
+                : (ObjectNode) inventory;
 
         if (useFirstPartyData) {
             final ExtImpContext context = extImpContext(imp);
@@ -470,7 +471,8 @@ public class RubiconBidder implements Bidder<BidRequest> {
     }
 
     private static RubiconUserExtRp rubiconUserExtRp(User user, ExtImpRubicon rubiconImpExt) {
-        final JsonNode visitor = !rubiconImpExt.getVisitor().isNull() ? rubiconImpExt.getVisitor() : null;
+        final JsonNode impExtVisitor = rubiconImpExt.getVisitor();
+        final JsonNode visitor = !impExtVisitor.isNull() && impExtVisitor.size() != 0 ? impExtVisitor : null;
 
         final boolean hasUser = user != null;
         final String gender = hasUser ? user.getGender() : null;

--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
@@ -267,8 +267,7 @@ public class RubiconBidder implements Bidder<BidRequest> {
     private static JsonNode makeTarget(Imp imp, ExtImpRubicon rubiconImpExt, Site site, App app,
                                        boolean useFirstPartyData) {
         final JsonNode inventory = rubiconImpExt.getInventory();
-        final ObjectNode inventoryNode = inventory.isNull() || inventory.size() == 0 ? Json.mapper.createObjectNode()
-                : (ObjectNode) inventory;
+        final ObjectNode inventoryNode = inventory.isNull() ? Json.mapper.createObjectNode() : (ObjectNode) inventory;
 
         if (useFirstPartyData) {
             final ExtImpContext context = extImpContext(imp);

--- a/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
@@ -336,6 +336,29 @@ public class RubiconBidderTest extends VertxTest {
     }
 
     @Test
+    public void makeHttpRequestsShouldNotFillUserExtRpWhenVisitorAndInventoryIsEmpty() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                builder -> builder.user(User.builder().id("id").build()),
+                builder -> builder.video(Video.builder().build()),
+                builder -> {
+                    builder.visitor(mapper.valueToTree("{}"));
+                    builder.inventory(mapper.valueToTree("{}"));
+                    return builder;
+                });
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1).doesNotContainNull()
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .extracting(BidRequest::getUser).doesNotContainNull()
+                .containsOnly(User.builder().id("id").build());
+    }
+
+    @Test
     public void makeHttpRequestsShouldFillUserExtIfUserAndDigiTrustPresent() {
         // given
         final BidRequest bidRequest = givenBidRequest(

--- a/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
@@ -341,11 +341,9 @@ public class RubiconBidderTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(
                 builder -> builder.user(User.builder().id("id").build()),
                 builder -> builder.video(Video.builder().build()),
-                builder -> {
-                    builder.visitor(mapper.valueToTree("{}"));
-                    builder.inventory(mapper.valueToTree("{}"));
-                    return builder;
-                });
+                builder -> builder
+                        .visitor(mapper.createObjectNode())
+                        .inventory(mapper.createObjectNode()));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);


### PR DESCRIPTION
Fix rubicon empty user.target when inventory and visitor is empty