### PR TITLE
Event of Win/Imp type handling

### DIFF
--- a/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
@@ -11,7 +11,7 @@ public class NotificationEvent {
 
     String bidId;
 
-    Integer accountId;
+    String accountId;
 
     HttpContext httpContext;
 

--- a/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
@@ -6,9 +6,11 @@ import lombok.Value;
 @AllArgsConstructor(staticName = "of")
 @Value
 public class NotificationEvent {
+
     String type;
 
     String bidId;
 
-    String bidder;
+    String accountId;
 }
+

--- a/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
@@ -11,7 +11,7 @@ public class NotificationEvent {
 
     String bidId;
 
-    String accountId;
+    Integer accountId;
 
     HttpContext httpContext;
 }

--- a/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
@@ -7,12 +7,16 @@ import lombok.Value;
 @Value
 public class NotificationEvent {
 
-    String type;
+    Type type;
 
     String bidId;
 
     Integer accountId;
 
     HttpContext httpContext;
+
+    public enum Type {
+        win, imp
+    }
 }
 

--- a/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
@@ -12,5 +12,7 @@ public class NotificationEvent {
     String bidId;
 
     String accountId;
+
+    HttpContext httpContext;
 }
 

--- a/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
+++ b/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.prebid.server.analytics.AnalyticsReporter;
 import org.prebid.server.analytics.model.HttpContext;
 import org.prebid.server.analytics.model.NotificationEvent;
@@ -126,8 +127,8 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
         }
 
         final String account = queryParameters.get(ACCOUNT_PARAMETER);
-        if (StringUtils.isBlank(account)) {
-            final String accountErrorMessage = "'account' is required query parameter and can't be empty";
+        if (!NumberUtils.isCreatable(account)) {
+            final String accountErrorMessage = "'account' is required query parameter and must be a number";
             respondWithUnauthorized(response, accountErrorMessage);
             throw new InvalidRequestException(accountErrorMessage);
         }
@@ -155,7 +156,7 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
         final MultiMap queryParameters = context.request().params();
         final String type = queryParameters.get(TYPE_PARAMETER);
         final String bidId = queryParameters.get(BID_ID_PARAMETER);
-        final String accountId = queryParameters.get(ACCOUNT_PARAMETER);
+        final Integer accountId = NumberUtils.createInteger(queryParameters.get(ACCOUNT_PARAMETER));
         final HttpContext httpContext = HttpContext.from(context);
         return NotificationEvent.of(type, bidId, accountId, httpContext);
     }

