### PR TITLE
Fix aliases processing from imp.ext if it is missing

### DIFF
--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -471,6 +471,8 @@ public class AuctionRequestFactory {
 
         // go through imps' bidders and figure out preconfigured aliases
         final Map<String, String> resolvedAliases = imps.stream()
+                .filter(Objects::nonNull)
+                .filter(imp -> imp.getExt() != null) // request validator is not called yet
                 .flatMap(imp -> asStream(imp.getExt().fieldNames())
                         .filter(bidder -> !aliases.containsKey(bidder))
                         .filter(bidderCatalog::isAlias))

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.prebid.server.VertxTest;
+import org.prebid.server.auction.model.AuctionContext;
 import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.cookie.UidsCookieService;
@@ -592,6 +593,23 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 .containsOnly(
                         tuple("requestScopedBidderAlias", "bidder1"),
                         tuple("configScopedBidderAlias", "bidder2"));
+    }
+
+    @Test
+    public void shouldTolerateMissingImpExtWhenProcessingAliases() {
+        // given
+        givenBidRequest(BidRequest.builder()
+                .imp(singletonList(Imp.builder().ext(null).build()))
+                .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
+                        .aliases(singletonMap("alias", "bidder"))
+                        .build())))
+                .build());
+
+        // when
+        final Future<AuctionContext> future = factory.fromRequest(routingContext, 0L);
+
+        // then
+        assertThat(future.succeeded()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Fixes NPE when `imp` has no `ext` object:
```
2019-09-25 08:48:15.903 ERROR 20589 --- [vert.x-eventloop-thread-0] o.p.s.handler.openrtb2.AuctionHandler    : Critical error while running the auction                                        
                                                                                                                                                                                                             
java.lang.NullPointerException: null                                                                                                                                                                         
        at org.prebid.server.auction.AuctionRequestFactory.lambda$aliasesOrNull$5(AuctionRequestFactory.java:474)                                                                                            
        at java.util.stream.ReferencePipeline$7$1.accept(Unknown Source)                                                                                                                                     
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)                                                                                                                         
        at java.util.stream.AbstractPipeline.copyInto(Unknown Source)                                                                                                                                        
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)                                                                                                                                 
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source)                                                                                                                            
        at java.util.stream.AbstractPipeline.evaluate(Unknown Source)                                                                                                                                        
        at java.util.stream.ReferencePipeline.collect(Unknown Source)                                                                                                                                        
        at org.prebid.server.auction.AuctionRequestFactory.aliasesOrNull(AuctionRequestFactory.java:478)                                                                                                     
        at org.prebid.server.auction.AuctionRequestFactory.populateBidRequestExtension(AuctionRequestFactory.java:383)                                                                                       
        at org.prebid.server.auction.AuctionRequestFactory.fillImplicitParameters(AuctionRequestFactory.java:200)                                                                                            
        at org.prebid.server.auction.AuctionRequestFactory.lambda$updateBidRequest$2(AuctionRequestFactory.java:175)                                                                                         
        at io.vertx.core.Future.lambda$map$2(Future.java:301)                                                                                                                                                
        at io.vertx.core.impl.SucceededFuture.setHandler(SucceededFuture.java:40)                                                                                                                            
        at io.vertx.core.Future.map(Future.java:297)                                                                                                                                                         
        at org.prebid.server.auction.AuctionRequestFactory.updateBidRequest(AuctionRequestFactory.java:175)                                                                                                  
        at org.prebid.server.auction.AuctionRequestFactory.fromRequest(AuctionRequestFactory.java:123)                                                                                                       
        at org.prebid.server.handler.openrtb2.AuctionHandler.handle(AuctionHandler.java:77)                                                                                                                  
        at org.prebid.server.handler.openrtb2.AuctionHandler.handle(AuctionHandler.java:40)                                                                                                                  
        at io.vertx.ext.web.impl.RouteImpl.handleContext(RouteImpl.java:232)                                                                                                                                 
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:121)                                                                                                         
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:134)                                                                                                                        
        at io.vertx.ext.web.handler.impl.CorsHandlerImpl.handle(CorsHandlerImpl.java:125)                                                                                                                    
        at io.vertx.ext.web.handler.impl.CorsHandlerImpl.handle(CorsHandlerImpl.java:38)                                                                                                                     
        at io.vertx.ext.web.impl.RouteImpl.handleContext(RouteImpl.java:232)                                                                                                                                 
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:121)                                                                                                         
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:134)                                                                                                                        
        at org.prebid.server.handler.NoCacheHandler.handle(NoCacheHandler.java:19)                                                                                                                           
        at org.prebid.server.handler.NoCacheHandler.handle(NoCacheHandler.java:7)                                                                                                                            
        at io.vertx.ext.web.impl.RouteImpl.handleContext(RouteImpl.java:232)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:121)
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:134)
        at io.vertx.ext.web.handler.impl.BodyHandlerImpl$BHandler.doEnd(BodyHandlerImpl.java:296)
        at io.vertx.ext.web.handler.impl.BodyHandlerImpl$BHandler.end(BodyHandlerImpl.java:276)
        at io.vertx.ext.web.handler.impl.BodyHandlerImpl.lambda$handle$0(BodyHandlerImpl.java:87)
        at io.vertx.core.http.impl.HttpServerRequestImpl.onEnd(HttpServerRequestImpl.java:529)
        at io.vertx.core.http.impl.HttpServerRequestImpl.handleEnd(HttpServerRequestImpl.java:515)
        at io.vertx.core.http.impl.Http1xServerConnection.handleEnd(Http1xServerConnection.java:172)
        at io.vertx.core.http.impl.Http1xServerConnection.handleContent(Http1xServerConnection.java:159)
        at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:136)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
        at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
        at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:188)
```