### PR TITLE
Handle corrupted starter file for RemoteFileSyncer 

### DIFF
--- a/src/main/java/org/prebid/server/execution/RemoteFileProcessor.java
+++ b/src/main/java/org/prebid/server/execution/RemoteFileProcessor.java
@@ -1,0 +1,12 @@
+package org.prebid.server.execution;
+
+import io.vertx.core.Future;
+
+/**
+ * Contract fro services which use external files.
+ */
+public interface RemoteFileProcessor {
+
+    Future<?> setDataPath(String dataFilePath);
+}
+

--- a/src/main/java/org/prebid/server/execution/RemoteFileSyncer.java
+++ b/src/main/java/org/prebid/server/execution/RemoteFileSyncer.java
@@ -11,6 +11,8 @@ import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.streams.Pump;
 import org.prebid.server.exception.PreBidException;
 import org.prebid.server.util.HttpUtil;
@@ -20,12 +22,13 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 
 /**
  * Works with remote web resource.
  */
 public class RemoteFileSyncer {
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoteFileSyncer.class);
 
     private final String downloadUrl;  // url to resource to be downloaded
     private final String saveFilePath; // full path on file system where downloaded file located
@@ -59,8 +62,8 @@ public class RemoteFileSyncer {
 
         createAndCheckWritePermissionsFor(fileSystem, saveFilePath);
 
-        return new RemoteFileSyncer(downloadUrl, saveFilePath, retryCount, retryInterval, timeout,
-                httpClient, vertx, fileSystem);
+        return new RemoteFileSyncer(downloadUrl, saveFilePath, retryCount, retryInterval, timeout, httpClient, vertx,
+                fileSystem);
     }
 
     /**
@@ -83,25 +86,51 @@ public class RemoteFileSyncer {
     /**
      * Fetches remote file and executes given callback with filepath on finish.
      */