--- a/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
+++ b/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
@@ -166,12 +166,7 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
     }
 
     private static NotificationEvent.Type toNotificationType(String type) {
-        if (Objects.equals(WIN_TYPE, type)) {
-            return NotificationEvent.Type.win;
-        } else if (Objects.equals(IMP_TYPE, type)) {
-            return NotificationEvent.Type.imp;
-        }
-        return null;
+        return Objects.equals(WIN_TYPE, type) ? NotificationEvent.Type.win : NotificationEvent.Type.imp;
     }
 
     private void respondWithOkStatus(HttpServerResponse response, String format) {

--- a/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
+++ b/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
@@ -15,7 +15,6 @@ import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.prebid.server.analytics.AnalyticsReporter;
 import org.prebid.server.analytics.model.HttpContext;
 import org.prebid.server.analytics.model.NotificationEvent;
@@ -134,8 +133,8 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
 
     private static void validateParametersForUnauthorizedError(MultiMap queryParameters) {
         final String account = queryParameters.get(ACCOUNT_PARAMETER);
-        if (!NumberUtils.isCreatable(account)) {
-            throw new InvalidRequestException("'account' is required query parameter and must be a number");
+        if (StringUtils.isBlank(account)) {
+            throw new InvalidRequestException("'account' is required query parameter and can't be empty");
         }
     }
 
@@ -161,7 +160,7 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
         final MultiMap queryParameters = context.request().params();
         final NotificationEvent.Type type = toNotificationType(queryParameters.get(TYPE_PARAMETER));
         final String bidId = queryParameters.get(BID_ID_PARAMETER);
-        final Integer accountId = NumberUtils.createInteger(queryParameters.get(ACCOUNT_PARAMETER));
+        final String accountId = queryParameters.get(ACCOUNT_PARAMETER);
         final HttpContext httpContext = HttpContext.from(context);
         return NotificationEvent.of(type, bidId, accountId, httpContext);
     }

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -323,8 +323,10 @@ public class WebConfiguration {
     }
 
     @Bean
-    NotificationEventHandler eventNotificationHandler(CompositeAnalyticsReporter compositeAnalyticsReporter) {
-        return NotificationEventHandler.create(compositeAnalyticsReporter);
+    NotificationEventHandler eventNotificationHandler(CompositeAnalyticsReporter compositeAnalyticsReporter,
+                                                      TimeoutFactory timeoutFactory,
+                                                      ApplicationSettings applicationSettings) {
+        return new NotificationEventHandler(compositeAnalyticsReporter, timeoutFactory, applicationSettings);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
@@ -266,7 +266,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .cookies(Collections.emptyMap())
                 .build();
 
-        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of("w", "bidId", 1233213,
+        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of(NotificationEvent.Type.win, "bidId", 1233213,
                 expectedHttpContext));
     }
 
@@ -315,7 +315,7 @@ public class NotificationEventHandlerTest extends VertxTest {
     }
 
     @Test
-    public void shouldNotRespondWithPixelAndContentTypeWhenRequestFormatNotDefined() {
+    public void shouldRespondWithNoContentWhenRequestFormatIsNotDefined() {
         // given
         given(httpRequest.params())
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
@@ -365,3 +365,4 @@ public class NotificationEventHandlerTest extends VertxTest {
         return captor.getValue();
     }
 }
+

--- a/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
@@ -129,27 +129,7 @@ public class NotificationEventHandlerTest extends VertxTest {
         // then
         assertThat(captureResponseStatusCode()).isEqualTo(401);
         assertThat(captureResponseBody())
-                .isEqualTo("'account' is required query parameter and must be a number");
-
-        verifyZeroInteractions(analyticsReporter);
-    }
-
-    @Test
-    public void shouldReturnUnauthorizedWhenAccountIsNotNumber() {
-        // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "id")
-                        .add("a", "notNumber"));
-
-        // when
-        notificationHandler.handle(routingContext);
-
-        // then
-        assertThat(captureResponseStatusCode()).isEqualTo(401);
-        assertThat(captureResponseBody())
-                .isEqualTo("'account' is required query parameter and must be a number");
+                .isEqualTo("'account' is required query parameter and can't be empty");
 
         verifyZeroInteractions(analyticsReporter);
     }
@@ -161,7 +141,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "id")
-                        .add("a", "1233211")
+                        .add("a", "acc")
                         .add("f", "invalid"));
 
         // when
@@ -204,7 +184,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "1233213"));
+                        .add("a", "acc"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.failedFuture(new PreBidException("Not Found")));
@@ -266,7 +246,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .cookies(Collections.emptyMap())
                 .build();
 
-        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of(NotificationEvent.Type.win, "bidId", 1233213,
+        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of(NotificationEvent.Type.win, "bidId", "1233213",
                 expectedHttpContext));
     }
 

--- a/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
@@ -118,7 +118,7 @@ public class NotificationEventHandlerTest extends VertxTest {
     }
 
     @Test
-    public void shouldReturnBadRequestWhenAccountWasNotDefined() {
+    public void shouldReturnUnauthorizedWhenAccountWasNotDefined() {
         // given
         given(httpRequest.params())
                 .willReturn(MultiMap.caseInsensitiveMultiMap().add("t", "w").add("b", "id"));
@@ -129,7 +129,27 @@ public class NotificationEventHandlerTest extends VertxTest {
         // then
         assertThat(captureResponseStatusCode()).isEqualTo(401);
         assertThat(captureResponseBody())
-                .isEqualTo("'account' is required query parameter and can't be empty");
+                .isEqualTo("'account' is required query parameter and must be a number");
+
+        verifyZeroInteractions(analyticsReporter);
+    }
+
+    @Test
+    public void shouldReturnUnauthorizedWhenAccountIsNotNumber() {
+        // given
+        given(httpRequest.params())
+                .willReturn(MultiMap.caseInsensitiveMultiMap()
+                        .add("t", "w")
+                        .add("b", "id")
+                        .add("a", "notNumber"));
+
+        // when
+        notificationHandler.handle(routingContext);
+
+        // then
+        assertThat(captureResponseStatusCode()).isEqualTo(401);
+        assertThat(captureResponseBody())
+                .isEqualTo("'account' is required query parameter and must be a number");
 
         verifyZeroInteractions(analyticsReporter);
     }
@@ -141,7 +161,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "id")
-                        .add("a", "account")
+                        .add("a", "1233211")
                         .add("f", "invalid"));
 
         // when
