### PR TITLE
Update bidders and difference docs on bidder info

### DIFF
--- a/docs/differenceBetweenPBSGo-and-Java.md
+++ b/docs/differenceBetweenPBSGo-and-Java.md
@@ -22,7 +22,7 @@ and not the other for an interim period. This page tracks known differences that
 1) PBS-Java has `/event` endpoint to allow Web browsers and mobile applications to notify about different ad events (win, view etc). Filling new bid extensions `response.seatbid.bid.ext.prebid.events.{win,view}` with events url after successful auction completing makes it possible. Also new targeting parameter `hb_winurl` with win event url is supported.
 1) PBS-Java supports per-account cache TTL and event URLs configuration in the database in columns `banner_cache_ttl`, `video_cache_ttl` and `events_enabled`.
 1) PBS-Java does not support passing bidder extensions in `imp[...].ext.prebid.bidder`. PBS-Go [PR 846](https://github.com/prebid/prebid-server/pull/846)
-1) PBS-Java responds with active bidders only in `/info/bidders` endpoint, although PBS-Go returns all implemented ones.
+1) PBS-Java responds with active bidders only in `/info/bidders` and `/info/bidders/all` endpoints, although PBS-Go returns all implemented ones. Calling `/info/bidders/{bidderName}` with a disabled bidder name will result in 404 Not Found, which is a desired behaviour, unlike in PBS-Go [issue 988](https://github.com/prebid/prebid-server/issues/988), [PR](https://github.com/prebid/prebid-server/pull/989).
 1) PBS-Java supports video impression tracking [issue 1015](https://github.com/prebid/prebid-server/issues/1015). PBS-Java [PR 437](https://github.com/rubicon-project/prebid-server-java/pull/437). 
 
 ## Minor differences

--- a/docs/endpoints/info/bidders.md
+++ b/docs/endpoints/info/bidders.md
@@ -2,7 +2,7 @@
 
 ## `GET /info/bidders`
 
-This endpoint returns a list of Bidders supported by Prebid Server.
+This endpoint returns a list of active Bidders supported by Prebid Server.
 These are the core values allowed to be used as `request.imp[i].ext.{bidder}`
 keys in [Auction](../openrtb2/auction.md) requests.
 


### PR DESCRIPTION
As it was decided with @bretg, the `/info/bidders` and `/info/bidders/{bidderName}` endpoints would keep a different behaviour from PBS-Go - Java won't display disabled bidders and will return 404 when trying to get an info for one which is not in active list.

Therefore, I've updated `bidders.md` and difference docs to emphasize these distinctions.