### PR TITLE
Add configuration property to process only predefined accounts id.

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -161,6 +161,9 @@ For HTTP data source available next options:
 - `settings.http.endpoint` - the url to fetch stored requests.
 - `settings.http.amp-endpoint` - the url to fetch AMP stored requests.
 
+For account processing rules available next options:
+- `settings.enforce-valid-account` - flag enables processing only request with account id.  
+
 For caching available next options:
 - `settings.in-memory-cache.ttl-seconds` - how long (in seconds) data will be available in LRU cache.
 - `settings.in-memory-cache.cache-size` - the size of LRU cache.

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -162,7 +162,7 @@ For HTTP data source available next options:
 - `settings.http.amp-endpoint` - the url to fetch AMP stored requests.
 
 For account processing rules available next options:
-- `settings.enforce-valid-account` - flag enables processing only request with account id.  
+- `settings.enforce-valid-account` - if equals to `true` then request without account id will be rejected with 401.
 
 For caching available next options:
 - `settings.in-memory-cache.ttl-seconds` - how long (in seconds) data will be available in LRU cache.

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -26,6 +26,7 @@ import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.cookie.UidsCookieService;
 import org.prebid.server.exception.InvalidRequestException;
 import org.prebid.server.exception.PreBidException;
+import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidRequest;
@@ -62,6 +63,7 @@ public class AuctionRequestFactory {
     private static final Logger logger = LoggerFactory.getLogger(AuctionRequestFactory.class);
 
     private final long maxRequestSize;
+    private final boolean isAccountEnforced;
     private final String adServerCurrency;
     private final StoredRequestProcessor storedRequestProcessor;
     private final ImplicitParametersExtractor paramsExtractor;
@@ -74,13 +76,14 @@ public class AuctionRequestFactory {
     private final ApplicationSettings applicationSettings;
 
     public AuctionRequestFactory(
-            long maxRequestSize,
+            long maxRequestSize, boolean isAccountEnforced,
             String adServerCurrency, StoredRequestProcessor storedRequestProcessor,
             ImplicitParametersExtractor paramsExtractor, UidsCookieService uidsCookieService,
             BidderCatalog bidderCatalog, RequestValidator requestValidator, InterstitialProcessor interstitialProcessor,
             TimeoutResolver timeoutResolver, TimeoutFactory timeoutFactory, ApplicationSettings applicationSettings) {
 
         this.maxRequestSize = maxRequestSize;
+        this.isAccountEnforced = isAccountEnforced;
         this.adServerCurrency = validateCurrency(adServerCurrency);
         this.storedRequestProcessor = Objects.requireNonNull(storedRequestProcessor);
         this.paramsExtractor = Objects.requireNonNull(paramsExtractor);
@@ -533,11 +536,14 @@ public class AuctionRequestFactory {
      */
     private Future<Account> accountFrom(BidRequest bidRequest, Timeout timeout) {
         final String accountId = accountIdFrom(bidRequest);
+        final Future<Account> failedAccountResult = isAccountEnforced
+                ? Future.failedFuture(new UnauthorizedAccountException("Unauthorised account id " + accountId))
+                : Future.succeededFuture(emptyAccount(accountId));
 
         return StringUtils.isEmpty(accountId)
-                ? Future.succeededFuture(emptyAccount(accountId))
+                ? failedAccountResult
                 : applicationSettings.getAccountById(accountId, timeout)
-                .otherwise(exception -> accountFallback(exception, accountId));
+                .recover(exception -> accountFallback(exception, failedAccountResult));
     }
 
     /**
@@ -583,15 +589,13 @@ public class AuctionRequestFactory {
     }
 
     /**
-     * Returns empty account if it is not found or any exception occurred.
-     * <p>
-     * Note: account data is not critical, so we don't want to fail whole request in case of error.
+     * Log any not {@link PreBidException} errors. Returns response provided in method parameters.
      */
-    private static Account accountFallback(Throwable exception, String accountId) {
+    private static Future<Account> accountFallback(Throwable exception, Future<Account> response) {
         if (!(exception instanceof PreBidException)) {
             logger.warn("Error occurred while fetching account", exception);
         }
-        return emptyAccount(accountId);
+        return response;
     }
 
     /**

--- a/src/main/java/org/prebid/server/exception/UnauthorizedAccountException.java
+++ b/src/main/java/org/prebid/server/exception/UnauthorizedAccountException.java
@@ -1,0 +1,9 @@
+package org.prebid.server.exception;
+
+@SuppressWarnings("serial")
+public class UnauthorizedAccountException extends RuntimeException {
+
+    public UnauthorizedAccountException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
@@ -34,6 +34,7 @@ import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.exception.InvalidRequestException;
 import org.prebid.server.exception.PreBidException;
+import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.metric.MetricName;
 import org.prebid.server.metric.Metrics;
 import org.prebid.server.proto.openrtb.ext.ExtPrebid;
@@ -299,6 +300,15 @@ public class AmpHandler implements Handler<RoutingContext> {
                 body = errorMessages.stream().map(
                         msg -> String.format("Invalid request format: %s", msg))
                         .collect(Collectors.joining("\n"));
+            } else if (exception instanceof UnauthorizedAccountException) {
+                metricRequestStatus = MetricName.badinput;
+                final String errorMessage = exception.getMessage();
+                logger.info("Unauthorized: {0}", errorMessage);
+
+                errorMessages = Collections.singletonList(errorMessage);
+
+                status = HttpResponseStatus.UNAUTHORIZED.code();
+                body = String.format("Unauthorised: %s", errorMessage);
             } else {
                 final String message = exception.getMessage();
 

--- a/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
@@ -20,6 +20,7 @@ import org.prebid.server.auction.model.AuctionContext;
 import org.prebid.server.auction.model.Tuple2;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.exception.InvalidRequestException;
+import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.metric.MetricName;
 import org.prebid.server.metric.Metrics;
 import org.prebid.server.util.HttpUtil;
@@ -137,6 +138,15 @@ public class AuctionHandler implements Handler<RoutingContext> {
                 body = errorMessages.stream()
                         .map(msg -> String.format("Invalid request format: %s", msg))
                         .collect(Collectors.joining("\n"));
+            } else if (exception instanceof UnauthorizedAccountException) {
+                metricRequestStatus = MetricName.badinput;
+                final String errorMessage = exception.getMessage();
+                logger.info("Unauthorized: {0}", errorMessage);
+
+                errorMessages = Collections.singletonList(errorMessage);
+
+                status = HttpResponseStatus.UNAUTHORIZED.code();
+                body = String.format("Unauthorised: %s", errorMessage);
             } else {
                 metricRequestStatus = MetricName.err;
                 logger.error("Critical error while running the auction", exception);

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -139,7 +139,7 @@ public class ServiceConfiguration {
     @Bean
     AuctionRequestFactory auctionRequestFactory(
             @Value("${auction.max-request-size}") @Min(0) int maxRequestSize,
-            @Value("${settings.enforce-valid-account}") boolean isAccountEnforced,
+            @Value("${settings.enforce-valid-account}") boolean enforceValidAccount,
             @Value("${auction.ad-server-currency:#{null}}") String adServerCurrency,
             StoredRequestProcessor storedRequestProcessor,
             ImplicitParametersExtractor implicitParametersExtractor,
@@ -150,7 +150,7 @@ public class ServiceConfiguration {
             TimeoutFactory timeoutFactory,
             ApplicationSettings applicationSettings) {
 
-        return new AuctionRequestFactory(maxRequestSize, isAccountEnforced, adServerCurrency,
+        return new AuctionRequestFactory(maxRequestSize, enforceValidAccount, adServerCurrency,
                 storedRequestProcessor, implicitParametersExtractor, uidsCookieService, bidderCatalog, requestValidator,
                 new InterstitialProcessor(), timeoutResolver, timeoutFactory, applicationSettings);
     }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -139,6 +139,7 @@ public class ServiceConfiguration {
     @Bean
     AuctionRequestFactory auctionRequestFactory(
             @Value("${auction.max-request-size}") @Min(0) int maxRequestSize,
+            @Value("${settings.enforce-valid-account}") boolean isAccountEnforced,
             @Value("${auction.ad-server-currency:#{null}}") String adServerCurrency,
             StoredRequestProcessor storedRequestProcessor,
             ImplicitParametersExtractor implicitParametersExtractor,
@@ -149,7 +150,7 @@ public class ServiceConfiguration {
             TimeoutFactory timeoutFactory,
             ApplicationSettings applicationSettings) {
 
-        return new AuctionRequestFactory(maxRequestSize, adServerCurrency,
+        return new AuctionRequestFactory(maxRequestSize, isAccountEnforced, adServerCurrency,
                 storedRequestProcessor, implicitParametersExtractor, uidsCookieService, bidderCatalog, requestValidator,
                 new InterstitialProcessor(), timeoutResolver, timeoutFactory, applicationSettings);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,6 +53,7 @@ metrics:
   accounts:
     default-verbosity: none
 settings:
+  enforce-valid-account: false
   database:
     pool-size: 20
   in-memory-cache:

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -34,6 +34,7 @@ import org.prebid.server.bidder.Bidder;
 import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.exception.InvalidRequestException;
+import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.metric.MetricName;
@@ -195,6 +196,26 @@ public class AmpHandlerTest extends VertxTest {
                         tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
                         tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"));
         verify(httpResponse).end(eq("Invalid request format: Request is invalid"));
+    }
+
+    @Test
+    public void shouldRespondWithUnauthorizedIfAccountIdIsInvalid() {
+        // given
+        given(ampRequestFactory.fromRequest(any(), anyLong()))
+                .willReturn(Future.failedFuture(new UnauthorizedAccountException("Account id is not provided")));
+
+        // when
+        ampHandler.handle(routingContext);
+
+        // then
+        verifyZeroInteractions(exchangeService);
+        verify(httpResponse).setStatusCode(eq(401));
+        assertThat(httpResponse.headers()).hasSize(2)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(
+                        tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
+                        tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"));
+        verify(httpResponse).end(eq("Unauthorised: Account id is not provided"));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -27,6 +27,7 @@ import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.auction.model.AuctionContext;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.exception.InvalidRequestException;
+import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.metric.MetricName;
@@ -56,6 +57,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class AuctionHandlerTest extends VertxTest {
 
@@ -163,6 +165,21 @@ public class AuctionHandlerTest extends VertxTest {
         // then
         verify(httpResponse).setStatusCode(eq(400));
         verify(httpResponse).end(eq("Invalid request format: Request is invalid"));
+    }
+
+    @Test
+    public void shouldRespondWithUnauthorizedIfAccountIdIsInvalid() {
+        // given
+        given(auctionRequestFactory.fromRequest(any(), anyLong()))
+                .willReturn(Future.failedFuture(new UnauthorizedAccountException("Account id is not provided")));
+
+        // when
+        auctionHandler.handle(routingContext);
+
+        // then
+        verifyZeroInteractions(exchangeService);
+        verify(httpResponse).setStatusCode(eq(401));
+        verify(httpResponse).end(eq("Unauthorised: Account id is not provided"));
     }
 
     @Test


### PR DESCRIPTION
```
settings:
    enforce-valid-account: true // defaults to false
```
if option is true, PBS will reject any request (/openrtb2/auction or /amp) that don't carry an account ID with an HTTP 401.