### PR TITLE
Update appnexus and PBS java/go difference docs

### DIFF
--- a/docs/bidders/appnexus.md
+++ b/docs/bidders/appnexus.md
@@ -17,3 +17,29 @@ is not supplied for an `imp`, but `request.app.ext.prebid.source`
 and `request.app.ext.prebid.version` are supplied, the adapter will fill in a value for
 `diplaymanagerver`. It will concatonate the two `app` fields as `<source>-<version>` to fill in
 the empty `displaymanagerver` before sending the request to AppNexus.
+
+## Test Request
+
+The following test parameters can be used to verify that Prebid Server is working properly with the 
+Appnexus adapter. This example includes an `imp` object with an Appnexus test placement ID and sizes
+that would match with the test creative.
+
+```
+	"imp": [{
+		"id": "some-impression-id",
+		"banner": {
+			"format": [{
+				"w": 600,
+				"h": 500
+			}, {
+				"w": 300,
+				"h": 600
+			}]
+		},
+		"ext": {
+			"appnexus": {
+				"placementId": 13144370
+			}
+		}
+	}]
+```

--- a/docs/differenceBetweenPBSGo-and-Java.md
+++ b/docs/differenceBetweenPBSGo-and-Java.md
@@ -23,7 +23,6 @@ and not the other for an interim period. This page tracks known differences that
 1) PBS-Java supports per-account cache TTL and event URLs configuration in the database in columns `banner_cache_ttl`, `video_cache_ttl` and `events_enabled`.
 1) PBS-Java does not support passing bidder extensions in `imp[...].ext.prebid.bidder`. PBS-Go [PR 846](https://github.com/prebid/prebid-server/pull/846)
 1) PBS-Java responds with active bidders only in `/info/bidders` endpoint, although PBS-Go returns all implemented ones.
-1) PBS-Java supports COPPA ([Children's Online Privacy Protection](http://www.coppa.org/)). [PR 376](https://github.com/rubicon-project/prebid-server-java/pull/376)
 
 ## Minor differences
 

--- a/docs/pbs-java-and-go-features-review.md
+++ b/docs/pbs-java-and-go-features-review.md
@@ -15,7 +15,7 @@ User ID module |+|+
 Bid Categories |-|+
 Event endpoint |+|-
 Video Endpoint |-|+
-COPPA |+|-
+COPPA |+|+
 All adapters ported to OpenRTB |+|-
 Bidder Generator |+|-
 


### PR DESCRIPTION
Updated `docs/bidders/appnexus.md`, `docs/differenceBetweenPBSGo-and-Java.md` and `docs/pbs-java-and-go-features-review.md ` documents.