### PR TITLE
Fix HttpBidderRequester to pass empty json body for 204 response status

### DIFF
--- a/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
+++ b/src/test/java/org/prebid/server/bidder/HttpBidderRequesterTest.java
@@ -36,6 +36,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.anyLong;
@@ -330,7 +331,7 @@ public class HttpBidderRequesterTest extends VertxTest {
     }
 
     @Test
-    public void shouldTolerateMultipleErrorsAndAllowNoContent() {
+    public void shouldTolerateMultipleErrors() {
         // given
         given(bidder.makeHttpRequests(any())).willReturn(Result.of(asList(
                 // this request will fail with response exception
@@ -412,6 +413,27 @@ public class HttpBidderRequesterTest extends VertxTest {
                 BidderError.badServerResponse("Unexpected status code: 500. Run with request.test = 1 for more info"),
                 BidderError.badInput("Unexpected status code: 400. Run with request.test = 1 for more info"),
                 BidderError.badServerResponse("makeBidsError"));
+    }
+
+    @Test
+    public void shouldPassEmptyJsonResponseBodyToMakeBidsIfResponseStatusIs204() {
+        // given
+        given(bidder.makeHttpRequests(any())).willReturn(Result.of(singletonList(
+                HttpRequest.<BidRequest>builder()
+                        .method(HttpMethod.POST)
+                        .uri(EMPTY)
+                        .body(EMPTY)
+                        .headers(new CaseInsensitiveHeaders())
+                        .build()),
+                emptyList()));
+
+        givenHttpClientReturnsResponse(204, EMPTY);
+
+        // when
+        bidderHttpConnector.requestBids(bidder, BidRequest.builder().test(1).build(), timeout, false);
+
+        // then
+        verify(bidder).makeBids(argThat(httpCall -> httpCall.getResponse().getBody().equals("{}")), any());
     }
 
     private void givenHttpClientReturnsResponse(int statusCode, String response) {


### PR DESCRIPTION
This PR fixes #461 when PBS response has non-critical error like:
```
Failed to decode: No content to map due to end-of-input\n 
at [Source: (String)\"\"; line: 1, column: 0]
```