### PR TITLE
Move publisher.ext.parentAccount property to publisher.ext.prebid

### DIFF
--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -32,6 +32,7 @@ import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidRequest;
 import org.prebid.server.proto.openrtb.ext.request.ExtPriceGranularity;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisher;
+import org.prebid.server.proto.openrtb.ext.request.ExtPublisherPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidCache;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestTargeting;
@@ -631,7 +632,8 @@ public class AuctionRequestFactory {
             return null; // not critical
         }
 
-        return extPublisher != null ? StringUtils.stripToNull(extPublisher.getParentAccount()) : null;
+        final ExtPublisherPrebid extPublisherPrebid = extPublisher != null ? extPublisher.getPrebid() : null;
+        return extPublisherPrebid != null ? StringUtils.stripToNull(extPublisherPrebid.getParentAccount()) : null;
     }
 
     /**

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtPublisher.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtPublisher.java
@@ -1,6 +1,5 @@
 package org.prebid.server.proto.openrtb.ext.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -12,9 +11,7 @@ import lombok.Value;
 public class ExtPublisher {
 
     /**
-     * parentAccount would define the legal entity (publisher owner or network) that has the direct relationship
-     * with the PBS host. As such, the definition depends on the PBS hosting entity.
+     * Defines the contract for bidrequest.app|site.publisher.prebid
      */
-    @JsonProperty("parentAccount")
-    String parentAccount;
+    ExtPublisherPrebid prebid;
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtPublisherPrebid.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtPublisherPrebid.java
@@ -1,0 +1,20 @@
+package org.prebid.server.proto.openrtb.ext.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Defines the contract for bidrequest.app|site.publisher.prebid
+ */
+@AllArgsConstructor(staticName = "of")
+@Value
+public class ExtPublisherPrebid {
+
+    /**
+     * parentAccount would define the legal entity (publisher owner or network) that has the direct relationship
+     * with the PBS host. As such, the definition depends on the PBS hosting entity.
+     */
+    @JsonProperty("parentAccount")
+    String parentAccount;
+}


### PR DESCRIPTION
Moved `publisher.ext.parentAccount` property to `publisher.ext.prebid` and updated unit tests to back up the changes.