### PR TITLE
Improve handling "Response is closed" error

### DIFF
--- a/src/main/java/org/prebid/server/handler/BidderParamHandler.java
+++ b/src/main/java/org/prebid/server/handler/BidderParamHandler.java
@@ -1,12 +1,16 @@
 package org.prebid.server.handler;
 
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 import org.prebid.server.validation.BidderParamValidator;
 
 import java.util.Objects;
 
 public class BidderParamHandler implements Handler<RoutingContext> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BidderParamHandler.class);
 
     private final BidderParamValidator bidderParamValidator;
 
@@ -16,6 +20,11 @@ public class BidderParamHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext context) {
+        // don't send the response if client has gone
+        if (context.response().closed()) {
+            logger.warn("The client already closed connection, response will be skipped");
+            return;
+        }
         context.response().end(bidderParamValidator.schemas());
     }
 }

--- a/src/main/java/org/prebid/server/handler/GetuidsHandler.java
+++ b/src/main/java/org/prebid/server/handler/GetuidsHandler.java
@@ -3,6 +3,8 @@ package org.prebid.server.handler;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 import lombok.AllArgsConstructor;
 import lombok.Value;
@@ -15,6 +17,8 @@ import java.util.stream.Collectors;
 
 public class GetuidsHandler implements Handler<RoutingContext> {
 
+    private static final Logger logger = LoggerFactory.getLogger(GetuidsHandler.class);
+
     private final UidsCookieService uidsCookieService;
 
     public GetuidsHandler(UidsCookieService uidsCookieService) {
@@ -22,14 +26,21 @@ public class GetuidsHandler implements Handler<RoutingContext> {
     }
 
     @Override
-    public void handle(RoutingContext routingContext) {
-        final UidsCookie uidsCookie = uidsCookieService.parseFromRequest(routingContext);
+    public void handle(RoutingContext context) {
+        final UidsCookie uidsCookie = uidsCookieService.parseFromRequest(context);
         final Map<String, String> uids = uidsCookie.getCookieUids().getUids().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
                         // Extract just the uid for each bidder
                         uidEntry -> uidEntry.getValue().getUid()));
 
-        routingContext.response().end(Json.encode(BuyerUids.of(uids)));
+        final String body = Json.encode(BuyerUids.of(uids));
+
+        // don't send the response if client has gone
+        if (context.response().closed()) {
+            logger.warn("The client already closed connection, response will be skipped");
+            return;
+        }
+        context.response().end(body);
     }
 
     @AllArgsConstructor(staticName = "of")

--- a/src/main/java/org/prebid/server/handler/NoCacheHandler.java
+++ b/src/main/java/org/prebid/server/handler/NoCacheHandler.java
@@ -11,11 +11,11 @@ public class NoCacheHandler implements Handler<RoutingContext> {
     }
 
     @Override
-    public void handle(RoutingContext routingContext) {
-        routingContext.response()
+    public void handle(RoutingContext context) {
+        context.response()
                 .putHeader(HttpUtil.CACHE_CONTROL_HEADER, "no-cache, no-store, must-revalidate")
                 .putHeader(HttpUtil.PRAGMA_HEADER, "no-cache")
                 .putHeader(HttpUtil.EXPIRES_HEADER, "0");
-        routingContext.next();
+        context.next();
     }
 }

--- a/src/main/java/org/prebid/server/handler/SetuidHandler.java
+++ b/src/main/java/org/prebid/server/handler/SetuidHandler.java
@@ -67,7 +67,7 @@ public class SetuidHandler implements Handler<RoutingContext> {
         final UidsCookie uidsCookie = uidsCookieService.parseFromRequest(context);
         if (!uidsCookie.allowsSync()) {
             final int status = HttpResponseStatus.UNAUTHORIZED.code();
-            context.response().setStatusCode(status).end();
+            respondWith(context, status, null);
             metrics.updateUserSyncOptoutMetric();
             analyticsReporter.processEvent(SetuidEvent.error(status));
             return;
@@ -76,7 +76,7 @@ public class SetuidHandler implements Handler<RoutingContext> {
         final String bidder = context.request().getParam(BIDDER_PARAM);
         if (StringUtils.isBlank(bidder)) {
             final int status = HttpResponseStatus.BAD_REQUEST.code();
-            context.response().setStatusCode(status).end("\"bidder\" query param is required");
+            respondWith(context, status, "\"bidder\" query param is required");
             metrics.updateUserSyncBadRequestMetric();
             analyticsReporter.processEvent(SetuidEvent.error(status));
             return;
@@ -92,12 +92,6 @@ public class SetuidHandler implements Handler<RoutingContext> {
 
     private void handleResult(AsyncResult<GdprResponse> asyncResult, RoutingContext context,
                               UidsCookie uidsCookie, String bidder) {
-        // don't send the response if client has gone
-        if (context.response().closed()) {
-            logger.warn("The client already closed connection, response will be skipped");
-            return;
-        }
-
         final boolean gdprProcessingFailed = asyncResult.failed();
         final GdprResponse gdprResponse = !gdprProcessingFailed ? asyncResult.result() : null;
 
@@ -150,16 +144,18 @@ public class SetuidHandler implements Handler<RoutingContext> {
         final Cookie cookie = uidsCookieService.toCookie(updatedUidsCookie);
         addCookie(context, cookie);
 
+        final int status = HttpResponseStatus.OK.code();
+
         // Send pixel file to response if "format=img"
         final String format = context.request().getParam(FORMAT_PARAM);
         if (StringUtils.equals(format, IMG_FORMAT_PARAM)) {
             context.response().sendFile(PIXEL_FILE_PATH);
         } else {
-            context.response().end();
+            respondWith(context, status, null);
         }
 
         analyticsReporter.processEvent(SetuidEvent.builder()
-                .status(HttpResponseStatus.OK.code())
+                .status(status)
                 .bidder(bidder)
                 .uid(uid)
                 .success(successfullyUpdated)
@@ -167,12 +163,27 @@ public class SetuidHandler implements Handler<RoutingContext> {
     }
 
     private void addCookie(RoutingContext context, Cookie cookie) {
-        context.response().putHeader(HttpUtil.SET_COOKIE_HEADER, HttpUtil.toSetCookieHeaderValue(cookie));
+        context.response().headers().add(HttpUtil.SET_COOKIE_HEADER, HttpUtil.toSetCookieHeaderValue(cookie));
     }
 
     private void respondWithoutCookie(RoutingContext context, int status, String body, String bidder) {
-        context.response().setStatusCode(status).end(body);
+        respondWith(context, status, body);
         metrics.updateUserSyncGdprPreventMetric(bidder);
         analyticsReporter.processEvent(SetuidEvent.error(status));
+    }
+
+    private static void respondWith(RoutingContext context, int status, String body) {
+        // don't send the response if client has gone
+        if (context.response().closed()) {
+            logger.warn("The client already closed connection, response will be skipped");
+            return;
+        }
+
+        context.response().setStatusCode(status);
+        if (body != null) {
+            context.response().end(body);
+        } else {
+            context.response().end();
+        }
     }
 }

--- a/src/main/java/org/prebid/server/handler/VersionHandler.java
+++ b/src/main/java/org/prebid/server/handler/VersionHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 public class VersionHandler implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(VersionHandler.class);
+
     private static final String DEFAULT_REVISION_VALUE = "not-set";
 
     private Revision revision;

--- a/src/test/java/org/prebid/server/handler/NoCacheHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NoCacheHandlerTest.java
@@ -23,7 +23,6 @@ public class NoCacheHandlerTest {
 
     @Mock
     private RoutingContext routingContext;
-
     @Mock
     private HttpServerResponse httpResponse;
 

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -8,7 +8,6 @@ import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -61,6 +60,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -116,9 +116,7 @@ public class AmpHandlerTest extends VertxTest {
         given(httpRequest.headers()).willReturn(new CaseInsensitiveHeaders());
         httpRequest.headers().add("Origin", "http://example.com");
 
-        given(httpResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).willReturn(httpResponse);
-        given(httpResponse.putHeader(anyString(), eq((String) null))).willReturn(httpResponse);
-        given(httpResponse.putHeader(anyString(), anyString())).willReturn(httpResponse);
+        given(httpResponse.headers()).willReturn(new CaseInsensitiveHeaders());
         given(httpResponse.setStatusCode(anyInt())).willReturn(httpResponse);
 
         given(uidsCookie.hasLiveUids()).willReturn(true);
@@ -191,8 +189,11 @@ public class AmpHandlerTest extends VertxTest {
         // then
         verifyZeroInteractions(exchangeService);
         verify(httpResponse).setStatusCode(eq(400));
-        verify(httpResponse).putHeader("AMP-Access-Control-Allow-Source-Origin", "http://example.com");
-        verify(httpResponse).putHeader("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin");
+        assertThat(httpResponse.headers()).hasSize(2)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(
+                        tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
+                        tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"));
         verify(httpResponse).end(eq("Invalid request format: Request is invalid"));
     }
 
@@ -210,8 +211,11 @@ public class AmpHandlerTest extends VertxTest {
 
         // then
         verify(httpResponse).setStatusCode(eq(500));
-        verify(httpResponse).putHeader("AMP-Access-Control-Allow-Source-Origin", "http://example.com");
-        verify(httpResponse).putHeader("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin");
+        assertThat(httpResponse.headers()).hasSize(2)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(
+                        tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
+                        tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"));
         verify(httpResponse).end(eq("Critical error while running the auction: Unexpected exception"));
     }
 
@@ -230,8 +234,11 @@ public class AmpHandlerTest extends VertxTest {
 
         // then
         verify(httpResponse).setStatusCode(eq(500));
-        verify(httpResponse).putHeader("AMP-Access-Control-Allow-Source-Origin", "http://example.com");
-        verify(httpResponse).putHeader("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin");
+        assertThat(httpResponse.headers()).hasSize(2)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(
+                        tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
+                        tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"));
         verify(httpResponse).end(
                 startsWith("Critical error while running the auction: Critical error while unpacking AMP targets:"));
     }
@@ -268,9 +275,12 @@ public class AmpHandlerTest extends VertxTest {
         ampHandler.handle(routingContext);
 
         // then
-        verify(httpResponse).putHeader("AMP-Access-Control-Allow-Source-Origin", "http://example.com");
-        verify(httpResponse).putHeader("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin");
-        verify(httpResponse).putHeader(HttpUtil.CONTENT_TYPE_HEADER, HttpHeaderValues.APPLICATION_JSON);
+        assertThat(httpResponse.headers()).hasSize(3)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(
+                        tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
+                        tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"),
+                        tuple("Content-Type", "application/json"));
         verify(httpResponse).end(eq("{\"targeting\":{\"key1\":\"value1\",\"hb_cache_id_bidder1\":\"value2\"}}"));
     }
 
@@ -307,9 +317,12 @@ public class AmpHandlerTest extends VertxTest {
         ampHandler.handle(routingContext);
 
         // then
-        verify(httpResponse).putHeader("AMP-Access-Control-Allow-Source-Origin", "http://example.com");
-        verify(httpResponse).putHeader("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin");
-        verify(httpResponse).putHeader(HttpUtil.CONTENT_TYPE_HEADER, HttpHeaderValues.APPLICATION_JSON);
+        assertThat(httpResponse.headers()).hasSize(3)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(
+                        tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
+                        tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"),
+                        tuple("Content-Type", "application/json"));
         verify(httpResponse).end(eq("{\"targeting\":{\"key1\":\"value1\",\"rpfl_11078\":\"15_tier0030\"," +
                 "\"hb_cache_id_bidder1\":\"value2\"}}"));
     }

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -4,7 +4,6 @@ import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.response.BidResponse;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -46,6 +45,7 @@ import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -93,7 +93,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap());
         given(httpRequest.headers()).willReturn(new CaseInsensitiveHeaders());
 
-        given(httpResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).willReturn(httpResponse);
+        given(httpResponse.headers()).willReturn(new CaseInsensitiveHeaders());
         given(httpResponse.setStatusCode(anyInt())).willReturn(httpResponse);
 
         given(clock.millis()).willReturn(Instant.now().toEpochMilli());
@@ -211,7 +211,9 @@ public class AuctionHandlerTest extends VertxTest {
 
         // then
         verify(exchangeService).holdAuction(any());
-        verify(httpResponse).putHeader(HttpUtil.CONTENT_TYPE_HEADER, HttpHeaderValues.APPLICATION_JSON);
+        assertThat(httpResponse.headers()).hasSize(1)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(tuple("Content-Type", "application/json"));
         verify(httpResponse).end(eq("{}"));
     }
 


### PR DESCRIPTION
This PR fixes error, like:
```
2019-08-22 00:00:03.028 ERROR 28553 --- [vert.x-eventloop-thread-8] io.vertx.core.impl.ContextImpl           : Unhandled exception

java.lang.IllegalStateException: Response is closed
	at io.vertx.core.http.impl.HttpServerResponseImpl.checkValid(HttpServerResponseImpl.java:564)
	at io.vertx.core.http.impl.HttpServerResponseImpl.end(HttpServerResponseImpl.java:324)
	at io.vertx.core.http.impl.HttpServerResponseImpl.end(HttpServerResponseImpl.java:313)
	at io.vertx.ext.web.impl.RoutingContextImplBase.unhandledFailure(RoutingContextImplBase.java:166)
	at io.vertx.ext.web.impl.RoutingContextImpl.checkHandleNoMatch(RoutingContextImpl.java:143)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:135)
	at io.vertx.ext.web.impl.RoutingContextImpl.doFail(RoutingContextImpl.java:471)
	at io.vertx.ext.web.impl.RoutingContextImpl.fail(RoutingContextImpl.java:167)
	at io.vertx.ext.web.handler.impl.BodyHandlerImpl$BHandler.lambda$new$3(BodyHandlerImpl.java:211)
	at io.vertx.core.http.impl.HttpServerRequestImpl.handleException(HttpServerRequestImpl.java:569)
	at io.vertx.core.http.impl.Http1xServerConnection.handleClosed(Http1xServerConnection.java:476)
	at io.vertx.core.net.impl.VertxHandler.lambda$channelInactive$5(VertxHandler.java:164)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:188)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:180)
	at io.vertx.core.net.impl.VertxHandler.channelInactive(VertxHandler.java:164)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75)
	at io.netty.handler.timeout.IdleStateHandler.channelInactive(IdleStateHandler.java:277)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	at io.netty.handler.stream.ChunkedWriteHandler.channelInactive(ChunkedWriteHandler.java:141)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75)
	at io.netty.handler.codec.http.HttpContentEncoder.channelInactive(HttpContentEncoder.java:299)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:390)
	at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:355)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1429)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:947)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:822)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:466)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Unknown Source)
```
These kind of errors don't point to exact PBS code, so we can just assume where to catch them.

See similar solution at https://github.com/vert-x3/issues/issues/369