### PR TITLE
Fix circuit breaker logging when ensuring state is failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <commons.version>3.6</commons.version>
         <commons.collections.version>4.1</commons.collections.version>
         <commons.compress.version>1.18</commons.compress.version>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <json.schema.validator.version>0.1.7</json.schema.validator.version>
         <jsonpatch.version>1.9</jsonpatch.version>
         <mysql.version>6.0.6</mysql.version>

--- a/src/main/java/org/prebid/server/vertx/CircuitBreaker.java
+++ b/src/main/java/org/prebid/server/vertx/CircuitBreaker.java
@@ -75,13 +75,13 @@ public class CircuitBreaker {
         vertx.executeBlocking(this::ensureState, false, ensureStateFuture);
 
         return ensureStateFuture
-                .compose(ignored -> { // ensuring state succeeded
-                    future.fail(exception);
-                    return future;
-                })
                 .recover(throwable -> {
                     logger.warn("Resetting circuit breaker state failed", throwable);
                     future.fail(throwable);
+                    return future;
+                })
+                .compose(ignored -> { // ensuring state succeeded, propagate real error
+                    future.fail(exception);
                     return future;
                 });
     }


### PR DESCRIPTION
This PR fixes logging in `Circuit Breaker`:
```
2019-10-03 01:35:50.063  WARN 22561 --- [ntloop-thread-4] org.prebid.server.vertx.CircuitBreaker   : Resetting circuit breaker state failed

java.util.concurrent.TimeoutException: Timeout period of 756ms has been exceeded
	at org.prebid.server.vertx.http.BasicHttpClient.handleTimeout(BasicHttpClient.java:66)
	at org.prebid.server.vertx.http.BasicHttpClient.lambda$request$0(BasicHttpClient.java:42)
	at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:907)
	at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:866)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
	at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:466)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```

Actual exception is not related to `Resetting circuit breaker state failed` which is confused.
After this fix PBS will log and propagate real error.