### PR TITLE
Fix supporting of ext.prebid.cache.winningonly flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
         <javax.annotation-api.version>1.3.1</javax.annotation-api.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
-        <vertx.version>3.6.2</vertx.version>
+        <vertx.version>3.7.1</vertx.version>
         <lombok.version>1.18.4</lombok.version>
         <commons.version>3.6</commons.version>
         <commons.collections.version>4.1</commons.collections.version>
-        <commons.compress.version>1.18</commons.compress.version>
+        <commons.compress.version>1.19</commons.compress.version>
         <jackson.version>2.9.10</jackson.version>
         <json.schema.validator.version>0.1.7</json.schema.validator.version>
         <jsonpatch.version>1.9</jsonpatch.version>

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -425,7 +425,7 @@ public class AuctionRequestFactory {
     /**
      * Returns populated {@link ExtRequestTargeting} or null if no changes were applied.
      */
-    private static ExtRequestTargeting targetingOrNull(ExtRequestPrebid prebid) {
+    private ExtRequestTargeting targetingOrNull(ExtRequestPrebid prebid) {
         final ExtRequestTargeting targeting = prebid != null ? prebid.getTargeting() : null;
 
         final boolean isTargetingNotNull = targeting != null;
@@ -442,11 +442,19 @@ public class AuctionRequestFactory {
                     targeting.getMediatypepricegranularity(),
                     targeting.getCurrency(),
                     isIncludeWinnersNull ? true : targeting.getIncludewinners(),
-                    isIncludeBidderKeysNull ? true : targeting.getIncludebidderkeys());
+                    isIncludeBidderKeysNull ? !isWinningOnly(prebid.getCache()) : targeting.getIncludebidderkeys());
         } else {
             result = null;
         }
         return result;
+    }
+
+    /**
+     * Returns winning only flag value.
+     */
+    private boolean isWinningOnly(ExtRequestPrebidCache cache) {
+        final Boolean cacheWinningOnly = cache != null ? cache.getWinningonly() : null;
+        return ObjectUtils.defaultIfNull(cacheWinningOnly, shouldCacheOnlyWinningBids);
     }
 
     /**
@@ -511,7 +519,7 @@ public class AuctionRequestFactory {
             return ExtRequestPrebidCache.of(
                     getIfNotNull(cache, ExtRequestPrebidCache::getBids),
                     getIfNotNull(cache, ExtRequestPrebidCache::getVastxml),
-                    shouldCacheOnlyWinningBids);
+                    true);
         }
         return null;
     }

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -616,6 +616,58 @@ public class AuctionRequestFactoryTest extends VertxTest {
     }
 
     @Test
+    public void shouldSetDefaultIncludeBidderKeysToFalseIfIncludeBidderKeysIsMissedAndWinningonlyIsTrue() {
+        // given
+        givenBidRequest(BidRequest.builder()
+                .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
+                .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
+                        .targeting(ExtRequestTargeting.of(null, null,
+                                null, null, null))
+                        .cache(ExtRequestPrebidCache.of(null, null, true))
+                        .build())))
+                .build());
+
+        // when
+        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
+
+        // then
+        assertThat(singletonList(request))
+                .extracting(BidRequest::getExt)
+                .extracting(ext -> mapper.treeToValue(ext, ExtBidRequest.class))
+                .extracting(ExtBidRequest::getPrebid)
+                .extracting(ExtRequestPrebid::getTargeting)
+                .extracting(ExtRequestTargeting::getIncludebidderkeys)
+                .containsOnly(false);
+    }
+
+    @Test
+    public void shouldSetDefaultIncludeBidderKeysToFalseIfIncludeBidderKeysIsMissedAndWinningonlyIsTrueInConfig() {
+        // given
+        factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, true, "USD",
+                BLACKLISTED_ACCOUNTS, storedRequestProcessor, paramsExtractor, uidsCookieService, bidderCatalog,
+                requestValidator, interstitialProcessor, timeoutResolver, timeoutFactory, applicationSettings);
+        givenBidRequest(BidRequest.builder()
+                .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
+                .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
+                        .targeting(ExtRequestTargeting.of(null, null,
+                                null, null, null))
+                        .build())))
+                .build());
+
+        // when
+        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
+
+        // then
+        assertThat(singletonList(request))
+                .extracting(BidRequest::getExt)
+                .extracting(ext -> mapper.treeToValue(ext, ExtBidRequest.class))
+                .extracting(ExtBidRequest::getPrebid)
+                .extracting(ExtRequestPrebid::getTargeting)
+                .extracting(ExtRequestTargeting::getIncludebidderkeys)
+                .containsOnly(false);
+    }
+
+    @Test
     public void shouldSetCacheWinningonlyFromConfigWhenExtRequestPrebidIsNull() {
         // given
         factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, true, "USD",

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -108,7 +108,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
         given(timeoutResolver.resolve(any())).willReturn(2000L);
         given(timeoutResolver.adjustTimeout(anyLong())).willReturn(1900L);
 
-        factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, true, "USD",
+        factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, false, "USD",
                 BLACKLISTED_ACCOUNTS, storedRequestProcessor, paramsExtractor, uidsCookieService, bidderCatalog,
                 requestValidator, interstitialProcessor, timeoutResolver, timeoutFactory, applicationSettings);
     }
@@ -618,6 +618,10 @@ public class AuctionRequestFactoryTest extends VertxTest {
     @Test
     public void shouldSetCacheWinningonlyFromConfigWhenExtRequestPrebidIsNull() {
         // given
+        factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, true, "USD",
+                BLACKLISTED_ACCOUNTS, storedRequestProcessor, paramsExtractor, uidsCookieService, bidderCatalog,
+                requestValidator, interstitialProcessor, timeoutResolver, timeoutFactory, applicationSettings);
+
         givenBidRequest(BidRequest.builder()
                 .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
                 .ext(mapper.valueToTree(ExtBidRequest.of(null)))
@@ -639,6 +643,10 @@ public class AuctionRequestFactoryTest extends VertxTest {
     @Test
     public void shouldSetCacheWinningonlyFromConfigWhenExtRequestPrebidCacheIsNull() {
         // given
+        factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, true, "USD",
+                BLACKLISTED_ACCOUNTS, storedRequestProcessor, paramsExtractor, uidsCookieService, bidderCatalog,
+                requestValidator, interstitialProcessor, timeoutResolver, timeoutFactory, applicationSettings);
+
         givenBidRequest(BidRequest.builder()
                 .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
                 .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder().build())))
@@ -660,6 +668,10 @@ public class AuctionRequestFactoryTest extends VertxTest {
     @Test
     public void shouldSetCacheWinningonlyFromConfigWhenCacheWinningonlyIsNull() {
         // given
+        factory = new AuctionRequestFactory(Integer.MAX_VALUE, false, true, "USD",
+                BLACKLISTED_ACCOUNTS, storedRequestProcessor, paramsExtractor, uidsCookieService, bidderCatalog,
+                requestValidator, interstitialProcessor, timeoutResolver, timeoutFactory, applicationSettings);
+
         givenBidRequest(BidRequest.builder()
                 .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
                 .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()


### PR DESCRIPTION
This PR fixes #484 and changes of **includebidderkeys** determining:

- if `ext.prebid.targeting.includebidderkeys` **is defined** (true/false) -> then use it and take precedence over `ext.prebid.cache.winningonly` flag: if true - then `ext.prebid.cache.winningonly` is ignored, if false - then `ext.prebid.cache.winningonly` is used as usual.

- if `ext.prebid.targeting.includebidderkeys` **is not defined** - then set it to **false** only in case if `ext.prebid.cache.winningonly == true`, otherwise - **true**.
