### PR TITLE
Add cache.vastxml description in auction.md doc

### DIFF
--- a/docs/endpoints/openrtb2/auction.md
+++ b/docs/endpoints/openrtb2/auction.md
@@ -371,12 +371,15 @@ Bids can be temporarily cached on the server by sending the following data as `r
 
 ```
 {
-  "bids": {}
+  "bids": {},
+  "vastxml": {}
 }
 ```
 
-This property has no effect unless `request.ext.prebid.targeting` is also set in the request.
-If present, Prebid Server will make a _best effort_ to include these extra `bid.ext.prebid.targeting` keys:
+Both `bids` and `vastxml` are optional, but one of the two is required. 
+This property will have no effect unless `request.ext.prebid.targeting` is also set in the request.
+
+If `bids` is present, Prebid Server will make a _best effort_ to include these extra `bid.ext.prebid.targeting` keys:
 
 - `hb_cache_id`: On the highest overall Bid in each Imp.
 - `hb_cache_id_{bidderName}`: On the highest Bid from {bidderName} in each Imp.
@@ -385,7 +388,11 @@ Clients _should not assume_ that these keys will exist, just because they were r
 If they exist, the value will be a UUID which can be used to fetch Bid JSON from [Prebid Cache](https://github.com/prebid/prebid-cache-java).
 They may not exist if the host company's cache is full, having connection problems, or other issues like that.
 
-This is mainly intended for certain limited Prebid Mobile setups, where bids cannot be cached client-side.
+If `vastxml` is present, PBS will try to add analogous keys `hb_uuid` and `hb_uuid_{bidderName}`.
+In addition to the caveats above, these will exist _only if the relevant Bids are for Video_.
+If they exist, the values can be used to fetch the bid's VAST XML from Prebid Cache directly.
+
+These options are mainly intended for certain limited Prebid Mobile setups, where bids cannot be cached client-side.
 
 #### GDPR
 


### PR DESCRIPTION
Added `cache.vastxml` description to `docs/endpoints/openrtb2/auction.md`.