### PR TITLE
Fix leaking host cookie to all bidders

### DIFF
--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -38,7 +38,6 @@ import org.prebid.server.proto.openrtb.ext.request.ExtUser;
 import org.prebid.server.proto.openrtb.ext.request.ExtUserDigiTrust;
 import org.prebid.server.settings.ApplicationSettings;
 import org.prebid.server.settings.model.Account;
-import org.prebid.server.util.HttpUtil;
 import org.prebid.server.validation.RequestValidator;
 import org.prebid.server.validation.model.ValidationResult;
 
@@ -191,7 +190,7 @@ public class AuctionRequestFactory {
 
         final Device populatedDevice = populateDevice(bidRequest.getDevice(), request);
         final Site populatedSite = bidRequest.getApp() == null ? populateSite(bidRequest.getSite(), request) : null;
-        final User populatedUser = populateUser(bidRequest.getUser(), context);
+        final User populatedUser = populateUser(bidRequest.getUser());
         final List<Imp> populatedImps = populateImps(imps, request);
         final Integer at = bidRequest.getAt();
         final boolean updateAt = at == null || at == 0;
@@ -291,36 +290,12 @@ public class AuctionRequestFactory {
     /**
      * Populates the request body's 'user' section from the incoming http request if the original is partially filled.
      */
-    private User populateUser(User user, RoutingContext context) {
-        final String id = userIdOrNull(user, context);
+    private User populateUser(User user) {
         final ObjectNode ext = userExtOrNull(user);
 
-        if (id != null || ext != null) {
+        if (ext != null) {
             final User.UserBuilder builder = user == null ? User.builder() : user.toBuilder();
-
-            if (id != null) {
-                builder.id(id);
-            }
-            if (ext != null) {
-                builder.ext(ext);
-            }
-
-            return builder.build();
-        }
-        return null;
-    }
-
-    /**
-     * Returns new user ID from host cookie if no request.user.id
-     * or null in case of request.user.id is already presented  or no host cookie passed in request.
-     */
-    private String userIdOrNull(User user, RoutingContext context) {
-        final String id = user != null ? user.getId() : null;
-        if (StringUtils.isBlank(id)) {
-            final String parsedId = uidsCookieService.parseHostCookie(HttpUtil.cookiesAsMap(context));
-            if (StringUtils.isNotBlank(parsedId)) {
-                return parsedId;
-            }
+            return builder.ext(ext).build();
         }
         return null;
     }

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -160,7 +160,6 @@ public class AuctionRequestFactoryTest extends VertxTest {
         givenValidBidRequest();
 
         givenImplicitParams("http://example.com", "example.com", "192.168.244.1", "UnitTest");
-        given(uidsCookieService.parseHostCookie(any())).willReturn("userId");
 
         // when
         final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
@@ -173,7 +172,6 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 .build());
         assertThat(request.getDevice())
                 .isEqualTo(Device.builder().ip("192.168.244.1").ua("UnitTest").build());
-        assertThat(request.getUser()).isEqualTo(User.builder().id("userId").build());
     }
 
     @Test
@@ -245,7 +243,6 @@ public class AuctionRequestFactoryTest extends VertxTest {
         givenBidRequest(bidRequest);
 
         givenImplicitParams("http://anotherexample.com", "anotherexample.com", "192.168.244.2", "UnitTest2");
-        given(uidsCookieService.parseHostCookie(any())).willReturn("userId");
 
         // when
         final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
@@ -352,20 +349,6 @@ public class AuctionRequestFactoryTest extends VertxTest {
     }
 
     @Test
-    public void shouldNotSetUserIfNoHostCookie() {
-        // given
-        givenValidBidRequest();
-
-        given(uidsCookieService.parseHostCookie(any())).willReturn(null);
-
-        // when
-        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
-
-        // then
-        assertThat(request.getUser()).isNull();
-    }
-
-    @Test
     public void shouldSetUserExtDigitrustPerfIfNotDefined() {
         // given
         givenBidRequest(BidRequest.builder()
@@ -375,8 +358,6 @@ public class AuctionRequestFactoryTest extends VertxTest {
                                 .build()))
                         .build())
                 .build());
-
-        given(uidsCookieService.parseHostCookie(any())).willReturn(null);
 
         // when
         final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();


### PR DESCRIPTION
Fixed leaking host cookie to all bidders. 

After looking into our code I've found that we do have the same issue as GO had, which is the result of host cookie value being set to `user.id`. Also, this change is a simple necessity to keep PBS-Java up with GO in terms of protocol and processing standards.