### PR TITLE
Fix tests for jackson 2.10

### DIFF
--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -1638,7 +1638,7 @@ public class ExchangeServiceTest extends VertxTest {
     }
 
     private static <T> Imp givenImp(T ext, Function<ImpBuilder, ImpBuilder> impBuilderCustomizer) {
-        return impBuilderCustomizer.apply(Imp.builder().ext(mapper.valueToTree(ext))).build();
+        return impBuilderCustomizer.apply(Imp.builder().ext(ext == null ? null : mapper.valueToTree(ext))).build();
     }
 
     private static <T> List<Imp> givenSingleImp(T ext) {
@@ -1725,7 +1725,7 @@ public class ExchangeServiceTest extends VertxTest {
         return BidResponse.builder()
                 .cur("USD")
                 .seatbid(singletonList(givenSeatBid(bids, identity())))
-                .ext(mapper.valueToTree(extBidResponse))
+                .ext(extBidResponse == null ? null : mapper.valueToTree(extBidResponse))
                 .build();
     }
 

--- a/src/test/java/org/prebid/server/bidder/appnexus/AppnexusBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/appnexus/AppnexusBidderTest.java
@@ -597,7 +597,8 @@ public class AppnexusBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1).containsOnly(BidderError.badServerResponse(
-                "Failed to decode: Unrecognized token 'invalid': was expecting ('true', 'false' or 'null')\n at " +
+                "Failed to decode: Unrecognized token 'invalid': " +
+                        "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at " +
                         "[Source: (String)\"invalid\"; line: 1, column: 15]"));
         assertThat(result.getValue()).isEmpty();
     }

--- a/src/test/java/org/prebid/server/bidder/facebook/FacebookBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/facebook/FacebookBidderTest.java
@@ -422,7 +422,8 @@ public class FacebookBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1).containsOnly(BidderError.badServerResponse(
-                "Failed to decode: Unrecognized token 'invalid': was expecting ('true', 'false' or 'null')\n" +
+                "Failed to decode: Unrecognized token 'invalid': " +
+                        "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
                         " at [Source: (String)\"invalid\"; line: 1, column: 15]"));
         assertThat(result.getValue()).isEmpty();
     }

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -344,7 +344,8 @@ public class OpenxBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1).containsOnly(BidderError.badServerResponse(
-                "Failed to decode: Unrecognized token 'invalid': was expecting ('true', 'false' or 'null')\n" +
+                "Failed to decode: Unrecognized token 'invalid':" +
+                        " was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
                         " at [Source: (String)\"invalid\"; line: 1, column: 15]"));
         assertThat(result.getValue()).isEmpty();
     }

--- a/src/test/java/org/prebid/server/bidder/sovrn/SovrnBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/sovrn/SovrnBidderTest.java
@@ -303,7 +303,7 @@ public class SovrnBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).hasSize(1).containsOnly(BidderError.badServerResponse(
-                "Failed to decode: Unrecognized token 'invalid': was expecting ('true', 'false' or 'null')\n" +
+                "Failed to decode: Unrecognized token 'invalid': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
                         " at [Source: (String)\"invalid\"; line: 1, column: 15]"));
         assertThat(result.getValue()).isEmpty();
     }


### PR DESCRIPTION
`mapper.valueToTree(ext)` now producing `NullNode` when null is received
in 2.9.10 method returns `null`. (NullNode is not extends ObjectNode)

Also `was expecting ('true', 'false' or 'null')` ->
`was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')`
in error message.