-    public void syncForFilepath(Consumer<String> consumer) {
-        downloadIfNotExist().setHandler(aVoid -> handleSync(consumer, aVoid));
+    public void syncForFilepath(RemoteFileProcessor remoteFileProcessor) {
+        downloadIfNotExist(remoteFileProcessor).setHandler(syncResult -> handleSync(remoteFileProcessor, syncResult));
     }
 
-    private Future<Void> downloadIfNotExist() {
+    private Future<Void> downloadIfNotExist(RemoteFileProcessor fileProcessor) {
         final Future<Void> future = Future.future();
-        fileSystem.exists(saveFilePath, existResult -> handleFileExists(future, existResult));
+        fileSystem.exists(saveFilePath, existResult -> handleFileExisting(future, existResult, fileProcessor));
         return future;
     }
 
-    private void handleFileExists(Future<Void> future, AsyncResult<Boolean> existResult) {
+    private void handleFileExisting(Future<Void> future, AsyncResult<Boolean> existResult,
+                                    RemoteFileProcessor fileProcessor) {
         if (existResult.succeeded()) {
             if (existResult.result()) {
-                future.complete();
+                fileProcessor.setDataPath(saveFilePath)
+                        .setHandler(serviceRespond -> handleServiceRespond(serviceRespond, future));
             } else {
                 tryDownload(future);
             }
         } else {
             future.fail(existResult.cause());
+        }
+    }
+
+    private void handleServiceRespond(AsyncResult<?> processResult, Future<Void> future) {
+        if (processResult.failed()) {
+            final Throwable cause = processResult.cause();
+            cleanUp().setHandler(removalResult -> handleCorruptedFileRemoval(removalResult, future, cause));
+        } else {
+            logger.info("Existing file {0} was successfully reused for service", saveFilePath);
+        }
+    }
+
+    private void handleCorruptedFileRemoval(AsyncResult<Void> removalResult, Future<Void> future,
+                                            Throwable serviceCause) {
+        if (removalResult.failed()) {
+            final Throwable cause = removalResult.cause();
+            future.fail(new PreBidException(
+                    String.format("Corrupted file %s cant be deleted. Please check permission or delete manually.",
+                            saveFilePath), cause));
+        } else {
+            logger.info("Existing file {0} cant be processed by service, try to download after removal",
+                    serviceCause, saveFilePath);
+
+            tryDownload(future);
         }
     }
 
@@ -124,8 +153,8 @@ public class RemoteFileSyncer {
                 final HttpClientRequest httpClientRequest = httpClient
                         .getAbs(downloadUrl, response -> pumpFileFromRequest(response, asyncFile, future));
                 httpClientRequest.end();
-            } catch (Exception ex) {
-                future.fail(ex);
+            } catch (Exception e) {
+                future.fail(e);
             }
         } else {
             future.fail(openResult.cause());
@@ -133,6 +162,7 @@ public class RemoteFileSyncer {
     }
 
     private void pumpFileFromRequest(HttpClientResponse httpClientResponse, AsyncFile asyncFile, Future<Void> future) {
+        logger.info("Trying to download from {0}", downloadUrl);
         httpClientResponse.pause();
         final Pump pump = Pump.pump(httpClientResponse, asyncFile);
         pump.start();
@@ -169,6 +199,7 @@ public class RemoteFileSyncer {
     }
 
     private void retryDownload(Future<Void> receivedFuture, long retryInterval, long retryCount) {
+        logger.info("Set retry {0} to download from {1}. {2} retries left", retryInterval, downloadUrl, retryCount);
         vertx.setTimer(retryInterval, retryTimerId -> handleRetry(receivedFuture, retryInterval, retryCount));
     }
 
@@ -208,9 +239,20 @@ public class RemoteFileSyncer {
         }
     }
 
-    private void handleSync(Consumer<String> consumer, AsyncResult<Void> aVoid) {
-        if (aVoid.succeeded()) {
-            consumer.accept(saveFilePath);
+    private void handleSync(RemoteFileProcessor remoteFileProcessor, AsyncResult<Void> syncResult) {
+        if (syncResult.succeeded()) {
+            remoteFileProcessor.setDataPath(saveFilePath)
+                    .setHandler(this::logFileProcessStatus);
+        } else {
+            logger.error("Cant download file from {0}", syncResult.cause(), downloadUrl);
+        }
+    }
+
+    private void logFileProcessStatus(AsyncResult<?> serviceRespond) {
+        if (serviceRespond.succeeded()) {
+            logger.info("Service successfully receive file {0}.", saveFilePath);
+        } else {
+            logger.error("Service cant process file {0} and still unavailable.", saveFilePath);
         }
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -473,8 +473,7 @@ public class ServiceConfiguration {
                     vertx.createHttpClient(httpClientOptions), vertx);
             final MaxMindGeoLocationService maxMindGeoLocationService = new MaxMindGeoLocationService();
 
-            remoteFileSyncer.syncForFilepath(maxMindGeoLocationService::setDatabaseReader);
-
+            remoteFileSyncer.syncForFilepath(maxMindGeoLocationService);
             return maxMindGeoLocationService;
         }
     }

--- a/src/test/java/org/prebid/server/geolocation/MaxMindGeoLocationServiceTest.java
+++ b/src/test/java/org/prebid/server/geolocation/MaxMindGeoLocationServiceTest.java
@@ -9,13 +9,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.FieldSetter;
-import org.prebid.server.exception.PreBidException;
 import org.prebid.server.geolocation.model.GeoInfo;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -43,10 +41,14 @@ public class MaxMindGeoLocationServiceTest {
     }
 
     @Test
-    public void setDatabaseReaderShouldThrowExceptionIfDatabaseArchiveNotFound() {
-        assertThatExceptionOfType(PreBidException.class)
-                .isThrownBy(() -> maxMindGeoLocationService.setDatabaseReader("no_file"))
-                .withMessageStartingWith("IO Exception occurred while trying to read an archive/db file: no_file");
+    public void setDatabaseReaderShouldReturnFailedFutureIfDatabaseArchiveNotFound() {
+        // given and when
+        final Future<?> result = maxMindGeoLocationService.setDataPath("no_file");
+
+        // then
+        assertTrue(result.failed());
+        assertThat(result.cause())
+                .hasMessageStartingWith("IO Exception occurred while trying to read an archive/db file: no_file");
     }
 
     @Test


### PR DESCRIPTION
When existing file is corrupted. (Service return failedFuture)
We remove that file and download again.

Works only first time, if later file is still corrupted, there will be error log only.

Add special interface `RemoteFileProcessor` for services which depends on remote files.