### PR TITLE
Add extra info param for bidder configuration

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -36,4 +36,6 @@ public class BidderConfigurationProperties {
 
     @NotNull
     private UsersyncConfigurationProperties usersync;
+
+    private String extraInfo;
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 
 @Validated
 @Data
@@ -37,5 +38,5 @@ public class BidderConfigurationProperties {
     @NotNull
     private UsersyncConfigurationProperties usersync;
 
-    private String extraInfo;
+    private Map<String, String> extraInfo;
 }


### PR DESCRIPTION
Added `extra-info` optional param for .yaml bidder configuration. Tried adding it as a JsonNode with no success as Spring refused to apply the registered converter bean, therefore left the property as a plain string.