### PR TITLE
Fix CircuitBreaker Thread blocked error

### DIFF
--- a/src/main/java/org/prebid/server/geolocation/CircuitBreakerSecuredGeoLocationService.java
+++ b/src/main/java/org/prebid/server/geolocation/CircuitBreakerSecuredGeoLocationService.java
@@ -9,6 +9,7 @@ import org.prebid.server.geolocation.model.GeoInfo;
 import org.prebid.server.metric.Metrics;
 import org.prebid.server.vertx.CircuitBreaker;
 
+import java.time.Clock;
 import java.util.Objects;
 
 /**
@@ -24,10 +25,10 @@ public class CircuitBreakerSecuredGeoLocationService implements GeoLocationServi
 
     public CircuitBreakerSecuredGeoLocationService(Vertx vertx, GeoLocationService geoLocationService, Metrics metrics,
                                                    int openingThreshold, long openingIntervalMs,
-                                                   long closingIntervalMs) {
+                                                   long closingIntervalMs, Clock clock) {
 
         breaker = new CircuitBreaker("geolocation-service-circuit-breaker", Objects.requireNonNull(vertx),
-                openingThreshold, openingIntervalMs, closingIntervalMs)
+                openingThreshold, openingIntervalMs, closingIntervalMs, Objects.requireNonNull(clock))
                 .openHandler(ignored -> circuitOpened())
                 .halfOpenHandler(ignored -> circuitHalfOpened())
                 .closeHandler(ignored -> circuitClosed());

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -201,14 +201,15 @@ public class ServiceConfiguration {
             Vertx vertx,
             Metrics metrics,
             HttpClientProperties httpClientProperties,
-            @Qualifier("httpClientCircuitBreakerProperties") CircuitBreakerProperties circuitBreakerProperties) {
+            @Qualifier("httpClientCircuitBreakerProperties") CircuitBreakerProperties circuitBreakerProperties,
+            Clock clock) {
 
         final HttpClient httpClient = createBasicHttpClient(vertx, httpClientProperties.getMaxPoolSize(),
                 httpClientProperties.getConnectTimeoutMs(), httpClientProperties.getUseCompression(),
                 httpClientProperties.getMaxRedirects());
         return new CircuitBreakerSecuredHttpClient(vertx, httpClient, metrics,
                 circuitBreakerProperties.getOpeningThreshold(), circuitBreakerProperties.getOpeningIntervalMs(),
-                circuitBreakerProperties.getClosingIntervalMs());
+                circuitBreakerProperties.getClosingIntervalMs(), clock);
     }
 
     private static BasicHttpClient createBasicHttpClient(Vertx vertx, int maxPoolSize, int connectTimeoutMs,
@@ -434,12 +435,13 @@ public class ServiceConfiguration {
                 Vertx vertx,
                 Metrics metrics,
                 RemoteFileSyncerProperties fileSyncerProperties,
-                @Qualifier("geolocationCircuitBreakerProperties") CircuitBreakerProperties circuitBreakerProperties) {
+                @Qualifier("geolocationCircuitBreakerProperties") CircuitBreakerProperties circuitBreakerProperties,
+                Clock clock) {
 
             return new CircuitBreakerSecuredGeoLocationService(vertx,
                     createGeoLocationService(fileSyncerProperties, vertx), metrics,
                     circuitBreakerProperties.getOpeningThreshold(), circuitBreakerProperties.getOpeningIntervalMs(),
-                    circuitBreakerProperties.getClosingIntervalMs());
+                    circuitBreakerProperties.getClosingIntervalMs(), clock);
         }
 
         private GeoLocationService createGeoLocationService(RemoteFileSyncerProperties fileSyncerProperties,

--- a/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
@@ -104,7 +104,7 @@ public class SettingsConfiguration {
             final JdbcClient jdbcClient = createBasicJdbcClient(vertx, vertxJdbcClient, metrics, clock, contextRunner);
             return new CircuitBreakerSecuredJdbcClient(vertx, jdbcClient, metrics,
                     circuitBreakerProperties.getOpeningThreshold(), circuitBreakerProperties.getOpeningIntervalMs(),
-                    circuitBreakerProperties.getClosingIntervalMs());
+                    circuitBreakerProperties.getClosingIntervalMs(), clock);
         }
 
         private static BasicJdbcClient createBasicJdbcClient(

--- a/src/main/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClient.java
+++ b/src/main/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClient.java
@@ -13,6 +13,7 @@ import org.prebid.server.vertx.http.model.HttpClientResponse;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Clock;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,9 +33,11 @@ public class CircuitBreakerSecuredHttpClient implements HttpClient {
     private final Metrics metrics;
 
     public CircuitBreakerSecuredHttpClient(Vertx vertx, HttpClient httpClient, Metrics metrics,
-                                           int openingThreshold, long openingIntervalMs, long closingIntervalMs) {
+                                           int openingThreshold, long openingIntervalMs, long closingIntervalMs,
+                                           Clock clock) {
         circuitBreakerCreator = name -> new CircuitBreaker("http-client-circuit-breaker-" + name,
-                Objects.requireNonNull(vertx), openingThreshold, openingIntervalMs, closingIntervalMs)
+                Objects.requireNonNull(vertx), openingThreshold, openingIntervalMs, closingIntervalMs,
+                Objects.requireNonNull(clock))
                 .openHandler(ignored -> circuitOpened(name))
                 .halfOpenHandler(ignored -> circuitHalfOpened(name))
                 .closeHandler(ignored -> circuitClosed(name));

--- a/src/main/java/org/prebid/server/vertx/jdbc/CircuitBreakerSecuredJdbcClient.java
+++ b/src/main/java/org/prebid/server/vertx/jdbc/CircuitBreakerSecuredJdbcClient.java
@@ -9,6 +9,7 @@ import org.prebid.server.execution.Timeout;
 import org.prebid.server.metric.Metrics;
 import org.prebid.server.vertx.CircuitBreaker;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -25,10 +26,11 @@ public class CircuitBreakerSecuredJdbcClient implements JdbcClient {
     private final Metrics metrics;
 
     public CircuitBreakerSecuredJdbcClient(Vertx vertx, JdbcClient jdbcClient, Metrics metrics,
-                                           int openingThreshold, long openingIntervalMs, long closingIntervalMs) {
+                                           int openingThreshold, long openingIntervalMs, long closingIntervalMs,
+                                           Clock clock) {
 
         breaker = new CircuitBreaker("jdbc-client-circuit-breaker", Objects.requireNonNull(vertx),
-                openingThreshold, openingIntervalMs, closingIntervalMs)
+                openingThreshold, openingIntervalMs, closingIntervalMs, Objects.requireNonNull(clock))
                 .openHandler(ignored -> circuitOpened())
                 .halfOpenHandler(ignored -> circuitHalfOpened())
                 .closeHandler(ignored -> circuitClosed());

--- a/src/test/java/org/prebid/server/vertx/CircuitBreakerTest.java
+++ b/src/test/java/org/prebid/server/vertx/CircuitBreakerTest.java
@@ -14,8 +14,11 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 @RunWith(VertxUnitRunner.class)
 public class CircuitBreakerTest {
@@ -25,25 +28,20 @@ public class CircuitBreakerTest {
 
     private Vertx vertx;
 
+    private Clock clock;
+
     private CircuitBreaker circuitBreaker;
 
     @Before
     public void setUp() {
         vertx = Vertx.vertx();
-        circuitBreaker = new CircuitBreaker("name", vertx, 1, 100L, 200L);
+        clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        circuitBreaker = new CircuitBreaker("name", vertx, 1, 100L, 200L, clock);
     }
 
     @After
     public void tearDown(TestContext context) {
         vertx.close(context.asyncAssertSuccess());
-    }
-
-    @Test
-    public void creationShouldFailOnNullArguments() {
-        assertThatNullPointerException().isThrownBy(
-                () -> new CircuitBreaker(null, null, 0, 0L, 0L));
-        assertThatNullPointerException().isThrownBy(
-                () -> new CircuitBreaker("name", null, 0, 0L, 0L));
     }
 
     @Test
@@ -122,7 +120,7 @@ public class CircuitBreakerTest {
     @Test
     public void executeShouldFailsWithOriginalExceptionIfOpeningIntervalExceeds(TestContext context) {
         // given
-        circuitBreaker = new CircuitBreaker("name", vertx, 2, 100L, 200L);
+        circuitBreaker = new CircuitBreaker("name", vertx, 2, 100L, 200L, clock);
 
         // when
         final Future<?> future1 = executeWithFail(context, "exception1");

--- a/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
+++ b/src/test/java/org/prebid/server/vertx/http/CircuitBreakerSecuredHttpClientTest.java
@@ -19,8 +19,11 @@ import org.prebid.server.exception.PreBidException;
 import org.prebid.server.metric.Metrics;
 import org.prebid.server.vertx.http.model.HttpClientResponse;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -37,6 +40,8 @@ public class CircuitBreakerSecuredHttpClientTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private Vertx vertx;
+
+    private Clock clock;
     @Mock
     private HttpClient wrappedHttpClient;
     @Mock
@@ -47,22 +52,13 @@ public class CircuitBreakerSecuredHttpClientTest {
     @Before
     public void setUp() {
         vertx = Vertx.vertx();
-        httpClient = new CircuitBreakerSecuredHttpClient(vertx, wrappedHttpClient, metrics, 1, 100L, 200L);
+        clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        httpClient = new CircuitBreakerSecuredHttpClient(vertx, wrappedHttpClient, metrics, 1, 100L, 200L, clock);
     }
 
     @After
     public void tearDown(TestContext context) {
         vertx.close(context.asyncAssertSuccess());
-    }
-
-    @Test
-    public void creationShouldFailOnNullArguments() {
-        assertThatNullPointerException().isThrownBy(
-                () -> new CircuitBreakerSecuredHttpClient(null, null, null, 0, 0L, 0L));
-        assertThatNullPointerException().isThrownBy(
-                () -> new CircuitBreakerSecuredHttpClient(vertx, null, null, 0, 0L, 0L));
-        assertThatNullPointerException().isThrownBy(
-                () -> new CircuitBreakerSecuredHttpClient(vertx, httpClient, null, 0, 0L, 0L));
     }
 
     @Test
@@ -174,7 +170,7 @@ public class CircuitBreakerSecuredHttpClientTest {
     @Test
     public void requestShouldFailsWithOriginalExceptionIfOpeningIntervalExceeds(TestContext context) {
         // given
-        httpClient = new CircuitBreakerSecuredHttpClient(vertx, wrappedHttpClient, metrics, 2, 100L, 200L);
+        httpClient = new CircuitBreakerSecuredHttpClient(vertx, wrappedHttpClient, metrics, 2, 100L, 200L, clock);
 
         givenHttpClientReturning(new RuntimeException("exception1"), new RuntimeException("exception2"));
 


### PR DESCRIPTION
This PR fixes error:
```
2019-08-22 07:26:53.942  WARN 6420 --- [vertx-blocked-thread-checker] io.vertx.core.impl.BlockedThreadChecker  : Thread Thread[vert.x-eventloop-thread-4,5,main] has been blocked for 572566 ms, time limit i
s 2000 ms                                                                                                                                                                                                    
                                                                                                                                                                                                             
io.vertx.core.VertxException: Thread blocked                                                                                                                                                                 
        at io.vertx.circuitbreaker.impl.CircuitBreakerImpl.state(CircuitBreakerImpl.java:185)                                                                                                                
        at org.prebid.server.vertx.CircuitBreaker.ensureToIncrementFailureCount(CircuitBreaker.java:77)                                                                                                      
        at org.prebid.server.vertx.CircuitBreaker.failBreaker(CircuitBreaker.java:65)                                                                                                                        
        at org.prebid.server.vertx.CircuitBreaker.lambda$execute$2(CircuitBreaker.java:50)                                                                                                                   
        at org.prebid.server.vertx.CircuitBreaker$$Lambda$438/1727815211.apply(Unknown Source)                                                                                                               
        at io.vertx.core.Future.lambda$recover$4(Future.java:387)                                                                                                                                            
        at io.vertx.core.Future$$Lambda$283/1530116403.handle(Unknown Source)                                                                                                                                
        at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79)                                                                                                                                      
        at io.vertx.core.Future.recover(Future.java:381)                                                                                                                                                     
        at org.prebid.server.vertx.CircuitBreaker.execute(CircuitBreaker.java:50)                                                                                                                            
        at org.prebid.server.vertx.CircuitBreaker.lambda$execute$0(CircuitBreaker.java:38)                                                                                                                   
        at org.prebid.server.vertx.CircuitBreaker$$Lambda$420/2125043348.handle(Unknown Source)                                                                                                              
        at io.vertx.circuitbreaker.impl.CircuitBreakerImpl.executeOperation(CircuitBreakerImpl.java:379)                                                                                                     
        at io.vertx.circuitbreaker.impl.CircuitBreakerImpl.executeAndReportWithFallback(CircuitBreakerImpl.java:240)                                                                                         
        at io.vertx.circuitbreaker.impl.CircuitBreakerImpl.executeWithFallback(CircuitBreakerImpl.java:395)                                                                                                  
        at io.vertx.circuitbreaker.impl.CircuitBreakerImpl.execute(CircuitBreakerImpl.java:400)                                                                                                              
        at org.prebid.server.vertx.CircuitBreaker.execute(CircuitBreaker.java:38)                                                                                                                            
        at org.prebid.server.geolocation.CircuitBreakerSecuredGeoLocationService.lookup(CircuitBreakerSecuredGeoLocationService.java:57)                                                                     
        at org.prebid.server.gdpr.GdprService.toGdprInfo(GdprService.java:272)                                                                                                                               
        at org.prebid.server.gdpr.GdprService.resultByVendor(GdprService.java:128)                                                                                                                           
        at org.prebid.server.auction.PrivacyEnforcementService.lambda$getVendorsToGdprPermission$1(PrivacyEnforcementService.java:114)                                                                       
        at org.prebid.server.auction.PrivacyEnforcementService$$Lambda$627/73038001.apply(Unknown Source)                                                                                                    
        at io.vertx.core.Future.lambda$compose$1(Future.java:265)                                                                                                                                            
        at io.vertx.core.Future$$Lambda$437/1312481869.handle(Unknown Source)                                                                                                                                
        at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79)                                                                                                                                      
        at io.vertx.core.Future.compose(Future.java:261)                                                                                                                                                     
        at org.prebid.server.auction.PrivacyEnforcementService.getVendorsToGdprPermission(PrivacyEnforcementService.java:112)                                                                                
        at org.prebid.server.auction.PrivacyEnforcementService.mask(PrivacyEnforcementService.java:69)                                                                                                       
        at org.prebid.server.auction.ExchangeService.makeBidderRequests(ExchangeService.java:350)                                                                                                            
        at org.prebid.server.auction.ExchangeService.extractBidderRequests(ExchangeService.java:305)                                                                                                         
        at org.prebid.server.auction.ExchangeService.lambda$holdAuction$1(ExchangeService.java:155)                                                                                                          
        at org.prebid.server.auction.ExchangeService$$Lambda$585/1958607927.apply(Unknown Source)                                                                                                            
        at io.vertx.core.Future.lambda$compose$1(Future.java:265)                                                                                                                                            
        at io.vertx.core.Future$$Lambda$437/1312481869.handle(Unknown Source)
        at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79)
        at io.vertx.core.Future.compose(Future.java:261)
        at org.prebid.server.auction.ExchangeService.holdAuction(ExchangeService.java:155)
        at org.prebid.server.handler.openrtb2.AuctionHandler.lambda$handle$4(AuctionHandler.java:84)
        at org.prebid.server.handler.openrtb2.AuctionHandler$$Lambda$582/1038430906.apply(Unknown Source)
        at io.vertx.core.Future.lambda$compose$1(Future.java:265)
        at io.vertx.core.Future$$Lambda$437/1312481869.handle(Unknown Source)
        at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:79)
        at io.vertx.core.Future.compose(Future.java:261)
        at org.prebid.server.handler.openrtb2.AuctionHandler.handle(AuctionHandler.java:84)
        at org.prebid.server.handler.openrtb2.AuctionHandler.handle(AuctionHandler.java:39)
        at io.vertx.ext.web.impl.RouteImpl.handleContext(RouteImpl.java:227)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:120)
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:134)
```