### PR TITLE
Add impression tracking to VAST (Server-Side)

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -54,6 +54,9 @@ This parameter affects how many CPU cores will be utilized by the application. R
 - `cookie-sync.coop-sync.default` - default value for coopSync when it missing in requests to `/cookie_sync` endpoint.
 - `cookie-sync.coop-sync.pri` - lists of bidders prioritised in groups.
 
+## Events
+- `urltemplate` - template string for impression tracking, where `{BIDID}` placeholder is used for Bid's id and `{ACCOUNT}` - for Account's id
+
 ## Adapters
 - `adapters.*` - the section for bidder specific configuration options.
 

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -55,8 +55,8 @@ This parameter affects how many CPU cores will be utilized by the application. R
 - `cookie-sync.coop-sync.default` - default value for coopSync when it missing in requests to `/cookie_sync` endpoint.
 - `cookie-sync.coop-sync.pri` - lists of bidders prioritised in groups.
 
-## Events
-- `urltemplate` - template string for impression tracking, where `{BIDID}` placeholder is used for Bid's id and `{ACCOUNT}` - for Account's id
+## Event
+- `event.url-template` - template string for impression tracking, suffixed to `external-url`, where `BIDID` placeholder is used for Bid's id and `ACCOUNT` - for Account's id
 
 ## Adapters
 - `adapters.*` - the section for bidder specific configuration options.

--- a/docs/differenceBetweenPBSGo-and-Java.md
+++ b/docs/differenceBetweenPBSGo-and-Java.md
@@ -23,6 +23,7 @@ and not the other for an interim period. This page tracks known differences that
 1) PBS-Java supports per-account cache TTL and event URLs configuration in the database in columns `banner_cache_ttl`, `video_cache_ttl` and `events_enabled`.
 1) PBS-Java does not support passing bidder extensions in `imp[...].ext.prebid.bidder`. PBS-Go [PR 846](https://github.com/prebid/prebid-server/pull/846)
 1) PBS-Java responds with active bidders only in `/info/bidders` endpoint, although PBS-Go returns all implemented ones.
