### PR TITLE
Refactor of NotificationEventHandler

### DIFF
--- a/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
+++ b/src/main/java/org/prebid/server/analytics/model/NotificationEvent.java
@@ -1,9 +1,13 @@
 package org.prebid.server.analytics.model;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
+import org.prebid.server.settings.model.Account;
 
-@AllArgsConstructor(staticName = "of")
+/**
+ * Represents a transaction at /event endpoint.
+ */
+@Builder
 @Value
 public class NotificationEvent {
 
@@ -11,7 +15,7 @@ public class NotificationEvent {
 
     String bidId;
 
-    String accountId;
+    Account account;
 
     HttpContext httpContext;
 
@@ -19,4 +23,3 @@ public class NotificationEvent {
         win, imp
     }
 }
-

--- a/src/main/java/org/prebid/server/events/EventsService.java
+++ b/src/main/java/org/prebid/server/events/EventsService.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 public class EventsService {
 
     private static final String EVENT_CALLBACK_URL_PATTERN = "%s/event?t=%s&b=%s&a=%s&f=i";
-    private static final String VIEW_EVENT_TYPE = "view";
     private static final String WIN_EVENT_TYPE = "win";
+    private static final String IMP_EVENT_TYPE = "imp";
     private static final String BIDID_PLACEHOLDER = "BIDID";
 
     private final String externalUrl;
@@ -24,7 +24,7 @@ public class EventsService {
     public Events createEvent(String bidId, String accountId) {
         return Events.of(
                 String.format(EVENT_CALLBACK_URL_PATTERN, externalUrl, WIN_EVENT_TYPE, bidId, accountId),
-                String.format(EVENT_CALLBACK_URL_PATTERN, externalUrl, VIEW_EVENT_TYPE, bidId, accountId));
+                String.format(EVENT_CALLBACK_URL_PATTERN, externalUrl, IMP_EVENT_TYPE, bidId, accountId));
     }
 
     /**

--- a/src/main/java/org/prebid/server/handler/SettingsCacheNotificationHandler.java
+++ b/src/main/java/org/prebid/server/handler/SettingsCacheNotificationHandler.java
@@ -11,6 +11,8 @@ import org.prebid.server.settings.CacheNotificationListener;
 import org.prebid.server.settings.proto.request.InvalidateSettingsCacheRequest;
 import org.prebid.server.settings.proto.request.UpdateSettingsCacheRequest;
 
+import java.util.Objects;
+
 /**
  * Handles HTTP requests for updating/invalidating settings cache.
  */
@@ -19,7 +21,7 @@ public class SettingsCacheNotificationHandler implements Handler<RoutingContext>
     private CacheNotificationListener cacheNotificationListener;
 
     public SettingsCacheNotificationHandler(CacheNotificationListener cacheNotificationListener) {
-        this.cacheNotificationListener = cacheNotificationListener;
+        this.cacheNotificationListener = Objects.requireNonNull(cacheNotificationListener);
     }
 
     @Override

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/response/Events.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/response/Events.java
@@ -3,11 +3,14 @@ package org.prebid.server.proto.openrtb.ext.response;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
+/**
+ * Defines the contract for bidresponse.seatbid.bid[i].ext.prebid.events
+ */
 @AllArgsConstructor(staticName = "of")
 @Value
 public class Events {
 
     String win;
 
-    String view;
+    String imp;
 }

--- a/src/test/java/org/prebid/server/events/EventsServiceTest.java
+++ b/src/test/java/org/prebid/server/events/EventsServiceTest.java
@@ -18,7 +18,7 @@ public class EventsServiceTest {
 
     @Before
     public void setUp() {
-        eventsService = new EventsService("http://external.org");
+        eventsService = new EventsService("http://external-url");
     }
 
     @Test
@@ -27,8 +27,9 @@ public class EventsServiceTest {
         final Events events = eventsService.createEvent("bidId", "accountId");
 
         // then
-        assertThat(events).isEqualTo(Events.of("http://external.org/event?t=win&b=bidId&a=accountId&f=i",
-                "http://external.org/event?t=view&b=bidId&a=accountId&f=i"));
+        assertThat(events).isEqualTo(Events.of(
+                "http://external-url/event?t=win&b=bidId&a=accountId&f=i",
+                "http://external-url/event?t=imp&b=bidId&a=accountId&f=i"));
     }
 
     @Test
@@ -37,6 +38,6 @@ public class EventsServiceTest {
         final String winUrlTargeting = eventsService.winUrlTargeting("accountId");
 
         // then
-        assertThat(winUrlTargeting).isEqualTo("http://external.org/event?t=win&b=BIDID&a=accountId&f=i");
+        assertThat(winUrlTargeting).isEqualTo("http://external-url/event?t=win&b=BIDID&a=accountId&f=i");
     }
 }

--- a/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/NotificationEventHandlerTest.java
@@ -80,111 +80,113 @@ public class NotificationEventHandlerTest extends VertxTest {
         notificationHandler.handle(routingContext);
 
         // then
+        verifyZeroInteractions(analyticsReporter);
+
         assertThat(captureResponseStatusCode()).isEqualTo(400);
         assertThat(captureResponseBody())
-                .isEqualTo("'type' is required query parameter. Possible values are i and w, but was null");
+                .isEqualTo("Type 't' is required query parameter. Possible values are win and imp, but was null");
     }
 
     @Test
     public void shouldReturnBadRequestWhenTypeValueIsInvalid() {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("t", "invalid"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "invalid"));
 
         // when
         notificationHandler.handle(routingContext);
 
         // then
+        verifyZeroInteractions(analyticsReporter);
+
         assertThat(captureResponseStatusCode()).isEqualTo(400);
         assertThat(captureResponseBody())
-                .isEqualTo("'type' is required query parameter. Possible values are i and w, but was invalid");
-
-        verifyZeroInteractions(analyticsReporter);
+                .isEqualTo("Type 't' is required query parameter. Possible values are win and imp, but was invalid");
     }
 
     @Test
-    public void shouldReturnBadRequestWhenBididWasNotDefined() {
+    public void shouldReturnBadRequestWhenBidIdWasNotDefined() {
         // given
-        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap().add("t", "w"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win"));
 
         // when
         notificationHandler.handle(routingContext);
 
         // then
+        verifyZeroInteractions(analyticsReporter);
+
         assertThat(captureResponseStatusCode()).isEqualTo(400);
         assertThat(captureResponseBody())
-                .isEqualTo("'bidid' is required query parameter and can't be empty");
-
-        verifyZeroInteractions(analyticsReporter);
+                .isEqualTo("BidId 'b' is required query parameter and can't be empty");
     }
 
     @Test
     public void shouldReturnUnauthorizedWhenAccountWasNotDefined() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap().add("t", "w").add("b", "id"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId"));
 
         // when
         notificationHandler.handle(routingContext);
 
         // then
+        verifyZeroInteractions(analyticsReporter);
+
         assertThat(captureResponseStatusCode()).isEqualTo(401);
         assertThat(captureResponseBody())
-                .isEqualTo("'account' is required query parameter and can't be empty");
-
-        verifyZeroInteractions(analyticsReporter);
+                .isEqualTo("Account 'a' is required query parameter and can't be empty");
     }
 
     @Test
     public void shouldReturnBadRequestWhenFormatValueIsInvalid() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "id")
-                        .add("a", "acc")
-                        .add("f", "invalid"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId")
+                .add("f", "invalid"));
 
         // when
         notificationHandler.handle(routingContext);
 
         // then
+        verifyZeroInteractions(analyticsReporter);
+
         assertThat(captureResponseStatusCode()).isEqualTo(400);
         assertThat(captureResponseBody())
-                .isEqualTo("'format' is required query parameter. Possible values are b and i, but was invalid");
-
-        verifyZeroInteractions(analyticsReporter);
+                .isEqualTo("Format 'f' query parameter is invalid. Possible values are b and i, but was invalid");
     }
 
     @Test
     public void shouldReturnBadRequestWhenAnalyticsValueIsInvalid() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "id")