@@ -162,7 +182,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "id")
-                        .add("a", "account")
+                        .add("a", "1233211")
                         .add("f", "b")
                         .add("x", "invalid"));
 
@@ -184,7 +204,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "accountId"));
+                        .add("a", "1233213"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.failedFuture(new PreBidException("Not Found")));
@@ -206,7 +226,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "accountId"));
+                        .add("a", "1233213"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(false).build()));
@@ -228,7 +248,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "accountId"));
+                        .add("a", "1233213"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));
@@ -240,13 +260,13 @@ public class NotificationEventHandlerTest extends VertxTest {
         final Map<String, String> headers = new HashMap<>();
         headers.put("t", "w");
         headers.put("b", "bidId");
-        headers.put("a", "accountId");
+        headers.put("a", "1233213");
         final HttpContext expectedHttpContext = HttpContext.builder().queryParams(headers)
                 .headers(Collections.emptyMap())
                 .cookies(Collections.emptyMap())
                 .build();
 
-        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of("w", "bidId", "accountId",
+        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of("w", "bidId", 1233213,
                 expectedHttpContext));
     }
 
@@ -257,7 +277,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "accountId")
+                        .add("a", "1233213")
                         .add("x", "0"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
@@ -277,7 +297,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "accountId")
+                        .add("a", "1233213")
                         .add("f", "i"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
@@ -301,7 +321,7 @@ public class NotificationEventHandlerTest extends VertxTest {
                 .willReturn(MultiMap.caseInsensitiveMultiMap()
                         .add("t", "w")
                         .add("b", "bidId")
-                        .add("a", "accountId"));
+                        .add("a", "1233213"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));

--- a/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
@@ -260,14 +260,12 @@ public class NotificationEventHandlerTest extends VertxTest {
                         .add("a", "1233213")
                         .add("x", "0"));
 
-        given(applicationSettings.getAccountById(anyString(), any()))
-                .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));
-
         // when
         notificationHandler.handle(routingContext);
 
         // then
         verifyZeroInteractions(analyticsReporter);
+        verifyZeroInteractions(applicationSettings);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -490,7 +490,7 @@ public class ApplicationTest extends IntegrationTest {
     }
 
     @Test
-    public void eventHandlerShouldRespondWithJPGTrackingPixel() throws IOException {
+    public void eventHandlerShouldRespondWithPNGTrackingPixel() throws IOException {
         final Response response = given(spec)
                 .queryParam("t", "w")
                 .queryParam("b", "bidId")

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -492,16 +492,16 @@ public class ApplicationTest extends IntegrationTest {
     @Test
     public void eventHandlerShouldRespondWithJPGTrackingPixel() throws IOException {
         final Response response = given(spec)
-                .queryParam("type", "win")
-                .queryParam("bidid", "bidId")
-                .queryParam("bidder", "rubicon")
-                .queryParam("format", "jpg")
+                .queryParam("t", "w")
+                .queryParam("b", "bidId")
+                .queryParam("a", "14062")
+                .queryParam("f", "i")
                 .get("/event");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
-        assertThat(response.getHeaders()).contains(new Header("content-type", "image/jpeg"));
+        assertThat(response.getHeaders()).contains(new Header("content-type", "image/png"));
         assertThat(response.getBody().asByteArray())
-                .isEqualTo(ResourceUtil.readByteArrayFromClassPath("static/tracking-pixel.jpg"));
+                .isEqualTo(ResourceUtil.readByteArrayFromClassPath("static/tracking-pixel.png"));
     }
 
     @Test


### PR DESCRIPTION
Implementation for /event?t=(win|imp)&b=BIDID&a=ACCOUNT[&f=i&x=0]
ApplicationSettings for retrieving info about EventEnable for account.
We never send second response.
For emptyAccount we send 401, not 400.
Be aware that I use 14062 id from configuration for integration test.