### PR TITLE
Increase HTTP headers size

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -17,9 +17,10 @@ This parameter affects how many CPU cores will be utilized by the application. R
 
 ## HTTP
 - `http.port` - the port to listen on.
-- `http.ssl` - enable SSL/TLS
-- `http.jks-path` - path to the java keystore (if ssl is enabled)
-- `http.jks-password` - password for the keystore (if ssl is enabled)
+- `http.max-header-size` - set the maximum length of all headers.
+- `http.ssl` - enable SSL/TLS support.
+- `http.jks-path` - path to the java keystore (if ssl is enabled).
+- `http.jks-password` - password for the keystore (if ssl is enabled).
 
 ## HTTP Client
 - `http-client.max-pool-size` - set the maximum pool size for outgoing connections.
@@ -66,7 +67,7 @@ There are several typical keys:
 - `adapters.<BIDDER_NAME>.usersync.url` - the url for synchronizing UIDs cookie.
 - `adapters.<BIDDER_NAME>.usersync.redirect-url` - the redirect part of url for synchronizing UIDs cookie.
 - `adapters.<BIDDER_NAME>.usersync.cookie-family-name` - the family name by which user ids within adapter's realm are stored in uidsCookie.
-- `adapters.<BIDDER_NAME>.usersync.type` - usersync type (i.e. redirect, iframe)
+- `adapters.<BIDDER_NAME>.usersync.type` - usersync type (i.e. redirect, iframe).
 - `adapters.<BIDDER_NAME>.usersync.support-cors` - flag signals if CORS supported by usersync.
 
 But feel free to add additional bidder's specific options.
@@ -115,7 +116,7 @@ See [metrics documentation](metrics.md) for complete list of metrics submitted a
 ## Cache
 - `cache.scheme` - set the external Cache Service protocol: `http`, `https`, etc.
 - `cache.host` - set the external Cache Service destination in format `host:port`.
-- `cache.path` - set the external Cache Service path, for example `/cache`
+- `cache.path` - set the external Cache Service path, for example `/cache`.
 - `cache.query` - appends to the cache path as query string params (used for legacy Auction requests).
 - `cache.banner-ttl-seconds` - how long (in seconds) banner will be available via the external Cache Service.
 - `cache.video-ttl-seconds` - how long (in seconds) video creative will be available via the external Cache Service.

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -17,7 +17,7 @@ This parameter affects how many CPU cores will be utilized by the application. R
 
 ## HTTP
 - `http.port` - the port to listen on.
-- `http.max-header-size` - set the maximum length of all headers.
+- `http.max-headers-size` - set the maximum length of all headers.
 - `http.ssl` - enable SSL/TLS support.
 - `http.jks-path` - path to the java keystore (if ssl is enabled).
 - `http.jks-password` - password for the keystore (if ssl is enabled).

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -110,7 +110,7 @@ public class WebConfiguration {
     }
 
     @Bean
-    HttpServerOptions httpServerOptions(@Value("${http.max-header-size}") int maxHeaderSize,
+    HttpServerOptions httpServerOptions(@Value("${http.max-headers-size}") int maxHeaderSize,
                                         @Value("${http.ssl}") boolean ssl,
                                         @Value("${http.jks-path}") String jksPath,
                                         @Value("${http.jks-password}") String jksPassword) {

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -110,11 +110,13 @@ public class WebConfiguration {
     }
 
     @Bean
-    HttpServerOptions httpServerOptions(@Value("${http.ssl}") boolean ssl,
+    HttpServerOptions httpServerOptions(@Value("${http.max-header-size}") int maxHeaderSize,
+                                        @Value("${http.ssl}") boolean ssl,
                                         @Value("${http.jks-path}") String jksPath,
                                         @Value("${http.jks-password}") String jksPassword) {
         final HttpServerOptions httpServerOptions = new HttpServerOptions()
                 .setHandle100ContinueAutomatically(true)
+                .setMaxHeaderSize(maxHeaderSize)
                 .setCompressionSupported(true)
                 .setIdleTimeout(10); // kick off long processing requests
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,7 @@ vertx:
   http-server-instances: 1
 http:
   port: 8080
+  max-header-size: 16384
   ssl: false
   jks-path:
   jks-password:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ vertx:
   http-server-instances: 1
 http:
   port: 8080
-  max-header-size: 16384
+  max-headers-size: 16384
   ssl: false
   jks-path:
   jks-password:


### PR DESCRIPTION
Vert.x set default size for all headers to 8kB which can be too small for Prebid Server since `uids` can be large.
Added `http.max-headers-size` config property to fix the error:
```
2019-08-22 00:00:00.465  WARN 28553 --- [vert.x-eventloop-thread-4] o.p.server.handler.ExceptionHandler      : Error while establishing HTTP connection

io.netty.handler.codec.TooLongFrameException: HTTP header is larger than 8192 bytes.
	at io.netty.handler.codec.http.HttpObjectDecoder$HeaderParser.newException(HttpObjectDecoder.java:837)
	at io.netty.handler.codec.http.HttpObjectDecoder$HeaderParser.process(HttpObjectDecoder.java:829)
	at io.netty.buffer.AbstractByteBuf.forEachByteAsc0(AbstractByteBuf.java:1298)
	at io.netty.buffer.AbstractByteBuf.forEachByte(AbstractByteBuf.java:1278)
	at io.netty.handler.codec.http.HttpObjectDecoder$HeaderParser.parse(HttpObjectDecoder.java:801)
	at io.netty.handler.codec.http.HttpObjectDecoder.readHeaders(HttpObjectDecoder.java:581)
	at io.netty.handler.codec.http.HttpObjectDecoder.decode(HttpObjectDecoder.java:227)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:502)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:441)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:278)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:648)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:583)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:500)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:462)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Unknown Source)
```