### PR TITLE
Add Account query param support for AMP endpoint

### DIFF
--- a/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
@@ -7,6 +7,7 @@ import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Format;
 import com.iab.openrtb.request.Imp;
+import com.iab.openrtb.request.Publisher;
 import com.iab.openrtb.request.Site;
 import com.iab.openrtb.request.User;
 import io.vertx.core.Future;
@@ -47,6 +48,7 @@ public class AmpRequestFactory {
     private static final String H_REQUEST_PARAM = "h";
     private static final String MS_REQUEST_PARAM = "ms";
     private static final String CURL_REQUEST_PARAM = "curl";
+    private static final String ACCOUNT_REQUEST_PARAM = "account";
     private static final String SLOT_REQUEST_PARAM = "slot";
     private static final String TIMEOUT_REQUEST_PARAM = "timeout";
     private static final String GDPR_CONSENT_PARAM = "gdpr_consent";
@@ -220,14 +222,23 @@ public class AmpRequestFactory {
 
     private static Site overrideSite(Site site, HttpServerRequest request) {
         final String canonicalUrl = canonicalUrl(request);
+        final String accountId = request.getParam(ACCOUNT_REQUEST_PARAM);
 
-        final ObjectNode siteExt = site != null ? site.getExt() : null;
+        final boolean hasSite = site != null;
+        final ObjectNode siteExt = hasSite ? site.getExt() : null;
         final boolean shouldSetExtAmp = siteExt == null || siteExt.get("amp") == null;
 
-        if (StringUtils.isNotBlank(canonicalUrl) || shouldSetExtAmp) {
-            final Site.SiteBuilder siteBuilder = site == null ? Site.builder() : site.toBuilder();
+        if (StringUtils.isNotBlank(canonicalUrl) || StringUtils.isNotBlank(accountId) || shouldSetExtAmp) {
+            final Site.SiteBuilder siteBuilder = hasSite ? site.toBuilder() : Site.builder();
             if (StringUtils.isNotBlank(canonicalUrl)) {
                 siteBuilder.page(canonicalUrl);
+            }
+            if (StringUtils.isNotBlank(accountId)) {
+                final Publisher publisher = hasSite ? site.getPublisher() : null;
+                final Publisher.PublisherBuilder publisherBuilder = publisher != null
+                        ? publisher.toBuilder() : Publisher.builder();
+
+                siteBuilder.publisher(publisherBuilder.id(accountId).build());
             }
             if (shouldSetExtAmp) {
                 final ObjectNode data = siteExt != null ? (ObjectNode) siteExt.get("data") : null;

--- a/src/test/java/org/prebid/server/auction/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AmpRequestFactoryTest.java
@@ -8,6 +8,7 @@ import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Format;
 import com.iab.openrtb.request.Imp;
+import com.iab.openrtb.request.Publisher;
 import com.iab.openrtb.request.Site;
 import com.iab.openrtb.request.User;
 import io.vertx.core.Future;
@@ -512,6 +513,76 @@ public class AmpRequestFactoryTest extends VertxTest {
                 .extracting(BidRequest::getSite)
                 .extracting(Site::getPage, Site::getExt)
                 .containsOnly(tuple("overridden-site-page", mapper.valueToTree(ExtSite.of(1, null))));
+    }
+
+
+    @Test
+    public void shouldReturnBidRequestWithSitePublisherIdOverriddenWithAccountParamValue() {
+        // given
+        given(httpRequest.getParam("account")).willReturn("accountId");
+
+        givenBidRequest(
+                builder -> builder
+                        .ext(mapper.valueToTree(ExtBidRequest.of(null)))
+                        .site(Site.builder().publisher(Publisher.builder().id("will-be-overridden").build()).build()),
+                Imp.builder().build());
+
+        // when
+        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
+
+        // then
+        assertThat(singletonList(request))
+                .extracting(BidRequest::getSite)
+                .extracting(Site::getPublisher, Site::getExt)
+                .containsOnly(tuple(
+                        Publisher.builder().id("accountId").build(),
+                        mapper.valueToTree(ExtSite.of(1, null))));
+    }
+
+    @Test
+    public void shouldReturnBidRequestWithSitePublisherIdFromAccountParamWhenSiteDoesNotExist() {
+        // given
+        given(httpRequest.getParam("account")).willReturn("accountId");
+
+        givenBidRequest(
+                builder -> builder
+                        .ext(mapper.valueToTree(ExtBidRequest.of(null)))
+                        .site(null),
+                Imp.builder().build());
+
+        // when
+        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
+
+        // then
+        assertThat(singletonList(request))
+                .extracting(BidRequest::getSite)
+                .extracting(Site::getPublisher, Site::getExt)
+                .containsOnly(tuple(
+                        Publisher.builder().id("accountId").build(),
+                        mapper.valueToTree(ExtSite.of(1, null))));
+    }
+
+    @Test
+    public void shouldReturnBidRequestWithSitePublisherIdFromAccountParamWhenSitePublisherDoesNotExist() {
+        // given
+        given(httpRequest.getParam("account")).willReturn("accountId");
+
+        givenBidRequest(
+                builder -> builder
+                        .ext(mapper.valueToTree(ExtBidRequest.of(null)))
+                        .site(Site.builder().build()),
+                Imp.builder().build());
+
+        // when
+        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
+
+        // then
+        assertThat(singletonList(request))
+                .extracting(BidRequest::getSite)
+                .extracting(Site::getPublisher, Site::getExt)
+                .containsOnly(tuple(
+                        Publisher.builder().id("accountId").build(),
+                        mapper.valueToTree(ExtSite.of(1, null))));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -276,7 +276,8 @@ public class ApplicationTest extends IntegrationTest {
                         "&oh=120" +
                         "&timeout=10000000" +
                         "&slot=overwrite-tagId" +
-                        "&curl=https%3A%2F%2Fgoogle.com");
+                        "&curl=https%3A%2F%2Fgoogle.com" +
+                        "&account=accountId");
 
         // then
         JSONAssert.assertEquals(jsonFrom("amp/test-amp-response.json"), response.asString(),

--- a/src/test/resources/org/prebid/server/it/amp/test-appnexus-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/amp/test-appnexus-bid-request.json
@@ -28,6 +28,9 @@
   "site": {
     "domain": "example.com",
     "page": "https://google.com",
+    "publisher": {
+      "id": "accountId"
+    },
     "ext": {
       "amp": 1
     }


### PR DESCRIPTION
- Added `account` query param support for `/openrtb2/amp` endpoint;
- Added new and updated existing unit and application tests.