### PR TITLE
Change /vtrack endpoint for updated requirements

### DIFF
--- a/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
+++ b/src/main/java/org/prebid/server/handler/NotificationEventHandler.java
@@ -104,6 +104,7 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
         if (exception instanceof PreBidException) {
             return Future.succeededFuture(Account.builder().id(accountId).eventsEnabled(false).build());
         }
+        logger.warn("Error occurred while fetching account", exception);
         return Future.failedFuture(exception);
     }
 
@@ -132,7 +133,8 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
 
     private void respondWithOkStatus(RoutingContext context, boolean respondWithPixel) {
         if (respondWithPixel) {
-            context.response().putHeader(HttpHeaders.CONTENT_TYPE, trackingPixel.getContentType())
+            context.response()
+                    .putHeader(HttpHeaders.CONTENT_TYPE, trackingPixel.getContentType())
                     .end(Buffer.buffer(trackingPixel.getContent()));
         } else {
             context.response().end();
@@ -140,20 +142,20 @@ public class NotificationEventHandler implements Handler<RoutingContext> {
     }
 
     private static void respondWithBadStatus(RoutingContext context, String message) {
-        respondWithError(context, message, HttpResponseStatus.BAD_REQUEST);
+        respondWithError(context, HttpResponseStatus.BAD_REQUEST, message);
     }
 
     private static void respondWithUnauthorized(RoutingContext context, String message) {
-        respondWithError(context, message, HttpResponseStatus.UNAUTHORIZED);
+        respondWithError(context, HttpResponseStatus.UNAUTHORIZED, message);
     }
 
     private static void respondWithServerError(RoutingContext context, Throwable exception) {
         final String message = "Error occurred while fetching account";
         logger.warn(message, exception);
-        respondWithError(context, message, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        respondWithError(context, HttpResponseStatus.INTERNAL_SERVER_ERROR, message);
     }
 
-    private static void respondWithError(RoutingContext context, String message, HttpResponseStatus status) {
+    private static void respondWithError(RoutingContext context, HttpResponseStatus status, String message) {
         context.response().setStatusCode(status.code()).end(message);
     }
 

--- a/src/main/java/org/prebid/server/handler/VtrackHandler.java
+++ b/src/main/java/org/prebid/server/handler/VtrackHandler.java
@@ -1,125 +1,172 @@
 package org.prebid.server.handler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.cache.CacheService;
 import org.prebid.server.cache.proto.request.BidCacheRequest;
 import org.prebid.server.cache.proto.request.PutObject;
 import org.prebid.server.cache.proto.response.BidCacheResponse;
+import org.prebid.server.exception.PreBidException;
+import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
+import org.prebid.server.settings.ApplicationSettings;
+import org.prebid.server.settings.model.Account;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class VtrackHandler implements Handler<RoutingContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(VtrackHandler.class);
 
-    private static final String ACCOUNT_REQUEST_PARAMETER = "a";
+    private static final String ACCOUNT_PARAMETER = "a";
 
+    private final ApplicationSettings applicationSettings;
     private final CacheService cacheService;
     private final BidderCatalog bidderCatalog;
     private final TimeoutFactory timeoutFactory;
     private final long defaultTimeout;
 
-    public VtrackHandler(CacheService cacheService, BidderCatalog bidderCatalog, TimeoutFactory timeoutFactory,
-                         long defaultTimeout) {
-        this.cacheService = Objects.requireNonNull(cacheService);
+    public VtrackHandler(ApplicationSettings applicationSettings, BidderCatalog bidderCatalog,
+                         CacheService cacheService, TimeoutFactory timeoutFactory, long defaultTimeout) {
+
+        this.applicationSettings = Objects.requireNonNull(applicationSettings);
         this.bidderCatalog = Objects.requireNonNull(bidderCatalog);
+        this.cacheService = Objects.requireNonNull(cacheService);
         this.timeoutFactory = Objects.requireNonNull(timeoutFactory);
         this.defaultTimeout = defaultTimeout;
     }
 
     @Override
     public void handle(RoutingContext context) {
+        final String accountId;
         final List<PutObject> vtrackPuts;
         try {
-            vtrackPuts = parsePuts(context.getBody());
+            accountId = accountId(context);
+            vtrackPuts = vtrackPuts(context);
         } catch (IllegalArgumentException e) {
-            respondWith(context, HttpResponseStatus.BAD_REQUEST.code(), e.getMessage());
+            respondWithBadRequest(context, e.getMessage());
             return;
         }
 
-        String accountId = null;
-        final List<String> updatableBidders = biddersWithUpdatableVast(vtrackPuts);
-        if (!updatableBidders.isEmpty()) {
-            try {
-                accountId = accountId(context);
-            } catch (IllegalArgumentException e) {
-                respondWith(context, HttpResponseStatus.BAD_REQUEST.code(), e.getMessage());
-                return;
-            }
-        }
-
-        cacheService.cachePutObjects(vtrackPuts, updatableBidders, accountId, timeoutFactory.create(defaultTimeout))
-                .setHandler(bidCacheResponseResult -> handleCacheResult(context, bidCacheResponseResult));
-    }
-
-    private static List<PutObject> parsePuts(Buffer body) {
-        if (body == null || body.length() == 0) {
-            throw new IllegalArgumentException("Incoming request has no body");
-        }
-
-        try {
-            final List<PutObject> puts = Json.decodeValue(body, BidCacheRequest.class).getPuts();
-            return puts == null ? Collections.emptyList() : puts;
-        } catch (DecodeException e) {
-            throw new IllegalArgumentException("Failed to parse /vtrack request body", e);
-        }
+        final Timeout timeout = timeoutFactory.create(defaultTimeout);
+        applicationSettings.getAccountById(accountId, timeout)
+                .recover(exception -> handleAccountExceptionOrFallback(exception, accountId))
+                .setHandler(async -> handleAccountResult(async, context, vtrackPuts, accountId, timeout));
     }
 
     private static String accountId(RoutingContext context) {
-        final String accountId = context.request().getParam(ACCOUNT_REQUEST_PARAMETER);
-        if (accountId == null) {
-            throw new IllegalArgumentException("Request must contain 'a'=accountId parameter");
+        final String accountId = context.request().getParam(ACCOUNT_PARAMETER);
+        if (StringUtils.isEmpty(accountId)) {
+            throw new IllegalArgumentException(
+                    String.format("Account '%s' is required query parameter and can't be empty", ACCOUNT_PARAMETER));
         }
         return accountId;
     }
 
-    private List<String> biddersWithUpdatableVast(List<PutObject> vtrackPuts) {
+    private static List<PutObject> vtrackPuts(RoutingContext context) {
+        final Buffer body = context.getBody();
+        if (body == null || body.length() == 0) {
+            throw new IllegalArgumentException("Incoming request has no body");
+        }
+
+        final BidCacheRequest bidCacheRequest;
+        try {
+            bidCacheRequest = Json.decodeValue(body, BidCacheRequest.class);
+        } catch (DecodeException e) {
+            throw new IllegalArgumentException("Failed to parse request body", e);
+        }
+
+        final List<PutObject> putObjects = ListUtils.emptyIfNull(bidCacheRequest.getPuts());
+        for (PutObject putObject : putObjects) {
+            if (StringUtils.isEmpty(putObject.getBidid())) {
+                throw new IllegalArgumentException("'bidid' is required field and can't be empty");
+            }
+            if (StringUtils.isEmpty(putObject.getBidder())) {
+                throw new IllegalArgumentException("'bidder' is required field and can't be empty");
+            }
+        }
+        return putObjects;
+    }
+
+    /**
+     * Returns fallback {@link Account} if account not found or propagate error if fetching failed.
+     */
+    private static Future<Account> handleAccountExceptionOrFallback(Throwable exception, String accountId) {
+        if (exception instanceof PreBidException) {
+            return Future.succeededFuture(Account.builder().id(accountId).eventsEnabled(false).build());
+        }
+        return Future.failedFuture(exception);
+    }
+
+    private void handleAccountResult(AsyncResult<Account> asyncAccount, RoutingContext context,
+                                     List<PutObject> vtrackPuts, String accountId, Timeout timeout) {
+        if (asyncAccount.failed()) {
+            respondWithServerError(context, "Error occurred while fetching account", asyncAccount.cause());
+        } else {
+            // insert impression tracking if account allows events and bidder allows VAST modification
+            final Set<String> biddersAllowingVastUpdate = asyncAccount.result().getEventsEnabled()
+                    ? biddersAllowingVastUpdate(vtrackPuts)
+                    : Collections.emptySet();
+
+            cacheService.cachePutObjects(vtrackPuts, biddersAllowingVastUpdate, accountId, timeout)
+                    .setHandler(asyncCache -> handleCacheResult(asyncCache, context));
+        }
+    }
+
+    /**
+     * Returns list of bidders that allow VAST XML modification.
+     */
+    private Set<String> biddersAllowingVastUpdate(List<PutObject> vtrackPuts) {
         return vtrackPuts.stream()
                 .map(PutObject::getBidder)
-                .distinct()
                 .filter(bidderCatalog::isModifyingVastXmlAllowed)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
-    private void handleCacheResult(RoutingContext context, AsyncResult<BidCacheResponse> bidCacheResponseResult) {
-        if (bidCacheResponseResult.succeeded()) {
-            respondWithCache(context, bidCacheResponseResult.result());
+    private static void handleCacheResult(AsyncResult<BidCacheResponse> async, RoutingContext context) {
+        if (async.failed()) {
+            respondWithServerError(context, "Error occurred while sending request to cache", async.cause());
         } else {
-            final String message = bidCacheResponseResult.cause().getMessage();
-            respondWith(context, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), message);
+            try {
+                respondWith(context, HttpResponseStatus.OK, Json.encode(async.result()));
+            } catch (EncodeException e) {
+                respondWithServerError(context, "Error occurred while encoding response", e);
+            }
         }
     }
 
-    private void respondWithCache(RoutingContext context, BidCacheResponse bidCacheResponse) {
-        try {
-            respondWith(context, HttpResponseStatus.OK.code(), Json.mapper.writeValueAsString(bidCacheResponse));
-        } catch (JsonProcessingException e) {
-            logger.error("/vtrack Critical error when trying to marshal cache response: {0}", e.getMessage());
-            respondWith(context, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), e.getMessage());
-        }
+    private static void respondWithBadRequest(RoutingContext context, String message) {
+        respondWith(context, HttpResponseStatus.BAD_REQUEST, message);
     }
 
-    private static void respondWith(RoutingContext context, int status, String body) {
+    private static void respondWithServerError(RoutingContext context, String message, Throwable exception) {
+        logger.warn(message, exception);
+        respondWith(context, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                String.format("%s: %s", message, exception.getMessage()));
+    }
+
+    private static void respondWith(RoutingContext context, HttpResponseStatus status, String body) {
         // don't send the response if client has gone
         if (context.response().closed()) {
             logger.warn("The client already closed connection, response will be skipped");
             return;
         }
-        context.response().setStatusCode(status).end(body);
+        context.response().setStatusCode(status.code()).end(body);
     }
 }
-

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -301,11 +301,13 @@ public class WebConfiguration {
 
     @Bean
     VtrackHandler vtrackHandler(
-            CacheService cacheService,
+            ApplicationSettings applicationSettings,
             BidderCatalog bidderCatalog,
+            CacheService cacheService,
             TimeoutFactory timeoutFactory,
             @Value("${vtrack.default-timeout-ms}") int defaultTimeoutMs) {
-        return new VtrackHandler(cacheService, bidderCatalog, timeoutFactory, defaultTimeoutMs);
+
+        return new VtrackHandler(applicationSettings, bidderCatalog, cacheService, timeoutFactory, defaultTimeoutMs);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/cache/CacheServiceTest.java
+++ b/src/test/java/org/prebid/server/cache/CacheServiceTest.java
@@ -51,6 +51,8 @@ import java.util.function.Function;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -272,8 +274,10 @@ public class CacheServiceTest extends VertxTest {
         final BidCacheRequest bidCacheRequest = captureBidCacheRequest();
         assertThat(bidCacheRequest.getPuts()).hasSize(4)
                 .containsOnly(
-                        PutObject.builder().type("json").value(mapper.valueToTree(BannerValue.of("adm1", "nurl1", 200, 100))).build(),
-                        PutObject.builder().type("json").value(mapper.valueToTree(BannerValue.of("adm2", "nurl2", 400, 300))).build(),
+                        PutObject.builder().type("json").value(
+                                mapper.valueToTree(BannerValue.of("adm1", "nurl1", 200, 100))).build(),
+                        PutObject.builder().type("json").value(
+                                mapper.valueToTree(BannerValue.of("adm2", "nurl2", 400, 300))).build(),
                         PutObject.builder().type("xml").value(new TextNode(adm3)).build(),
                         PutObject.builder().type("xml").value(new TextNode(adm4)).build()
                 );
@@ -692,9 +696,10 @@ public class CacheServiceTest extends VertxTest {
                         PutObject.builder().type("json").value(mapper.valueToTree(bid1)).build(),
                         PutObject.builder().type("json").value(mapper.valueToTree(bid2)).build(),
                         PutObject.builder().type("xml").value(new TextNode("adm1")).build(),
-                        PutObject.builder().type("xml").value(new TextNode("<VAST version=\"3.0\"><Ad><Wrapper><AdSystem>" +
-                                "prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[adm2]]></VASTAdTagURI><Impression>" +
-                                "</Impression><Creatives></Creatives></Wrapper></Ad></VAST>")).build());
+                        PutObject.builder().type("xml").value(
+                                new TextNode("<VAST version=\"3.0\"><Ad><Wrapper><AdSystem>" +
+                                        "prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[adm2]]></VASTAdTagURI><Impression>" +
+                                        "</Impression><Creatives></Creatives></Wrapper></Ad></VAST>")).build());
     }
 
     @Test
@@ -804,7 +809,7 @@ public class CacheServiceTest extends VertxTest {
     public void cachePutObjectsShouldTolerateGlobalTimeoutAlreadyExpired() {
         // when
         final Future<BidCacheResponse> future = cacheService.cachePutObjects(singletonList(PutObject.builder().build()),
-                emptyList(), "", expiredTimeout);
+                emptySet(), "", expiredTimeout);
 
         // then
         assertThat(future.failed()).isTrue();
@@ -814,7 +819,7 @@ public class CacheServiceTest extends VertxTest {
     @Test
     public void cachePutObjectsShouldReturnResultWithEmptyListWhenPutObjectsIsEmpty() {
         // when
-        final Future<BidCacheResponse> result = cacheService.cachePutObjects(emptyList(), emptyList(), null, null);
+        final Future<BidCacheResponse> result = cacheService.cachePutObjects(emptyList(), emptySet(), null, null);
 
         // then
         verifyZeroInteractions(httpClient);
@@ -842,7 +847,8 @@ public class CacheServiceTest extends VertxTest {
                 .willReturn("https://test-event.com/event?t=imp&b=biddid1&f=b&a=account");
 
         // when
-        cacheService.cachePutObjects(Arrays.asList(firstPutObject, secondPutObject), singletonList("bidder1"), "account", timeout);
+        cacheService.cachePutObjects(Arrays.asList(firstPutObject, secondPutObject), singleton("bidder1"), "account",
+                timeout);
 
         // then
         final PutObject modifiedSecondPutObject = firstPutObject.toBuilder()


### PR DESCRIPTION
PBS should validate the arguments supplied with /vtrack: if ACCOUNT, BIDID, or BIDDER aren't supplied, it should reject the /vtrack request with 400. This should get caught when the page is being tested.

If the ACCOUNT doesn't exist and PBS is enforcing accounts, that should also result in a 400.

PBS will process /vtrack similar to the server-side VAST response, inserting impression tracking when:
- account ID allows events
- the bidder allows VAST modification

See for details https://github.com/prebid/prebid-server/issues/1015