### PR TITLE
Update rubicon bidder to accept and handle a 204 No Content response

### DIFF
--- a/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
+++ b/src/main/java/org/prebid/server/bidder/HttpBidderRequester.java
@@ -146,7 +146,7 @@ public class HttpBidderRequester {
 
         final List<Result<List<BidderBid>>> createdBids = calls.stream()
                 .filter(httpCall -> httpCall.getError() == null)
-                .filter(httpCall -> httpCall.getResponse().getStatusCode() == HttpResponseStatus.OK.code())
+                .filter(HttpBidderRequester::isOkOrNoContent)
                 .map(httpCall -> bidder.makeBids(httpCall, bidRequest))
                 .collect(Collectors.toList());
 
@@ -175,6 +175,11 @@ public class HttpBidderRequester {
         }
 
         return builder.build();
+    }
+
+    private static boolean isOkOrNoContent(HttpCall httpCall) {
+        final int statusCode = httpCall.getResponse().getStatusCode();
+        return statusCode == HttpResponseStatus.OK.code() || statusCode == HttpResponseStatus.NO_CONTENT.code();
     }
 
     /**

--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconBidder.java
@@ -35,6 +35,7 @@ import org.prebid.server.bidder.model.BidderBid;
 import org.prebid.server.bidder.model.BidderError;
 import org.prebid.server.bidder.model.HttpCall;
 import org.prebid.server.bidder.model.HttpRequest;
+import org.prebid.server.bidder.model.HttpResponse;
 import org.prebid.server.bidder.model.Result;
 import org.prebid.server.bidder.rubicon.proto.RubiconAppExt;
 import org.prebid.server.bidder.rubicon.proto.RubiconBannerExt;
@@ -138,8 +139,13 @@ public class RubiconBidder implements Bidder<BidRequest> {
 
     @Override
     public Result<List<BidderBid>> makeBids(HttpCall<BidRequest> httpCall, BidRequest bidRequest) {
+        final HttpResponse response = httpCall.getResponse();
+        if (response.getStatusCode() == 204) {
+            return Result.of(Collections.emptyList(), Collections.emptyList());
+        }
+
         try {
-            final BidResponse bidResponse = Json.decodeValue(httpCall.getResponse().getBody(), BidResponse.class);
+            final BidResponse bidResponse = Json.decodeValue(response.getBody(), BidResponse.class);
             return Result.of(extractBids(httpCall.getRequest().getPayload(), bidResponse), Collections.emptyList());
         } catch (DecodeException e) {
             return Result.emptyWithError(BidderError.badServerResponse(e.getMessage()));

--- a/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
+++ b/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
@@ -330,7 +330,7 @@ public class HttpBidderRequesterTest extends VertxTest {
     }
 
     @Test
-    public void shouldTolerateMultipleErrors() {
+    public void shouldTolerateMultipleErrorsAndAllowNoContent() {
         // given
         given(bidder.makeHttpRequests(any())).willReturn(Result.of(asList(
                 // this request will fail with response exception
@@ -402,9 +402,9 @@ public class HttpBidderRequesterTest extends VertxTest {
                 .result();
 
         // then
-        // only one call is expected since other requests failed with errors or returned with 204 status
-        verify(bidder).makeBids(any(), any());
-        assertThat(bidderSeatBid.getBids()).hasSize(1);
+        // only two calls are expected (200 and 204) since other requests have failed with errors.
+        verify(bidder, times(2)).makeBids(any(), any());
+        assertThat(bidderSeatBid.getBids()).hasSize(2);
         assertThat(bidderSeatBid.getErrors()).containsOnly(
                 BidderError.badInput("makeHttpRequestsError"),
                 BidderError.generic("Response exception"),

--- a/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
@@ -73,6 +73,7 @@ import org.prebid.server.util.HttpUtil;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -1226,6 +1227,19 @@ public class RubiconBidderTest extends VertxTest {
                 .containsOnly(RubiconImpExt.of(RubiconImpExtRp.of(null,
                         NullNode.getInstance(),
                         RubiconImpExtRpTrack.of("", "")), asList("moat.com", "doubleclickbygoogle.com")));
+    }
+
+    @Test
+    public void makeBidsShouldReturnEmptyResultIfResponseStatusIsNoContent() {
+        // given
+        final HttpCall<BidRequest> httpCall = HttpCall.success(HttpRequest.<BidRequest>builder().build(),
+                HttpResponse.of(204, null, null), null);
+
+        // when
+        final Result<List<BidderBid>> result = rubiconBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result).isEqualTo(Result.of(Collections.emptyList(), Collections.emptyList()));
     }
 
     @Test


### PR DESCRIPTION
- Updated `HttpBidderRequester` to not filter out http responses with 204 No Content status;
- Updated `RubiconBidder#makeBids` method to check the response status first - if it is 204, meaning that there are no errors, but no bids either - return empty response;
- Updated existing unit test in `HttpBidderRequesterTest` and added a new one in `RubiconBidderTest` to reflect the changes.