### PR TITLE
Fix NPE in /vtrack handler if account.events_enabled is NULL

### DIFF
--- a/src/main/java/org/prebid/server/handler/VtrackHandler.java
+++ b/src/main/java/org/prebid/server/handler/VtrackHandler.java
@@ -120,7 +120,7 @@ public class VtrackHandler implements Handler<RoutingContext> {
             respondWithServerError(context, "Error occurred while fetching account", asyncAccount.cause());
         } else {
             // insert impression tracking if account allows events and bidder allows VAST modification
-            final Set<String> biddersAllowingVastUpdate = asyncAccount.result().getEventsEnabled()
+            final Set<String> biddersAllowingVastUpdate = Objects.equals(asyncAccount.result().getEventsEnabled(), true)
                     ? biddersAllowingVastUpdate(vtrackPuts)
                     : Collections.emptySet();
 


### PR DESCRIPTION
Fixed error:
```
2019-09-23 09:35:18.946 ERROR 30452 --- [vert.x-eventloop-thread-3] io.vertx.core.impl.ContextImpl           : Unhandled exception

java.lang.NullPointerException: null
        at org.prebid.server.handler.VtrackHandler.handleAccountResult(VtrackHandler.java:123)
        at org.prebid.server.handler.VtrackHandler.lambda$handle$1(VtrackHandler.java:70)
        at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
        at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86)
        at io.vertx.core.Future.lambda$recover$4(Future.java:385)
        at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
        at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86)
        at io.vertx.core.Future.lambda$recover$4(Future.java:385)
        at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
        at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86)
        at io.vertx.core.Future.lambda$map$2(Future.java:306)
        at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
        at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86)
        at io.vertx.core.Future.lambda$recover$4(Future.java:385)
        at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
        at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86)
        at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:151)
        at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18)
        at io.vertx.core.impl.SucceededFuture.setHandler(SucceededFuture.java:40)
        at io.vertx.core.Future.lambda$compose$1(Future.java:270)
        at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
        at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:86)
        at io.vertx.circuitbreaker.impl.CircuitBreakerImpl.lambda$null$4(CircuitBreakerImpl.java:229)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
        at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:466)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Unknown Source)
```