### PR TITLE
Fix displaying missing Json Node as Null Node

### DIFF
--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -536,21 +536,21 @@ public class BidResponseCreator {
 
         final Map<BidType, TargetingKeywordsCreator> result = new HashMap<>();
 
-        final JsonNode banner = mediaTypePriceGranularity.getBanner();
+        final ObjectNode banner = mediaTypePriceGranularity.getBanner();
         final boolean isBannerNull = banner == null || banner.isNull();
         if (!isBannerNull) {
             result.put(BidType.banner, TargetingKeywordsCreator.create(parsePriceGranularity(banner),
                     targeting.getIncludewinners(), targeting.getIncludebidderkeys(), isApp));
         }
 
-        final JsonNode video = mediaTypePriceGranularity.getVideo();
+        final ObjectNode video = mediaTypePriceGranularity.getVideo();
         final boolean isVideoNull = video == null || video.isNull();
         if (!isVideoNull) {
             result.put(BidType.video, TargetingKeywordsCreator.create(parsePriceGranularity(video),
                     targeting.getIncludewinners(), targeting.getIncludebidderkeys(), isApp));
         }
 
-        final JsonNode xNative = mediaTypePriceGranularity.getXNative();
+        final ObjectNode xNative = mediaTypePriceGranularity.getXNative();
         final boolean isNativeNull = xNative == null || xNative.isNull();
         if (!isNativeNull) {
             result.put(BidType.xNative, TargetingKeywordsCreator.create(parsePriceGranularity(xNative),

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtMediaTypePriceGranularity.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtMediaTypePriceGranularity.java
@@ -1,7 +1,7 @@
 package org.prebid.server.proto.openrtb.ext.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
@@ -16,17 +16,17 @@ public class ExtMediaTypePriceGranularity {
     /**
      * Defines the contract for bidrequest.ext.prebid.targeting.mediatypepricegranularity.banner
      */
-    JsonNode banner;
+    ObjectNode banner;
 
     /**
      * Defines the contract for bidrequest.ext.prebid.targeting.mediatypepricegranularity.video
      */
-    JsonNode video;
+    ObjectNode video;
 
     /**
      * Defines the contract for bidrequest.ext.prebid.targeting.mediatypepricegranularity.native
      */
     @JsonProperty("native")
     @Getter(onMethod = @__({@JsonProperty("native")}))
-    JsonNode xNative;
+    ObjectNode xNative;
 }

--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -251,9 +251,9 @@ public class RequestValidator {
     private static void validateMediaTypePriceGranularity(ExtMediaTypePriceGranularity mediaTypePriceGranularity)
             throws ValidationException {
         if (mediaTypePriceGranularity != null) {
-            final JsonNode banner = mediaTypePriceGranularity.getBanner();
-            final JsonNode video = mediaTypePriceGranularity.getVideo();
-            final JsonNode xNative = mediaTypePriceGranularity.getXNative();
+            final ObjectNode banner = mediaTypePriceGranularity.getBanner();
+            final ObjectNode video = mediaTypePriceGranularity.getVideo();
+            final ObjectNode xNative = mediaTypePriceGranularity.getXNative();
             final boolean isBannerNull = banner == null || banner.isNull();
             final boolean isVideoNull = video == null || video.isNull();
             final boolean isNativeNull = xNative == null || xNative.isNull();

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -56,6 +56,7 @@ import org.prebid.server.proto.openrtb.ext.request.ExtUserEidUid;
 import org.prebid.server.proto.openrtb.ext.request.ExtUserPrebid;
 import org.prebid.server.validation.model.ValidationResult;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -1418,49 +1419,6 @@ public class RequestValidatorTest extends VertxTest {
         // then
         assertThat(result.getErrors()).hasSize(1)
                 .containsOnly("Media type price granularity error: must have at least one media type present");
-    }
-
-    @Test
-    public void validateShouldReturnValidationMessageWhenMediaTypePriceGranularityTypeNodesAreNull() {
-        // given
-        final NullNode nullNode = NullNode.getInstance();
-        final BidRequest bidRequest = validBidRequestBuilder()
-                .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
-                        .targeting(ExtRequestTargeting.of(mapper.valueToTree(ExtPriceGranularity.of(1,
-                                singletonList(
-                                        ExtGranularityRange.of(BigDecimal.valueOf(5), BigDecimal.valueOf(0.01))))),
-                                ExtMediaTypePriceGranularity.of(nullNode, nullNode, nullNode),
-                                null, null, null))
-                        .build())))
-                .build();
-        // when
-        final ValidationResult result = requestValidator.validate(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("Media type price granularity error: must have at least one media type present");
-    }
-
-    @Test
-    public void validateShouldReturnValidationMessageWhenAnyPresentMediaTypePriceGranularityIsInvalid() {
-        // given
-        final BidRequest bidRequest = validBidRequestBuilder()
-                .ext(mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()
-                        .targeting(ExtRequestTargeting.of(mapper.valueToTree(ExtPriceGranularity.of(1,
-                                singletonList(
-                                        ExtGranularityRange.of(BigDecimal.valueOf(5), BigDecimal.valueOf(0.01))))),
-                                ExtMediaTypePriceGranularity.of(mapper.valueToTree(ExtPriceGranularity.of(2,
-                                        singletonList(ExtGranularityRange.of(BigDecimal.valueOf(5),
-                                                BigDecimal.valueOf(1))))), null, new TextNode("pricegranularity")),
-                                null, null, null))
-                        .build())))
-                .build();
-        // when
-        final ValidationResult result = requestValidator.validate(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("Error while parsing request.ext.prebid.targeting.mediatypepricegranularity.xNative");
     }
 
     @Test


### PR DESCRIPTION
Fixed missing media type price granularity node being displayed as a NullNode i.e. a field would have `null` value, despite json mapper set to ignore `null` fields.