### PR TITLE
Add handling of format parameter in /setuid

### DIFF
--- a/docs/endpoints/setuid.md
+++ b/docs/endpoints/setuid.md
@@ -13,6 +13,7 @@ This endpoint saves a UserID for a Bidder in the Cookie. Saved IDs will be recog
 - `uid`: The ID which the Bidder uses to recognize this user. If undefined, the UID for `bidder` will be deleted.
 - `gdpr`: This should be `1` if GDPR is in effect, `0` if not, and undefined if the caller isn't sure
 - `gdpr_consent`: This is required if `gdpr` is one, and optional (but encouraged) otherwise. If present, it should be an [unpadded base64-URL](https://tools.ietf.org/html/rfc4648#page-7) encoded [Vendor Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-).
+- `format`: is optional. When `format=img`, response will include `tracking-pixel.png` file.
 
 If the `gdpr` and `gdpr_consent` params are included, this endpoint will _not_ write a cookie unless:
 

--- a/src/main/java/org/prebid/server/handler/SetuidHandler.java
+++ b/src/main/java/org/prebid/server/handler/SetuidHandler.java
@@ -36,6 +36,9 @@ public class SetuidHandler implements Handler<RoutingContext> {
     private static final String GDPR_PARAM = "gdpr";
     private static final String GDPR_CONSENT_PARAM = "gdpr_consent";
     private static final String UID_PARAM = "uid";
+    private static final String FORMAT_PARAM = "format";
+    private static final String IMG_FORMAT_PARAM = "img";
+    private static final String PIXEL_FILE_PATH = "static/tracking-pixel.png";
 
     private final long defaultTimeout;
     private final UidsCookieService uidsCookieService;
@@ -145,7 +148,15 @@ public class SetuidHandler implements Handler<RoutingContext> {
         }
 
         final Cookie cookie = uidsCookieService.toCookie(updatedUidsCookie);
-        context.addCookie(cookie).response().end();
+        context.addCookie(cookie);
+
+        // Send pixel file to response if "format=img"
+        final String format = context.request().getParam(FORMAT_PARAM);
+        if (StringUtils.equals(format, IMG_FORMAT_PARAM)) {
+            context.response().sendFile(PIXEL_FILE_PATH);
+        } else {
+            context.response().end();
+        }
 
         analyticsReporter.processEvent(SetuidEvent.builder()
                 .status(HttpResponseStatus.OK.code())

--- a/src/test/java/org/prebid/server/handler/SetuidHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/SetuidHandlerTest.java
@@ -184,6 +184,7 @@ public class SetuidHandlerTest extends VertxTest {
         setuidHandler.handle(routingContext);
 
         // then
+        verify(httpResponse, never()).sendFile(any());
         verify(routingContext, never()).addCookie(any());
         verify(httpResponse).setStatusCode(eq(500));
         verify(httpResponse).end(eq("Unexpected GDPR processing error"));
@@ -224,6 +225,7 @@ public class SetuidHandlerTest extends VertxTest {
         given(uidsCookieService.parseFromRequest(any())).willReturn(new UidsCookie(Uids.builder().uids(uids).build()));
 
         given(httpRequest.getParam("bidder")).willReturn(RUBICON);
+        given(httpRequest.getParam("format")).willReturn("img");
 
         // this uids cookie stands for {"tempUIDs":{"adnxs":{"uid":"12345"}}}
         given(uidsCookieService.toCookie(any())).willReturn(Cookie
@@ -234,7 +236,7 @@ public class SetuidHandlerTest extends VertxTest {
 
         // then
         final Cookie uidsCookie = captureCookie();
-        verify(httpResponse).end();
+        verify(httpResponse).sendFile(any());
         // this uids cookie value stands for {"uids":{"adnxs":"12345"}}
         final Uids decodedUids = decodeUids(uidsCookie.getValue());
         assertThat(decodedUids.getUids()).hasSize(1);
@@ -260,6 +262,7 @@ public class SetuidHandlerTest extends VertxTest {
         // then
         final Cookie uidsCookie = captureCookie();
         verify(httpResponse).end();
+        verify(httpResponse, never()).sendFile(any());
         // this uids cookie value stands for {"uids":{"audienceNetwork":"facebookUid"}}
         final Uids decodedUids = decodeUids(uidsCookie.getValue());
         assertThat(decodedUids.getUids()).hasSize(1);
@@ -277,6 +280,7 @@ public class SetuidHandlerTest extends VertxTest {
                 .cookie("uids", "eyJ0ZW1wVUlEcyI6eyJydWJpY29uIjp7InVpZCI6Iko1VkxDV1FQLTI2LUNXRlQifX19"));
 
         given(httpRequest.getParam("bidder")).willReturn(RUBICON);
+        given(httpRequest.getParam("format")).willReturn("img");
         given(httpRequest.getParam("uid")).willReturn("J5VLCWQP-26-CWFT");
 
         given(httpResponse.setStatusCode(anyInt())).willReturn(httpResponse);
@@ -285,7 +289,7 @@ public class SetuidHandlerTest extends VertxTest {
         setuidHandler.handle(routingContext);
 
         // then
-        verify(httpResponse).end();
+        verify(httpResponse).sendFile(any());
         final Cookie uidsCookie = captureCookie();
         final Uids decodedUids = decodeUids(uidsCookie.getValue());
         assertThat(decodedUids.getUids()).hasSize(1);


### PR DESCRIPTION
When we receive /setuid...&format=img, we response with pixel file.  