-                        .add("a", "1233211")
-                        .add("f", "b")
-                        .add("x", "invalid"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId")
+                .add("f", "b")
+                .add("x", "invalid"));
 
         // when
         notificationHandler.handle(routingContext);
 
         // then
+        verifyZeroInteractions(analyticsReporter);
+
         assertThat(captureResponseStatusCode()).isEqualTo(400);
         assertThat(captureResponseBody())
-                .isEqualTo("'analytics' is required query parameter. Possible values are 1 and 0, but was invalid");
-
-        verifyZeroInteractions(analyticsReporter);
+                .isEqualTo("Analytics 'x' query parameter is invalid. Possible values are 1 and 0, but was invalid");
     }
 
     @Test
-    public void shouldNotPassEventToAnalyticReporterAndRespondUnauthorizedWhenAccountNotFound() {
+    public void shouldNotPassEventToAnalyticsReporterWhenAccountNotFound() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "bidId")
-                        .add("a", "acc"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.failedFuture(new PreBidException("Not Found")));
@@ -193,20 +195,19 @@ public class NotificationEventHandlerTest extends VertxTest {
         notificationHandler.handle(routingContext);
 
         // then
-        assertThat(captureResponseStatusCode()).isEqualTo(401);
-        assertThat(captureResponseBody()).isEqualTo("Given 'accountId' is not supporting the event");
-
         verifyZeroInteractions(analyticsReporter);
+
+        assertThat(captureResponseStatusCode()).isEqualTo(401);
+        assertThat(captureResponseBody()).isEqualTo("Account 'accountId' doesn't not support events");
     }
 
     @Test
