### PR TITLE
Change ImpExtRubicon inventory and visitor fields type

### DIFF
--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/rubicon/ExtImpRubicon.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/rubicon/ExtImpRubicon.java
@@ -1,7 +1,7 @@
 package org.prebid.server.proto.openrtb.ext.request.rubicon;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Builder;
 import lombok.Value;
 
@@ -25,9 +25,9 @@ public class ExtImpRubicon {
 
     List<Integer> sizes;
 
-    JsonNode inventory;
+    ObjectNode inventory;
 
-    JsonNode visitor;
+    ObjectNode visitor;
 
     RubiconVideoParams video;
 }


### PR DESCRIPTION
- Changed ImpExtRubicon inventory and visitor fields type from `JsonNode` to `ObjectNode` as specified in `rubicon.json` bidder parameters description.
- Modified Rubicon Bidder request processing to reflect the changes.