### PR TITLE
Update Grid usersync url

### DIFF
--- a/src/main/java/org/prebid/server/proto/response/UsersyncInfo.java
+++ b/src/main/java/org/prebid/server/proto/response/UsersyncInfo.java
@@ -95,7 +95,18 @@ public class UsersyncInfo {
         }
 
         public UsersyncInfo assemble() {
-            return new UsersyncInfo(usersyncUrl + HttpUtil.encodeUrl(redirectUrl), type, supportCORS);
+            redirectUrl = StringUtils.countMatches(redirectUrl, '?') > 1
+                    ? resolveQueryParams(redirectUrl)
+                    : HttpUtil.encodeUrl(redirectUrl);
+
+            return new UsersyncInfo(usersyncUrl + redirectUrl, type, supportCORS);
+        }
+
+        private static String resolveQueryParams(String redirectUrl) {
+            final int queryParamsIndex = redirectUrl.lastIndexOf('?');
+            final String queryParams = redirectUrl.substring(queryParamsIndex);
+
+            return HttpUtil.encodeUrl(redirectUrl.substring(0, queryParamsIndex)) + queryParams;
         }
     }
 }

--- a/src/main/resources/bidder-config/grid.yaml
+++ b/src/main/resources/bidder-config/grid.yaml
@@ -15,8 +15,8 @@ adapters:
       supported-vendors:
       vendor-id: 0
     usersync:
-      url: http://grid.bidswitch.net/sp_sync?sp_id=prebid&redir=
-      redirect-url: /setuid?bidder=grid&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&uid=$UID
+      url: https://x.bidswitch.net/check_uuid/
+      redirect-url: /setuid?bidder=grid&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&uid=${BSW_UUID}?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}
       cookie-family-name: grid
       type: redirect
       support-cors: false

--- a/src/test/java/org/prebid/server/proto/response/UsersyncInfoTest.java
+++ b/src/test/java/org/prebid/server/proto/response/UsersyncInfoTest.java
@@ -20,6 +20,18 @@ public class UsersyncInfoTest {
     }
 
     @Test
+    public void assembleUsersyncInfoShouldAppendEncodedRedirectUrlAndNotEncodedQueryParamsToUsersyncUrl() {
+        // given and when
+        final UsersyncInfo result = UsersyncInfo.UsersyncInfoAssembler
+                .assembler(new Usersyncer(null, "http://url/redirect=", "/setuid?gdpr={{gdpr}}?gdpr={{gdpr}}",
+                        "http://localhost:8000", null, false)).assemble();
+
+        // then
+        assertThat(result.getUrl()).isEqualTo(
+                "http://url/redirect=http%3A%2F%2Flocalhost%3A8000%2Fsetuid%3Fgdpr%3D%7B%7Bgdpr%7D%7D?gdpr={{gdpr}}");
+    }
+
+    @Test
     public void assembleUsersyncInfoShouldIgnoreRedirectUrlIfNotDefined() {
         // given and when
         final UsersyncInfo result = UsersyncInfo.UsersyncInfoAssembler


### PR DESCRIPTION
- Updated Grid usersync url and redirect url;
- Added redirect url query parameters handling since in GO they just pass `redirectUrl` as a string, which already contains encoded value (and, like in this case, also query params), while we encode the whole string later (instead a certain part should be encoded).