-    public void shouldNotPassEventToAnalyticReporterWhenAccountEventNotEnabled() {
+    public void shouldNotPassEventToAnalyticsReporterWhenAccountEventNotEnabled() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "bidId")
-                        .add("a", "1233213"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(false).build()));
@@ -215,50 +216,53 @@ public class NotificationEventHandlerTest extends VertxTest {
         notificationHandler.handle(routingContext);
 
         // then
-        assertThat(captureResponseStatusCode()).isEqualTo(401);
-        assertThat(captureResponseBody()).isEqualTo("Given 'accountId' is not supporting the event");
-
         verifyZeroInteractions(analyticsReporter);
+
+        assertThat(captureResponseStatusCode()).isEqualTo(401);
+        assertThat(captureResponseBody()).isEqualTo("Account 'null' doesn't not support events");
     }
 
     @Test
-    public void shouldPassEventToAnalyticReporterWhenAccountEventEnabled() {
+    public void shouldPassEventToAnalyticsReporterWhenAccountEventEnabled() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "bidId")
-                        .add("a", "1233213"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId"));
 
+        final Account account = Account.builder().eventsEnabled(true).build();
         given(applicationSettings.getAccountById(anyString(), any()))
-                .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));
+                .willReturn(Future.succeededFuture(account));
 
         // when
         notificationHandler.handle(routingContext);
 
         // then
         final Map<String, String> headers = new HashMap<>();
-        headers.put("t", "w");
+        headers.put("t", "win");
         headers.put("b", "bidId");
-        headers.put("a", "1233213");
+        headers.put("a", "accountId");
         final HttpContext expectedHttpContext = HttpContext.builder().queryParams(headers)
                 .headers(Collections.emptyMap())
                 .cookies(Collections.emptyMap())
                 .build();
 
-        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.of(NotificationEvent.Type.win, "bidId", "1233213",
-                expectedHttpContext));
+        assertThat(captureAnalyticEvent()).isEqualTo(NotificationEvent.builder()
+                .type(NotificationEvent.Type.win)
+                .bidId("bidId")
+                .account(account)
+                .httpContext(expectedHttpContext)
+                .build());
     }
 
     @Test
-    public void shouldNotPassEventToAnalyticReporterWhenAnalyticsValueIsZero() {
+    public void shouldNotPassEventToAnalyticsReporterWhenAnalyticsValueIsZero() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "bidId")
-                        .add("a", "1233213")
-                        .add("x", "0"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId")
+                .add("x", "0"));
 
         // when
         notificationHandler.handle(routingContext);
