### PR TITLE
Change Rubicon player width/height params to accept integer or string

### DIFF
--- a/src/main/resources/static/bidder-params/rubicon.json
+++ b/src/main/resources/static/bidder-params/rubicon.json
@@ -46,11 +46,11 @@
           "description": "Language of the ad - should match content video"
         },
         "playerHeight": {
-          "type": "string",
+          "type": ["integer", "string"],
           "description": "Height in pixels of the video player"
         },
         "playerWidth": {
-          "type": "string",
+          "type": ["integer", "string"],
           "description": "Width in pixels of the video player"
         },
         "size_id": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-request.json
@@ -44,6 +44,8 @@
           },
           "video": {
             "size_id": 15,
+            "playerWidth": 780,
+            "playerHeight": "438",
             "skip": 5,
             "skipdelay": 1
           }
@@ -284,4 +286,5 @@
     "ext": {
       "us_privacy": "1YN"
     }
-  }}
+  }
+}

--- a/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rubicon_appnexus/test-auction-rubicon-appnexus-response.json
@@ -460,6 +460,8 @@
                 },
                 "video": {
                   "size_id": 15,
+                  "playerWidth": 780,
+                  "playerHeight": "438",
                   "skip": 5,
                   "skipdelay": 1
                 }


### PR DESCRIPTION
Modified JSON schema for Rubicon bidder params to accept multiple format for `playerWidth` and `playerHeight`:
```
"imp": [
    {
      "ext": {
        "rubicon": {
          "video": {
            "playerWidth": 624,
            "playerHeight": 351
          }
      }
    }
```
and
```
"imp": [
    {
      "ext": {
        "rubicon": {
          "video": {
            "playerWidth": "624",
            "playerHeight": "351"
          }
      }
    }
```
This PR fixes https://github.com/rubicon-project/prebid-server-java/pull/565