+1) PBS-Java supports video impression tracking [issue 1015](https://github.com/prebid/prebid-server/issues/1015). PBS-Java [PR 437](https://github.com/rubicon-project/prebid-server-java/pull/437). 
 
 ## Minor differences
 

--- a/docs/pbs-java-and-go-features-review.md
+++ b/docs/pbs-java-and-go-features-review.md
@@ -16,6 +16,7 @@ Bid Categories |-|+
 Event endpoint |+|-
 Video Endpoint |-|+
 COPPA |+|+
+Video Impression Tracking |+|-
 All adapters ported to OpenRTB |+|-
 Bidder Generator |+|-
 

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -930,7 +930,7 @@ public class ExchangeService {
 
     private static boolean isVideoBid(Bid bid, List<Imp> imps) {
         return imps.stream()
-                .filter(imp -> imp.getId() != null && imp.getVideo() != null)
+                .filter(imp -> imp.getVideo() != null)
                 .map(Imp::getId)
                 .anyMatch(impId -> bid.getImpid().equals(impId));
     }

--- a/src/main/java/org/prebid/server/bidder/BidderCatalog.java
+++ b/src/main/java/org/prebid/server/bidder/BidderCatalog.java
@@ -57,6 +57,13 @@ public class BidderCatalog {
     }
 
     /**
+     * Tells if given bidder allows to modify video's Vast XML.
+     */
+    public boolean isModifyingVastXmlAllowed(String name) {
+        return bidderDepsMap.containsKey(name) && bidderDepsMap.get(name).getBidderInfo().isModifyingVastXmlAllowed();
+    }
+
+    /**
      * Tells if given name corresponds to any of the registered deprecated bidder's name.
      */
     public boolean isDeprecatedName(String name) {

--- a/src/main/java/org/prebid/server/cache/CacheService.java
+++ b/src/main/java/org/prebid/server/cache/CacheService.java
@@ -152,20 +152,23 @@ public class CacheService {
             final Map<String, Integer> impIdToTtl = new HashMap<>(imps.size());
             boolean impWithNoExpExists = false; // indicates at least one impression without expire presents
             final List<String> videoImpIds = new ArrayList<>();
+            final boolean shouldCacheVideoBids = cacheContext.isShouldCacheVideoBids();
             for (Imp imp : imps) {
-                impIdToTtl.put(imp.getId(), imp.getExp());
+                final String impId = imp.getId();
+                impIdToTtl.put(impId, imp.getExp());
                 impWithNoExpExists |= imp.getExp() == null;
-                if (cacheContext.isShouldCacheVideoBids() && imp.getId() != null && imp.getVideo() != null) {
-                    videoImpIds.add(imp.getId());
+                if (shouldCacheVideoBids && impId != null && imp.getVideo() != null) {
+                    videoImpIds.add(impId);
                 }
             }
 
             final List<CacheBid> cacheBids = getCacheBids(cacheContext.isShouldCacheBids(), bids, impIdToTtl,
                     impWithNoExpExists, cacheContext.getCacheBidsTtl(), account);
-            final List<CacheBid> videoCacheBids = getVideoCacheBids(cacheContext.isShouldCacheVideoBids(), bids,
+            final List<CacheBid> videoCacheBids = getVideoCacheBids(shouldCacheVideoBids, bids,
                     impIdToTtl, videoImpIds, impWithNoExpExists, cacheContext.getCacheVideoBidsTtl(), account);
 
-            result = doCacheOpenrtb(cacheBids, videoCacheBids, timeout);
+            result = doCacheOpenrtb(cacheBids, videoCacheBids, cacheContext.getVideoBidIdsToModify(), account.getId(),
+                    timeout);
         }
 
         return result;
@@ -238,10 +241,11 @@ public class CacheService {
      * <p>
      * The returned result will always have the number of elements equals to sum of sizes of bids and video bids.
      */
-    private Future<CacheServiceResult> doCacheOpenrtb(List<CacheBid> bids, List<CacheBid> videoBids, Timeout timeout) {
+    private Future<CacheServiceResult> doCacheOpenrtb(List<CacheBid> bids, List<CacheBid> videoBids,
+                                                      List<String> bidIdsToModify, String accountId, Timeout timeout) {
         final List<PutObject> putObjects = Stream.concat(
                 bids.stream().map(CacheService::createJsonPutObjectOpenrtb),
-                videoBids.stream().map(CacheService::createXmlPutObjectOpenrtb))
+                videoBids.stream().map(cacheBid -> createXmlPutObjectOpenrtb(cacheBid, bidIdsToModify, accountId)))
                 .collect(Collectors.toList());
 
         if (putObjects.isEmpty()) {
@@ -326,16 +330,47 @@ public class CacheService {
     /**
      * Makes XML type {@link PutObject} from {@link com.iab.openrtb.response.Bid}. Used for OpenRTB auction request.
      */
-    private static PutObject createXmlPutObjectOpenrtb(CacheBid cacheBid) {
-        if (cacheBid.getBid().getAdm() == null) {
-            return PutObject.of("xml", new TextNode("<VAST version=\"3.0\"><Ad><Wrapper>"
+    private static PutObject createXmlPutObjectOpenrtb(CacheBid cacheBid, List<String> bidIdsToModify,
+                                                       String accountId) {
+        final com.iab.openrtb.response.Bid bid = cacheBid.getBid();
+        String stringValue;
+        if (bid.getAdm() == null) {
+            stringValue = "<VAST version=\"3.0\"><Ad><Wrapper>"
                     + "<AdSystem>prebid.org wrapper</AdSystem>"
-                    + "<VASTAdTagURI><![CDATA[" + cacheBid.getBid().getNurl() + "]]></VASTAdTagURI>"
+                    + "<VASTAdTagURI><![CDATA[" + bid.getNurl() + "]]></VASTAdTagURI>"
                     + "<Impression></Impression><Creatives></Creatives>"
-                    + "</Wrapper></Ad></VAST>"), cacheBid.getTtl());
+                    + "</Wrapper></Ad></VAST>";
         } else {
-            return PutObject.of("xml", new TextNode(cacheBid.getBid().getAdm()), cacheBid.getTtl());
+            stringValue = bid.getAdm();
         }
+
+        final String bidId = bid.getId();
+        if (CollectionUtils.isNotEmpty(bidIdsToModify) && bidIdsToModify.contains(bidId)) {
+            stringValue = modifyVastXml(stringValue, bidId, accountId);
+        }
+
+        return PutObject.of("xml", new TextNode(stringValue), cacheBid.getTtl());
+    }
+
+    private static String modifyVastXml(String stringValue, String bidId, String accountId) {
+        final String closeTag = "</Impression>";
+        final int closeTagIndex = stringValue.indexOf(closeTag);
+
+        // no impression tag - pass it as it is
+        if (closeTagIndex == -1) {
+            return stringValue;
+        }
+
+        final String impressionUrl = String.format("https://prebid-server.rubiconproject.com/event?t=imp&b=%s&f=b&a=%s",
+                bidId, accountId);
+        final String openTag = "<Impression>";
+
+        // empty impression tag - just insert the link
+        if (closeTagIndex - stringValue.indexOf(openTag) == openTag.length()) {
+            return stringValue.replaceFirst(openTag, openTag + impressionUrl);
+        }
+
+        return stringValue.replaceFirst(closeTag, closeTag + "\n" + openTag + impressionUrl + closeTag);
     }
 
     /**

--- a/src/main/java/org/prebid/server/cache/CacheService.java
+++ b/src/main/java/org/prebid/server/cache/CacheService.java
@@ -55,8 +55,8 @@ public class CacheService {
 
     private static final Logger logger = LoggerFactory.getLogger(CacheService.class);
 
-    private static final String BID_ID_PLACEHOLDER = "{BIDID}";
-    private static final String ACCOUNT_PLACEHOLDER = "{ACCOUNT}";
+    private static final String BID_ID_PLACEHOLDER = "BIDID";
+    private static final String ACCOUNT_PLACEHOLDER = "ACCOUNT";
 
     private final CacheTtl mediaTypeCacheTtl;
     private final HttpClient httpClient;

--- a/src/main/java/org/prebid/server/cache/CacheService.java
+++ b/src/main/java/org/prebid/server/cache/CacheService.java
@@ -55,6 +55,9 @@ public class CacheService {
 
     private static final Logger logger = LoggerFactory.getLogger(CacheService.class);
 
+    private static final String BID_ID_PLACEHOLDER = "{BIDID}";
+    private static final String ACCOUNT_PLACEHOLDER = "{ACCOUNT}";
+
     private final CacheTtl mediaTypeCacheTtl;
     private final HttpClient httpClient;
     private final URL endpointUrl;
@@ -364,7 +367,8 @@ public class CacheService {
             return stringValue;
         }
 
-        final String impressionUrl = String.format(eventsUrlTemplate, bidId, accountId);
+        final String impressionUrl = eventsUrlTemplate.replace(BID_ID_PLACEHOLDER, bidId)
+                .replace(ACCOUNT_PLACEHOLDER, accountId);
         final String openTag = "<Impression>";
 
         // empty impression tag - just insert the link

--- a/src/main/java/org/prebid/server/cache/model/CacheContext.java
+++ b/src/main/java/org/prebid/server/cache/model/CacheContext.java
@@ -1,12 +1,14 @@
 package org.prebid.server.cache.model;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
+
+import java.util.List;
 
 /**
  * Holds the state needed to perform caching response bids.
  */
-@AllArgsConstructor(staticName = "of")
+@Builder
 @Value
 public class CacheContext {
 
@@ -17,4 +19,6 @@ public class CacheContext {
     boolean shouldCacheVideoBids;
 
     Integer cacheVideoBidsTtl;
+
+    List<String> videoBidIdsToModify;
 }

--- a/src/main/java/org/prebid/server/proto/response/BidderInfo.java
+++ b/src/main/java/org/prebid/server/proto/response/BidderInfo.java
@@ -10,8 +10,6 @@ public class BidderInfo {
 
     boolean enabled;
 
-    boolean modifyingVastXmlAllowed;
-
     MaintainerInfo maintainer;
 
     CapabilitiesInfo capabilities;
@@ -20,15 +18,17 @@ public class BidderInfo {
 
     GdprInfo gdpr;
 
-    public static BidderInfo create(boolean enabled, boolean modifyingVastXmlAllowed, String maintainerEmail,
-                                    List<String> appMediaTypes, List<String> siteMediaTypes,
-                                    List<String> supportedVendors, int vendorId, boolean enforceGdpr) {
+    boolean modifyingVastXmlAllowed;
+
+    public static BidderInfo create(boolean enabled, String maintainerEmail, List<String> appMediaTypes,
+                                    List<String> siteMediaTypes, List<String> supportedVendors, int vendorId,
+                                    boolean enforceGdpr, boolean modifyingVastXmlAllowed) {
         final MaintainerInfo maintainer = new MaintainerInfo(maintainerEmail);
         final CapabilitiesInfo capabilities = new CapabilitiesInfo(platformInfo(appMediaTypes),
                 platformInfo(siteMediaTypes));
         final GdprInfo gdpr = new GdprInfo(vendorId, enforceGdpr);
 
-        return new BidderInfo(enabled, modifyingVastXmlAllowed, maintainer, capabilities, supportedVendors, gdpr);
+        return new BidderInfo(enabled, maintainer, capabilities, supportedVendors, gdpr, modifyingVastXmlAllowed);
     }
 
     private static PlatformInfo platformInfo(List<String> mediaTypes) {

--- a/src/main/java/org/prebid/server/proto/response/BidderInfo.java
+++ b/src/main/java/org/prebid/server/proto/response/BidderInfo.java
@@ -10,6 +10,8 @@ public class BidderInfo {
 
     boolean enabled;
 
+    boolean modifyingVastXmlAllowed;
+
     MaintainerInfo maintainer;
 
     CapabilitiesInfo capabilities;
@@ -18,15 +20,15 @@ public class BidderInfo {
 
     GdprInfo gdpr;
 
-    public static BidderInfo create(boolean enabled, String maintainerEmail, List<String> appMediaTypes,
-                                    List<String> siteMediaTypes, List<String> supportedVendors,
-                                    int vendorId, boolean enforceGdpr) {
+    public static BidderInfo create(boolean enabled, boolean modifyingVastXmlAllowed, String maintainerEmail,
+                                    List<String> appMediaTypes, List<String> siteMediaTypes,
+                                    List<String> supportedVendors, int vendorId, boolean enforceGdpr) {
         final MaintainerInfo maintainer = new MaintainerInfo(maintainerEmail);
         final CapabilitiesInfo capabilities = new CapabilitiesInfo(platformInfo(appMediaTypes),
                 platformInfo(siteMediaTypes));
         final GdprInfo gdpr = new GdprInfo(vendorId, enforceGdpr);
 
-        return new BidderInfo(enabled, maintainer, capabilities, supportedVendors, gdpr);
+        return new BidderInfo(enabled, modifyingVastXmlAllowed, maintainer, capabilities, supportedVendors, gdpr);
     }
 
     private static PlatformInfo platformInfo(List<String> mediaTypes) {

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -79,6 +79,7 @@ public class ServiceConfiguration {
             @Value("${cache.query}") String query,
             @Value("${cache.banner-ttl-seconds:#{null}}") Integer bannerCacheTtl,
             @Value("${cache.video-ttl-seconds:#{null}}") Integer videoCacheTtl,
+            @Value("${events.urltemplate}") String eventsUrlTemplate,
             HttpClient httpClient,
             Clock clock) {
 
@@ -87,7 +88,7 @@ public class ServiceConfiguration {
                 httpClient,
                 CacheService.getCacheEndpointUrl(scheme, host, path),
                 CacheService.getCachedAssetUrlTemplate(scheme, host, path, query),
-                clock);
+                eventsUrlTemplate, clock);
     }
 
     @Bean

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -79,7 +79,8 @@ public class ServiceConfiguration {
             @Value("${cache.query}") String query,
             @Value("${cache.banner-ttl-seconds:#{null}}") Integer bannerCacheTtl,
             @Value("${cache.video-ttl-seconds:#{null}}") Integer videoCacheTtl,
-            @Value("${events.urltemplate}") String eventsUrlTemplate,
+            @Value("${external-url}") String externalUrl,
+            @Value("${event.url-template}") String eventUrlTemplate,
             HttpClient httpClient,
             Clock clock) {
 
@@ -88,7 +89,7 @@ public class ServiceConfiguration {
                 httpClient,
                 CacheService.getCacheEndpointUrl(scheme, host, path),
                 CacheService.getCachedAssetUrlTemplate(scheme, host, path, query),
-                eventsUrlTemplate, clock);
+                externalUrl + eventUrlTemplate, clock);
     }
 
     @Bean

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -16,6 +16,8 @@ public class BidderConfigurationProperties {
     @NotNull
     private Boolean enabled;
 
+    private boolean modifyingVastXmlAllowed;
+
     @NotBlank
     private String endpoint;
 

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -23,6 +23,9 @@ public class BidderConfigurationProperties {
     private Boolean pbsEnforcesGdpr;
 
     @NotNull
+    private Boolean modifyingVastXmlAllowed;
+
+    @NotNull
     private List<String> deprecatedNames;
 
     @NotNull
@@ -30,8 +33,6 @@ public class BidderConfigurationProperties {
 
     @NotNull
     private MetaInfo metaInfo;
-
-    private boolean modifyingVastXmlAllowed;
 
     @NotNull
     private UsersyncConfigurationProperties usersync;

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -16,8 +16,6 @@ public class BidderConfigurationProperties {
     @NotNull
     private Boolean enabled;
 
-    private boolean modifyingVastXmlAllowed;
-
     @NotBlank
     private String endpoint;
 
@@ -32,6 +30,8 @@ public class BidderConfigurationProperties {
 
     @NotNull
     private MetaInfo metaInfo;
+
+    private boolean modifyingVastXmlAllowed;
 
     @NotNull
     private UsersyncConfigurationProperties usersync;

--- a/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
@@ -14,12 +14,12 @@ public class BidderInfoCreator {
         final MetaInfo metaInfo = configurationProperties.getMetaInfo();
         return BidderInfo.create(
                 configurationProperties.getEnabled(),
-                configurationProperties.isModifyingVastXmlAllowed(),
                 metaInfo.getMaintainerEmail(),
                 metaInfo.getAppMediaTypes(),
                 metaInfo.getSiteMediaTypes(),
                 metaInfo.getSupportedVendors(),
                 metaInfo.getVendorId(),
-                configurationProperties.getPbsEnforcesGdpr());
+                configurationProperties.getPbsEnforcesGdpr(),
+                configurationProperties.isModifyingVastXmlAllowed());
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
@@ -20,6 +20,6 @@ public class BidderInfoCreator {
                 metaInfo.getSupportedVendors(),
                 metaInfo.getVendorId(),
                 configurationProperties.getPbsEnforcesGdpr(),
-                configurationProperties.isModifyingVastXmlAllowed());
+                configurationProperties.getModifyingVastXmlAllowed());
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
@@ -14,6 +14,7 @@ public class BidderInfoCreator {
         final MetaInfo metaInfo = configurationProperties.getMetaInfo();
         return BidderInfo.create(
                 configurationProperties.getEnabled(),
+                configurationProperties.isModifyingVastXmlAllowed(),
                 metaInfo.getMaintainerEmail(),
                 metaInfo.getAppMediaTypes(),
                 metaInfo.getSiteMediaTypes(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ cookie-sync:
     default: true
   default-timeout-ms: 2000
 events:
-  urltemplate: https://prebid-server.rubiconproject.com/event?t=imp&b=%s&f=b&a=%s
+  urltemplate: https://prebid-server.rubiconproject.com/event?t=imp&b={BIDID}&f=b&a={ACCOUNT}
 currency-converter:
   enabled: true
   url: https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,8 +41,8 @@ cookie-sync:
   coop-sync:
     default: true
   default-timeout-ms: 2000
-events:
-  urltemplate: https://prebid-server.rubiconproject.com/event?t=imp&b={BIDID}&f=b&a={ACCOUNT}
+event:
+  url-template: /event?t=imp&b=BIDID&f=b&a=ACCOUNT
 currency-converter:
   enabled: true
   url: https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,6 +40,8 @@ cookie-sync:
   coop-sync:
     default: true
   default-timeout-ms: 2000
+events:
+  urltemplate: https://prebid-server.rubiconproject.com/event?t=imp&b=%s&f=b&a=%s
 currency-converter:
   enabled: true
   url: https://cdn.jsdelivr.net/gh/prebid/currency-file@1/latest.json

--- a/src/main/resources/bidder-config/adform.yaml
+++ b/src/main/resources/bidder-config/adform.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://adx.adform.net/adx
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/adkerneladn.yaml
+++ b/src/main/resources/bidder-config/adkerneladn.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://tag.adkernel.com/rtbpub?account=
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/adtelligent.yaml
+++ b/src/main/resources/bidder-config/adtelligent.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://hb.adtelligent.com/auction
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/advangelists.yaml
+++ b/src/main/resources/bidder-config/advangelists.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://nep.advangelists.com/xp/get?pubid=
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/appnexus.yaml
+++ b/src/main/resources/bidder-config/appnexus.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://ib.adnxs.com/openrtb2
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases: districtm
     meta-info:

--- a/src/main/resources/bidder-config/beachfront.yaml
+++ b/src/main/resources/bidder-config/beachfront.yaml
@@ -4,6 +4,7 @@ adapters:
     endpoint: https://display.bfmio.com/prebid_display
     video-endpoint: https://reachms.bfmio.com/bid.json?exchange_id=
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/brightroll.yaml
+++ b/src/main/resources/bidder-config/brightroll.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://east-bid.ybp.yahoo.com/bid/appnexuspbs
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/consumable.yaml
+++ b/src/main/resources/bidder-config/consumable.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://e.serverbid.com/api/v2
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/conversant.yaml
+++ b/src/main/resources/bidder-config/conversant.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://api.hb.ad.cpe.dotomi.com/s2s/header/24
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/emxdigital.yaml
+++ b/src/main/resources/bidder-config/emxdigital.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://hb.emxdgt.com
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/eplanning.yaml
+++ b/src/main/resources/bidder-config/eplanning.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://ads.us.e-planning.net/hb/1
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/facebook.yaml
+++ b/src/main/resources/bidder-config/facebook.yaml
@@ -5,6 +5,7 @@ adapters:
     non-secure-endpoint: http://an.facebook.com/placementbid.ortb
     platform-id:
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/gamoshi.yaml
+++ b/src/main/resources/bidder-config/gamoshi.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://rtb.gamoshi.io
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/grid.yaml
+++ b/src/main/resources/bidder-config/grid.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://grid.bidswitch.net/sp_bid?sp=prebid
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/gumgum.yaml
+++ b/src/main/resources/bidder-config/gumgum.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://g2.gumgum.com/providers/prbds2s/bid
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/improvedigital.yaml
+++ b/src/main/resources/bidder-config/improvedigital.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://ad.360yield.com/pbs
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/ix.yaml
+++ b/src/main/resources/bidder-config/ix.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://appnexus-us-east.lb.indexww.com/transbidder?p=184932
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names: indexExchange
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/lifestreet.yaml
+++ b/src/main/resources/bidder-config/lifestreet.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://prebid.s2s.lfstmedia.com/adrequest
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/mgid.yaml
+++ b/src/main/resources/bidder-config/mgid.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://prebid.mgid.com/prebid/
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/openx.yaml
+++ b/src/main/resources/bidder-config/openx.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://rtb.openx.net/prebid
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/pubmatic.yaml
+++ b/src/main/resources/bidder-config/pubmatic.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://hbopenbid.pubmatic.com/translator?source=prebid-server
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/pulsepoint.yaml
+++ b/src/main/resources/bidder-config/pulsepoint.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://bid.contextweb.com/header/s/ortb/prebid-s2s
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/rhythmone.yaml
+++ b/src/main/resources/bidder-config/rhythmone.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://tag.1rx.io/rmp
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/rtbhouse.yaml
+++ b/src/main/resources/bidder-config/rtbhouse.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://prebidserver-s2s-ams.creativecdn.com/bidder/prebidserver/bids
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/rubicon.yaml
+++ b/src/main/resources/bidder-config/rubicon.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://exapi-us-east.rubiconproject.com/a/api/exchange.json
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     XAPI:

--- a/src/main/resources/bidder-config/sharethrough.yaml
+++ b/src/main/resources/bidder-config/sharethrough.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://btlr.sharethrough.com/FGMrCMMc/v1
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/somoaudience.yaml
+++ b/src/main/resources/bidder-config/somoaudience.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://publisher-east.mobileadtrading.com/rtb/bid
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/sonobi.yaml
+++ b/src/main/resources/bidder-config/sonobi.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://apex.go.sonobi.com/prebid?partnerid=71d9d3d8af
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/sovrn.yaml
+++ b/src/main/resources/bidder-config/sovrn.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://ap.lijit.com/rtb/bid?src=prebid_server
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/tappx.yaml
+++ b/src/main/resources/bidder-config/tappx.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/ttx.yaml
+++ b/src/main/resources/bidder-config/ttx.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://ssc.33across.com/api/v1/hb
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/unruly.yaml
+++ b/src/main/resources/bidder-config/unruly.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://targeting.unrulymedia.com/openrtb/2.2
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/verizonmedia.yaml
+++ b/src/main/resources/bidder-config/verizonmedia.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/visx.yaml
+++ b/src/main/resources/bidder-config/visx.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: https://t.visx.net/s2s_bid?wrapperType=s2s_prebid_standard
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/vrtcal.yaml
+++ b/src/main/resources/bidder-config/vrtcal.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://rtb.vrtcal.com/bidder_prebid.vap?ssp=1804
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/main/resources/bidder-config/yieldmo.yaml
+++ b/src/main/resources/bidder-config/yieldmo.yaml
@@ -3,6 +3,7 @@ adapters:
     enabled: false
     endpoint: http://ads.yieldmo.com/exchange/prebid-server
     pbs-enforces-gdpr: true
+    modifying-vast-xml-allowed: true
     deprecated-names:
     aliases:
     meta-info:

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -1035,7 +1035,6 @@ public class ExchangeServiceTest extends VertxTest {
         givenBidder("bidder1", mock(Bidder.class), givenSeatBid(singletonList(givenBid(bid1))));
         givenBidder("bidder2", mock(Bidder.class), givenSeatBid(singletonList(givenBid(bid2))));
 
-        // imp ids are not really used for matching, included them here for clarity
         final Imp imp1 = givenImp(singletonMap("bidder1", 1), builder -> builder.id("impId1"));
         final Imp imp2 = givenImp(singletonMap("bidder2", 2), builder -> builder.id("impId2"));
         final BidRequest bidRequest = givenBidRequest(asList(imp1, imp2),
@@ -1062,9 +1061,8 @@ public class ExchangeServiceTest extends VertxTest {
         givenBidder("bidder1", mock(Bidder.class), givenSeatBid(singletonList(givenBid(bid1))));
         givenBidder("bidder2", mock(Bidder.class), givenSeatBid(singletonList(givenBid(bid2))));
 
-        given(bidderCatalog.isModifyingVastXmlAllowed(eq("bidder1"))).willReturn(true, false);
+        given(bidderCatalog.isModifyingVastXmlAllowed(eq("bidder1"))).willReturn(true);
 
-        // imp ids are not really used for matching, included them here for clarity
         final Imp imp1 = givenImp(singletonMap("bidder1", 1),
                 builder -> builder.id("impId1").video(Video.builder().build()));
         final Imp imp2 = givenImp(singletonMap("bidder2", 2),
@@ -1585,7 +1583,7 @@ public class ExchangeServiceTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo(int gdprVendorId, boolean enforceGdpr) {
-        return new BidderInfo(true, false, null, null, null, new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
+        return new BidderInfo(true, null, null, null, new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr), false);
     }
 
     private static ExtRequestTargeting givenTargeting() {

--- a/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
@@ -657,7 +657,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo(int gdprVendorId, boolean enforceGdpr) {
-        return new BidderInfo(true, null, null, null, new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
+        return new BidderInfo(true, false, null, null, null,
+                new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
     }
 }
-

--- a/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
@@ -657,7 +657,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo(int gdprVendorId, boolean enforceGdpr) {
-        return new BidderInfo(true, false, null, null, null,
-                new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
+        return new BidderInfo(true, null, null, null,
+                new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr), false);
     }
 }

--- a/src/test/java/org/prebid/server/bidder/BidderCatalogTest.java
+++ b/src/test/java/org/prebid/server/bidder/BidderCatalogTest.java
@@ -139,8 +139,8 @@ public class BidderCatalogTest {
     @Test
     public void metaInfoByNameShouldReturnMetaInfoForKnownBidder() {
         // given
-        final BidderInfo bidderInfo = BidderInfo.create(true, false, "test@email.com",
-                singletonList("banner"), singletonList("video"), null, 99, true);
+        final BidderInfo bidderInfo = BidderInfo.create(true, "test@email.com",
+                singletonList("banner"), singletonList("video"), null, 99, true, false);
 
         bidderDeps = BidderDeps.builder()
                 .name(BIDDER)

--- a/src/test/java/org/prebid/server/bidder/BidderCatalogTest.java
+++ b/src/test/java/org/prebid/server/bidder/BidderCatalogTest.java
@@ -139,7 +139,7 @@ public class BidderCatalogTest {
     @Test
     public void metaInfoByNameShouldReturnMetaInfoForKnownBidder() {
         // given
-        final BidderInfo bidderInfo = BidderInfo.create(true, "test@email.com",
+        final BidderInfo bidderInfo = BidderInfo.create(true, false, "test@email.com",
                 singletonList("banner"), singletonList("video"), null, 99, true);
 
         bidderDeps = BidderDeps.builder()

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class CacheServiceTest extends VertxTest {
 
-    private static final String ENDPOINT_URL_TEMPLATE = "https://test-event.com/event?t=imp&b=%s&f=b&a=%s";
+    private static final String ENDPOINT_URL_TEMPLATE = "https://test-event.com/event?t=imp&b={BIDID}&f=b&a={ACCOUNT}";
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class CacheServiceTest extends VertxTest {
 
-    private static final String ENDPOINT_URL_TEMPLATE = "https://test-event.com/event?t=imp&b={BIDID}&f=b&a={ACCOUNT}";
+    private static final String ENDPOINT_URL_TEMPLATE = "https://test-event.com/event?t=imp&b=BIDID&f=b&a=ACCOUNT";
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -64,6 +64,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class CacheServiceTest extends VertxTest {
 
+    private static final String ENDPOINT_URL_TEMPLATE = "https://test-event.com/event?t=imp&b=%s&f=b&a=%s";
+
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -88,7 +90,7 @@ public class CacheServiceTest extends VertxTest {
 
         cacheService = new CacheService(mediaTypeCacheTtl, httpClient,
                 new URL("http://cache-service/cache"),
-                "http://cache-service-host/cache?uuid=", clock);
+                "http://cache-service-host/cache?uuid=", ENDPOINT_URL_TEMPLATE, clock);
 
         final TimeoutFactory timeoutFactory = new TimeoutFactory(clock);
         timeout = timeoutFactory.create(500L);
@@ -236,7 +238,7 @@ public class CacheServiceTest extends VertxTest {
         // given
         cacheService = new CacheService(mediaTypeCacheTtl, httpClient,
                 new URL("https://cache-service-host:8888/cache"),
-                "https://cache-service-host:8080/cache?uuid=", clock);
+                "https://cache-service-host:8080/cache?uuid=", ENDPOINT_URL_TEMPLATE, clock);
 
         // when
         cacheService.cacheBids(singleBidList(), timeout);
@@ -528,7 +530,8 @@ public class CacheServiceTest extends VertxTest {
     public void cacheBidsOpenrtbShouldSendCacheRequestWithExpectedTtlFromAccountBannerTtl() throws IOException {
         // given
         cacheService = new CacheService(CacheTtl.of(20, null), httpClient,
-                new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=", clock);
+                new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=",
+                ENDPOINT_URL_TEMPLATE, clock);
 
         // when
         cacheService.cacheBidsOpenrtb(
@@ -547,7 +550,8 @@ public class CacheServiceTest extends VertxTest {
     public void cacheBidsOpenrtbShouldSendCacheRequestWithExpectedTtlFromMediaTypeTtl() throws IOException {
         // given
         cacheService = new CacheService(CacheTtl.of(10, null), httpClient,
-                new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=", clock);
+                new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=",
+                ENDPOINT_URL_TEMPLATE, clock);
 
         // when
         cacheService.cacheBidsOpenrtb(
@@ -565,7 +569,8 @@ public class CacheServiceTest extends VertxTest {
     public void cacheBidsOpenrtbShouldSendCacheRequestWithTtlFromMediaTypeWhenAccountIsEmpty() throws IOException {
         // given
         cacheService = new CacheService(CacheTtl.of(10, null), httpClient,
-                new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=", clock);
+                new URL("http://cache-service/cache"), "http://cache-service-host/cache?uuid=",
+                ENDPOINT_URL_TEMPLATE, clock);
 
         // when
         cacheService.cacheBidsOpenrtb(
@@ -747,8 +752,8 @@ public class CacheServiceTest extends VertxTest {
         assertThat(bidCacheRequest.getPuts()).hasSize(2)
                 .containsOnly(
                         PutObject.of("json", mapper.valueToTree(bid), null),
-                        PutObject.of("xml", new TextNode("<Impression>https://prebid-server." +
-                                "rubiconproject.com/event?t=imp&b=bid1&f=b&a=accountId</Impression>"), null));
+                        PutObject.of("xml", new TextNode("<Impression>https://test-event.com/event?t=imp&" +
+                                "b=bid1&f=b&a=accountId</Impression>"), null));
     }
 
     @Test
@@ -769,9 +774,8 @@ public class CacheServiceTest extends VertxTest {
         assertThat(bidCacheRequest.getPuts()).hasSize(2)
                 .containsOnly(
                         PutObject.of("json", mapper.valueToTree(bid), null),
-                        PutObject.of("xml", new TextNode("<Impression>http:/test.com</Impression>\n" +
-                                "<Impression>https://prebid-server.rubiconproject.com/event?t=imp&b=bid1&f=b&" +
-                                "a=accountId</Impression>"), null));
+                        PutObject.of("xml", new TextNode("<Impression>http:/test.com</Impression><Impression>" +
+                                "https://test-event.com/event?t=imp&b=bid1&f=b&a=accountId</Impression>"), null));
     }
 
     private static List<Bid> singleBidList() {

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -322,7 +322,7 @@ public class CacheServiceTest extends VertxTest {
     public void cacheBidsOpenrtbShouldPerformHttpRequestWithExpectedTimeout() {
         // when
         cacheService.cacheBidsOpenrtb(singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         verify(httpClient).post(anyString(), any(), any(), eq(500L));
@@ -333,7 +333,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null), account, expiredTimeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, expiredTimeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -352,7 +352,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(builder -> builder.id("impId1"))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -372,7 +372,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(builder -> builder.id("impId1"))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -393,7 +393,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(builder -> builder.id("impId1"))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -414,7 +414,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(builder -> builder.id("impId1"))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -434,7 +434,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(builder -> builder.id("impId1"))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -451,7 +451,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(builder -> builder.id("impId1"))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final CacheServiceResult result = future.result();
@@ -470,7 +470,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 asList(bid1, bid2), asList(imp1, imp2),
-                CacheContext.of(true, null, true, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).shouldCacheVideoBids(true).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -487,7 +487,7 @@ public class CacheServiceTest extends VertxTest {
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(builder -> builder.impid("impId1").exp(10))),
                 singletonList(givenImp(buider -> buider.id("impId1").exp(20))),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -501,7 +501,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(buider -> buider.exp(10))),
-                CacheContext.of(true, 20, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).cacheBidsTtl(20).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -515,7 +515,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, 10, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).cacheBidsTtl(10).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -533,7 +533,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null),
+                CacheContext.builder().shouldCacheBids(true).build(),
                 Account.builder().bannerCacheTtl(10).build(), timeout);
 
         // then
@@ -552,7 +552,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -570,7 +570,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -584,7 +584,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 singletonList(givenBidOpenrtb(identity())), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -601,7 +601,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(givenImp(identity())),
-                CacheContext.of(true, null, false, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).build(), account, timeout);
 
         // then
         assertThat(future.result().getCacheBids()).hasSize(1)
@@ -617,7 +617,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 singletonList(bid), singletonList(imp),
-                CacheContext.of(false, null, true, null), account, timeout);
+                CacheContext.builder().shouldCacheVideoBids(true).build(), account, timeout);
 
         // then
         assertThat(future.result().getCacheBids()).hasSize(1)
@@ -639,7 +639,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 asList(bid1, bid2), asList(imp1, imp2),
-                CacheContext.of(true, null, true, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).shouldCacheVideoBids(true).build(), account, timeout);
 
         // then
         assertThat(future.result().getCacheBids()).hasSize(2)
@@ -659,7 +659,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         final Future<CacheServiceResult> future = cacheService.cacheBidsOpenrtb(
                 asList(bid1, bid2), asList(imp1, imp2),
-                CacheContext.of(false, null, true, null), account, timeout);
+                CacheContext.builder().shouldCacheVideoBids(true).build(), account, timeout);
 
         // then
         assertThat(future.result().getCacheBids()).hasSize(1)
@@ -676,7 +676,7 @@ public class CacheServiceTest extends VertxTest {
         // when
         cacheService.cacheBidsOpenrtb(
                 asList(bid1, bid2), singletonList(imp1),
-                CacheContext.of(true, null, true, null), account, timeout);
+                CacheContext.builder().shouldCacheBids(true).shouldCacheVideoBids(true).build(), account, timeout);
 
         // then
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
@@ -688,6 +688,90 @@ public class CacheServiceTest extends VertxTest {
                         PutObject.of("xml", new TextNode("<VAST version=\"3.0\"><Ad><Wrapper><AdSystem>" +
                                 "prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[adm2]]></VASTAdTagURI><Impression>" +
                                 "</Impression><Creatives></Creatives></Wrapper></Ad></VAST>"), null));
+    }
+
+    @Test
+    public void cacheBidsOpenrtbShouldNotModifyVastXmlWhenBidIdIsNotInToModifyList() throws IOException {
+        // given
+        final com.iab.openrtb.response.Bid bid = givenBidOpenrtb(builder -> builder.id("bid1").impid("impId1")
+                .adm("adm"));
+        final Imp imp1 = givenImp(builder -> builder.id("impId1").video(Video.builder().build()));
+
+        // when
+        cacheService.cacheBidsOpenrtb(singletonList(bid), singletonList(imp1), CacheContext.builder()
+                .shouldCacheBids(true).shouldCacheVideoBids(true).videoBidIdsToModify(singletonList("bid2"))
+                .build(), Account.builder().id("accountId").build(), timeout);
+
+        // then
+        final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
+        assertThat(bidCacheRequest.getPuts()).hasSize(2)
+                .containsOnly(
+                        PutObject.of("json", mapper.valueToTree(bid), null),
+                        PutObject.of("xml", new TextNode("adm"), null));
+    }
+
+    @Test
+    public void cacheBidsOpenrtbShouldNotAddTrackingImpToBidAdmWhenXmlDoesNotContainImpTag() throws IOException {
+        // given
+        final com.iab.openrtb.response.Bid bid = givenBidOpenrtb(builder -> builder.id("bid1").impid("impId1")
+                .adm("no impression tag"));
+        final Imp imp1 = givenImp(builder -> builder.id("impId1").video(Video.builder().build()));
+
+        // when
+        cacheService.cacheBidsOpenrtb(singletonList(bid), singletonList(imp1), CacheContext.builder()
+                .shouldCacheBids(true).shouldCacheVideoBids(true).videoBidIdsToModify(singletonList("bid1"))
+                .build(), account, timeout);
+
+        // then
+        final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
+        assertThat(bidCacheRequest.getPuts()).hasSize(2)
+                .containsOnly(
+                        PutObject.of("json", mapper.valueToTree(bid), null),
+                        PutObject.of("xml", new TextNode("no impression tag"), null));
+    }
+
+    @Test
+    public void cacheBidsOpenrtbShouldAddTrackingLinkToImpTagWhenItIsEmpty() throws IOException {
+        // given
+        final com.iab.openrtb.response.Bid bid = givenBidOpenrtb(builder -> builder.id("bid1").impid("impId1")
+                .adm("<Impression></Impression>"));
+        final Imp imp1 = givenImp(builder -> builder.id("impId1").video(Video.builder().build()));
+
+        // when
+        cacheService.cacheBidsOpenrtb(singletonList(bid), singletonList(imp1), CacheContext.builder()
+                .shouldCacheBids(true).shouldCacheVideoBids(true).videoBidIdsToModify(singletonList("bid1"))
+                .build(), Account.builder().id("accountId").build(), timeout);
+
+        // then
+        final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
+        assertThat(bidCacheRequest.getPuts()).hasSize(2)
+                .containsOnly(
+                        PutObject.of("json", mapper.valueToTree(bid), null),
+                        PutObject.of("xml", new TextNode("<Impression>https://prebid-server." +
+                                "rubiconproject.com/event?t=imp&b=bid1&f=b&a=accountId</Impression>"), null));
+    }
+
+    @Test
+    public void cacheBidsOpenrtbShouldAddTrackingImpToBidAdmXmlWhenThatBidShouldBeModifiedAndContainsImpTag()
+            throws IOException {
+        // given
+        final com.iab.openrtb.response.Bid bid = givenBidOpenrtb(builder -> builder.id("bid1").impid("impId1")
+                .adm("<Impression>http:/test.com</Impression>"));
+        final Imp imp1 = givenImp(builder -> builder.id("impId1").video(Video.builder().build()));
+
+        // when
+        cacheService.cacheBidsOpenrtb(singletonList(bid), singletonList(imp1), CacheContext.builder()
+                        .shouldCacheBids(true).shouldCacheVideoBids(true).videoBidIdsToModify(singletonList("bid1")).build(),
+                Account.builder().id("accountId").build(), timeout);
+
+        // then
+        final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
+        assertThat(bidCacheRequest.getPuts()).hasSize(2)
+                .containsOnly(
+                        PutObject.of("json", mapper.valueToTree(bid), null),
+                        PutObject.of("xml", new TextNode("<Impression>http:/test.com</Impression>\n" +
+                                "<Impression>https://prebid-server.rubiconproject.com/event?t=imp&b=bid1&f=b&" +
+                                "a=accountId</Impression>"), null));
     }
 
     private static List<Bid> singleBidList() {

--- a/src/test/java/org/prebid/server/gdpr/vendorlist/VendorListServiceTest.java
+++ b/src/test/java/org/prebid/server/gdpr/vendorlist/VendorListServiceTest.java
@@ -64,7 +64,8 @@ public class VendorListServiceTest extends VertxTest {
 
         given(bidderCatalog.names()).willReturn(singleton(null));
         given(bidderCatalog.bidderInfoByName(any()))
-                .willReturn(new BidderInfo(true, null, null, null, new BidderInfo.GdprInfo(52, true)));
+                .willReturn(new BidderInfo(true, false, null, null, null,
+                        new BidderInfo.GdprInfo(52, true)));
 
         vendorListService = VendorListService.create(fileSystem, CACHE_DIR, httpClient, "http://vendorlist/{VERSION}",
                 0, null, bidderCatalog);

--- a/src/test/java/org/prebid/server/gdpr/vendorlist/VendorListServiceTest.java
+++ b/src/test/java/org/prebid/server/gdpr/vendorlist/VendorListServiceTest.java
@@ -64,8 +64,8 @@ public class VendorListServiceTest extends VertxTest {
 
         given(bidderCatalog.names()).willReturn(singleton(null));
         given(bidderCatalog.bidderInfoByName(any()))
-                .willReturn(new BidderInfo(true, false, null, null, null,
-                        new BidderInfo.GdprInfo(52, true)));
+                .willReturn(new BidderInfo(true, null, null, null,
+                        new BidderInfo.GdprInfo(52, true), false));
 
         vendorListService = VendorListService.create(fileSystem, CACHE_DIR, httpClient, "http://vendorlist/{VERSION}",
                 0, null, bidderCatalog);

--- a/src/test/java/org/prebid/server/geolocation/MaxMindGeoLocationServiceTest.java
+++ b/src/test/java/org/prebid/server/geolocation/MaxMindGeoLocationServiceTest.java
@@ -46,8 +46,7 @@ public class MaxMindGeoLocationServiceTest {
     public void setDatabaseReaderShouldThrowExceptionIfDatabaseArchiveNotFound() {
         assertThatExceptionOfType(PreBidException.class)
                 .isThrownBy(() -> maxMindGeoLocationService.setDatabaseReader("no_file"))
-                .withMessage("IO Exception occurred while trying to read an archive/db file: no_file " +
-                        "(No such file or directory)");
+                .withMessageStartingWith("IO Exception occurred while trying to read an archive/db file: no_file");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
@@ -891,7 +891,7 @@ public class AuctionHandlerTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo(int gdprVendorId, boolean enforceGdpr) {
-        return new BidderInfo(true, false, null, null, null,
-                new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
+        return new BidderInfo(true, null, null, null,
+                new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr), false);
     }
 }

--- a/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
@@ -891,6 +891,7 @@ public class AuctionHandlerTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo(int gdprVendorId, boolean enforceGdpr) {
-        return new BidderInfo(true, null, null, null, new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
+        return new BidderInfo(true, false, null, null, null,
+                new BidderInfo.GdprInfo(gdprVendorId, enforceGdpr));
     }
 }

--- a/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
@@ -478,8 +478,8 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
-                .willReturn(BidderInfo.create(true, false, null, null,
-                        null, null, 2, true));
+                .willReturn(BidderInfo.create(true, null, null,
+                        null, null, 2, true, false));
 
         givenGdprServiceReturningResult(singletonMap(RUBICON, 1));
 
@@ -508,8 +508,8 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
-                .willReturn(BidderInfo.create(true, false, null, null,
-                        null, null, 2, true));
+                .willReturn(BidderInfo.create(true, null, null,
+                        null, null, 2, true, false));
 
         givenGdprServiceReturningResult(singletonMap(RUBICON, 1));
 
@@ -978,8 +978,8 @@ public class CookieSyncHandlerTest extends VertxTest {
 
         for (Map.Entry<String, Integer> entry : bidderToGdprVendorId.entrySet()) {
             given(bidderCatalog.bidderInfoByName(entry.getKey()))
-                    .willReturn(BidderInfo.create(true, false, null, null,
-                            null, null, entry.getValue(), true));
+                    .willReturn(BidderInfo.create(true, null, null,
+                            null, null, entry.getValue(), true, false));
 
             vendorToGdprResult.put(entry.getValue(), true);
         }

--- a/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
@@ -478,7 +478,8 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
-                .willReturn(BidderInfo.create(true, null, null, null, null, 2, true));
+                .willReturn(BidderInfo.create(true, false, null, null,
+                        null, null, 2, true));
 
         givenGdprServiceReturningResult(singletonMap(RUBICON, 1));
 
@@ -507,7 +508,8 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
-                .willReturn(BidderInfo.create(true, null, null, null, null, 2, true));
+                .willReturn(BidderInfo.create(true, false, null, null,
+                        null, null, 2, true));
 
         givenGdprServiceReturningResult(singletonMap(RUBICON, 1));
 
@@ -976,7 +978,8 @@ public class CookieSyncHandlerTest extends VertxTest {
 
         for (Map.Entry<String, Integer> entry : bidderToGdprVendorId.entrySet()) {
             given(bidderCatalog.bidderInfoByName(entry.getKey()))
-                    .willReturn(BidderInfo.create(true, null, null, null, null, entry.getValue(), true));
+                    .willReturn(BidderInfo.create(true, false, null, null,
+                            null, null, entry.getValue(), true));
 
             vendorToGdprResult.put(entry.getValue(), true);
         }

--- a/src/test/java/org/prebid/server/handler/info/BidderDetailsHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/info/BidderDetailsHandlerTest.java
@@ -166,7 +166,7 @@ public class BidderDetailsHandlerTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo() {
-        return BidderInfo.create(true, "test@email.org",
+        return BidderInfo.create(true, false, "test@email.org",
                 singletonList("mediaType1"), singletonList("mediaType2"), null, 0, true);
     }
 }

--- a/src/test/java/org/prebid/server/handler/info/BidderDetailsHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/info/BidderDetailsHandlerTest.java
@@ -166,7 +166,7 @@ public class BidderDetailsHandlerTest extends VertxTest {
     }
 
     private static BidderInfo givenBidderInfo() {
-        return BidderInfo.create(true, false, "test@email.org",
-                singletonList("mediaType1"), singletonList("mediaType2"), null, 0, true);
+        return BidderInfo.create(true, "test@email.org", singletonList("mediaType1"),
+                singletonList("mediaType2"), null, 0, true, false);
     }
 }


### PR DESCRIPTION
- Added impression tracking to VAST xml when account has events enabled and for bidders that allow modifying VAST xml;
- Added new bidder configuration property - `modifyingVastXmlAllowed` with a default value `false`;
- Adjusted `ExchangeService` and `CacheService` flows to process changing VAST xml;
- Corrected existing unit tests and added new ones to reflect the changes.