@@ -271,12 +275,11 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldRespondWithPixelAndContentTypeWhenRequestFormatIsImp() throws IOException {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "bidId")
-                        .add("a", "1233213")
-                        .add("f", "i"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId")
+                .add("f", "i"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));
@@ -295,11 +298,10 @@ public class NotificationEventHandlerTest extends VertxTest {
     @Test
     public void shouldRespondWithNoContentWhenRequestFormatIsNotDefined() {
         // given
-        given(httpRequest.params())
-                .willReturn(MultiMap.caseInsensitiveMultiMap()
-                        .add("t", "w")
-                        .add("b", "bidId")
-                        .add("a", "1233213"));
+        given(httpRequest.params()).willReturn(MultiMap.caseInsensitiveMultiMap()
+                .add("t", "win")
+                .add("b", "bidId")
+                .add("a", "accountId"));
 
         given(applicationSettings.getAccountById(anyString(), any()))
                 .willReturn(Future.succeededFuture(Account.builder().eventsEnabled(true).build()));
@@ -343,4 +345,3 @@ public class NotificationEventHandlerTest extends VertxTest {
         return captor.getValue();
     }
 }
-

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -490,9 +490,9 @@ public class ApplicationTest extends IntegrationTest {
     }
 
     @Test
-    public void eventHandlerShouldRespondWithPNGTrackingPixel() throws IOException {
+    public void eventHandlerShouldRespondWithTrackingPixel() throws IOException {
         final Response response = given(spec)
-                .queryParam("t", "w")
+                .queryParam("t", "win")
                 .queryParam("b", "bidId")
                 .queryParam("a", "14062")
                 .queryParam("f", "i")

--- a/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-response.json
@@ -33,7 +33,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=a121a07f-1579-4465-bc5e-5c5b02a0c421&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=a121a07f-1579-4465-bc5e-5c5b02a0c421&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=a121a07f-1579-4465-bc5e-5c5b02a0c421&a=5001&f=i"
               }
             }
           }
@@ -74,7 +74,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=7706636740145184841&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=7706636740145184841&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=7706636740145184841&a=5001&f=i"
               },
               "cache": {
                 "bids": {
@@ -129,7 +129,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=928185755156387460&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=928185755156387460&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=928185755156387460&a=5001&f=i"
               },
               "cache": {
                 "bids": {
@@ -181,7 +181,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=7706636740145184840&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=7706636740145184840&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=7706636740145184840&a=5001&f=i"
               },
               "cache": {
                 "bids": {
@@ -237,7 +237,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=f227a07f-1579-4465-bc5e-5c5b02a0c181&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=f227a07f-1579-4465-bc5e-5c5b02a0c181&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=f227a07f-1579-4465-bc5e-5c5b02a0c181&a=5001&f=i"
               }
             }
           }
@@ -264,7 +264,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=f227a07f-1579-4465-bc5e-5c5b02a0c180&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=f227a07f-1579-4465-bc5e-5c5b02a0c180&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=f227a07f-1579-4465-bc5e-5c5b02a0c180&a=5001&f=i"
               }
             }
           }
@@ -304,7 +304,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=880290288&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=880290288&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=880290288&a=5001&f=i"
               },
               "cache": {
                 "vastXml": {
@@ -364,7 +364,7 @@
               },
               "events": {
                 "win": "http://localhost:8000/event?t=win&b=466223845&a=5001&f=i",
-                "view": "http://localhost:8000/event?t=view&b=466223845&a=5001&f=i"
+                "imp": "http://localhost:8000/event?t=imp&b=466223845&a=5001&f=i"
               },
               "cache": {
                 "bids": {


### PR DESCRIPTION
CL:
- Use `Accout` object instead of `accout id` string in NotificationEvent
- Fixed type `t` parameter values: `win/imp` instead of `w/i`
- NotificationEventHandler returns HTTP 500 in case of error while account fetching