### PR TITLE
Add Geo Location metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,15 +24,20 @@ Other available metrics can found at [Vert.x Dropwizard Metrics](https://vertx.i
 - `imps_audio` - number of audio impressions
 - `requests.(ok|badinput|err|networkerr).(openrtb2-web|openrtb-app|amp|legacy)` - number of requests broken down by status and type
 - `connection_accept_errors` - number of errors occurred while establishing HTTP connection
-- `db_circuitbreaker_opened` - number of how many times database circuit breaker was opened (database is unavailable)
-- `db_circuitbreaker_closed` - number of how many times database circuit breaker was closed (database is available again)
+- `db_circuitbreaker_opened` - number of times database circuit breaker was opened (database is unavailable)
+- `db_circuitbreaker_closed` - number of times database circuit breaker was closed (database is available again)
 - `db_query_time` - timer tracking how long did it take for database client to obtain the result for a query
-- `httpclient_circuitbreaker_opened` - number of how many times http client circuit breaker was opened (requested resource is unavailable)
-- `httpclient_circuitbreaker_closed` - number of how many times http client circuit breaker was closed (requested resource is available again)
+- `httpclient_circuitbreaker_opened` - number of times http client circuit breaker was opened (requested resource is unavailable)
+- `httpclient_circuitbreaker_closed` - number of times http client circuit breaker was closed (requested resource is available again)
 - `stored_requests_found` - number of stored requests that were found
 - `stored_requests_missing` - number of stored requests that were not found by provided stored request IDs
 - `stored_imps_found` - number of stored impressions that were found
 - `stored_imps_missing` - number of stored impressions that were not found by provided stored impression IDs
+- `geolocation_requests` - number of times geo location lookup was requested
+- `geolocation_successful` - number of successful geo location lookup responses
+- `geolocation_fail` - number of failed geo location lookup responses
+- `geolocation_circuitbreaker_opened` - number of times geo location circuit breaker was opened (geo location resource is unavailable)
+- `geolocation_circuitbreaker_closed` - number of times geo location circuit breaker was closed (geo location resource is available again)
 
 ## Auction per-adapter metrics
 - `adapter.<bidder-name>.no_cookie_requests` - number of requests made to `<bidder-name>` that did not contain UID

--- a/src/main/java/org/prebid/server/gdpr/GdprService.java
+++ b/src/main/java/org/prebid/server/gdpr/GdprService.java
@@ -232,7 +232,7 @@ public class GdprService {
             return geoLocationService.lookup(ipAddress, timeout)
                     .map(GeoInfo::getCountry)
                     .map(resolvedCountry -> createGdprInfoWithCountry(gdprConsent, resolvedCountry))
-                    .otherwise(throwable -> updateMetricsAndReturnDefault(gdprConsent));
+                    .otherwise(updateMetricsAndReturnDefault(gdprConsent));
         }
 
         // use default

--- a/src/main/java/org/prebid/server/metric/MetricName.java
+++ b/src/main/java/org/prebid/server/metric/MetricName.java
@@ -14,6 +14,9 @@ public enum MetricName {
     httpclient_circuitbreaker_closed,
 
     // geo location
+    geolocation_requests,
+    geolocation_successful,
+    geolocation_fail,
     geolocation_circuitbreaker_opened,
     geolocation_circuitbreaker_closed,
 

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -271,6 +271,15 @@ public class Metrics extends UpdatableMetrics {
         }
     }
 
+    public void updateGeoLocationMetric(boolean successful) {
+        incCounter(MetricName.geolocation_requests);
+        if (successful) {
+            incCounter(MetricName.geolocation_successful);
+        } else {
+            incCounter(MetricName.geolocation_fail);
+        }
+    }
+
     public void updateGeoLocationCircuitBreakerMetric(boolean opened) {
         if (opened) {
             incCounter(MetricName.geolocation_circuitbreaker_opened);

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -264,12 +264,13 @@ public class ServiceConfiguration {
     @Bean
     GdprService gdprService(
             @Autowired(required = false) GeoLocationService geoLocationService,
+            Metrics metrics,
             VendorListService vendorListService,
             @Value("${gdpr.eea-countries}") String eeaCountriesAsString,
             @Value("${gdpr.default-value}") String defaultValue) {
 
         final List<String> eeaCountries = Arrays.asList(eeaCountriesAsString.trim().split(","));
-        return new GdprService(geoLocationService, vendorListService, eeaCountries, defaultValue);
+        return new GdprService(geoLocationService, metrics, vendorListService, eeaCountries, defaultValue);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/metric/MetricsTest.java
+++ b/src/test/java/org/prebid/server/metric/MetricsTest.java
@@ -692,6 +692,39 @@ public class MetricsTest {
     }
 
     @Test
+    public void shouldIncrementBothGeoLocationRequestsAndSuccessfulMetrics() {
+        // when
+        metrics.updateGeoLocationMetric(true);
+
+        // then
+        assertThat(metricRegistry.counter("geolocation_requests").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("geolocation_successful").getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldIncrementBothGeoLocationRequestsAndFailMetrics() {
+        // when
+        metrics.updateGeoLocationMetric(false);
+
+        // then
+        assertThat(metricRegistry.counter("geolocation_requests").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("geolocation_fail").getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldAlwaysIncrementGeoLocationRequestsMetricAndEitherSuccessfulOrFailMetricDependingOnFlag() {
+        // when
+        metrics.updateGeoLocationMetric(true);
+        metrics.updateGeoLocationMetric(false);
+        metrics.updateGeoLocationMetric(true);
+
+        // then
+        assertThat(metricRegistry.counter("geolocation_requests").getCount()).isEqualTo(3);
+        assertThat(metricRegistry.counter("geolocation_fail").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("geolocation_successful").getCount()).isEqualTo(2);
+    }
+
+    @Test
     public void shouldIncrementStoredRequestFoundMetric() {
         // when
         metrics.updateStoredRequestMetric(true);


### PR DESCRIPTION
- Added new Geo Location metrics that count overall amount of requests as well as amount of successful and failed responses from Geo Location Service;
- Added unit tests for new metrics and updated existing tests where new metrics were added to reflect and ensure the correct behavior;
- Updated `metrics.md` document for new metrics and added description for existing but not mentioned `geolocation_circuitbreaker_*` metrics.