### PR TITLE
Add referrer logging for invalid request

### DIFF
--- a/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
@@ -75,7 +75,7 @@ public class AmpRequestFactory {
     public Future<AuctionContext> fromRequest(RoutingContext routingContext, long startTime) {
         final String tagId = routingContext.request().getParam(TAG_ID_REQUEST_PARAM);
         if (StringUtils.isBlank(tagId)) {
-            return Future.failedFuture(new InvalidRequestException("AMP requests require an AMP tag_id"));
+            return Future.failedFuture(new InvalidRequestException("AMP requests require an AMP tag_id", true));
         }
 
         return createBidRequest(routingContext, tagId)

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -179,7 +179,7 @@ public class AuctionRequestFactory {
         try {
             return Json.decodeValue(body, BidRequest.class);
         } catch (DecodeException e) {
-            throw new InvalidRequestException(e.getMessage());
+            throw new InvalidRequestException(String.format("Error decoding bidRequest: %s", e.getMessage()), e);
         }
     }
 

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -179,7 +179,7 @@ public class AuctionRequestFactory {
         try {
             return Json.decodeValue(body, BidRequest.class);
         } catch (DecodeException e) {
-            throw new InvalidRequestException(String.format("Error decoding bidRequest: %s", e.getMessage()), e);
+            throw new InvalidRequestException(String.format("Error decoding bidRequest: %s", e.getMessage()), true);
         }
     }
 

--- a/src/main/java/org/prebid/server/auction/StoredRequestProcessor.java
+++ b/src/main/java/org/prebid/server/auction/StoredRequestProcessor.java
@@ -112,9 +112,9 @@ public class StoredRequestProcessor {
                                                           Map<Imp, String> impsToStoredRequestId) {
         return storedDataFuture
                 .recover(exception -> Future.failedFuture(new InvalidRequestException(
-                        String.format("Stored request fetching failed: %s", exception.getMessage()))))
+                        String.format("Stored request fetching failed: %s", exception.getMessage()), true)))
                 .compose(result -> !result.getErrors().isEmpty()
-                        ? Future.failedFuture(new InvalidRequestException(result.getErrors()))
+                        ? Future.failedFuture(new InvalidRequestException(result.getErrors(), true))
                         : Future.succeededFuture(result))
                 .map(result -> mergeBidRequestAndImps(bidRequest, storedBidRequestId,
                         impsToStoredRequestId, result));

--- a/src/main/java/org/prebid/server/exception/InvalidRequestException.java
+++ b/src/main/java/org/prebid/server/exception/InvalidRequestException.java
@@ -8,22 +8,43 @@ public class InvalidRequestException extends RuntimeException {
 
     private final List<String> messages;
 
+    private final boolean needEnhancedLogging;
+
     public InvalidRequestException(String message) {
         super(message);
         this.messages = Collections.singletonList(message);
+        this.needEnhancedLogging = false;
     }
 
     public InvalidRequestException(String message, Throwable cause) {
         super(message, cause);
         this.messages = Collections.singletonList(message);
+        this.needEnhancedLogging = false;
+    }
+
+    public InvalidRequestException(String message, boolean needEnhancedLogging) {
+        super(message);
+        this.messages = Collections.singletonList(message);
+        this.needEnhancedLogging = needEnhancedLogging;
     }
 
     public InvalidRequestException(List<String> messages) {
         super(String.join("\n", messages));
         this.messages = messages;
+        this.needEnhancedLogging = false;
+    }
+
+    public InvalidRequestException(List<String> messages, boolean needEnhancedLogging) {
+        super(String.join("\n", messages));
+        this.messages = messages;
+        this.needEnhancedLogging = needEnhancedLogging;
     }
 
     public List<String> getMessages() {
         return messages;
+    }
+
+    public boolean isNeedEnhancedLogging() {
+        return needEnhancedLogging;
     }
 }

--- a/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AmpHandler.java
@@ -14,7 +14,6 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -297,11 +296,12 @@ public class AmpHandler implements Handler<RoutingContext> {
             if (exception instanceof InvalidRequestException) {
                 metricRequestStatus = MetricName.badinput;
 
-                errorMessages = ((InvalidRequestException) exception).getMessages().stream()
+                final InvalidRequestException invalidRequestException = (InvalidRequestException) exception;
+                errorMessages = invalidRequestException.getMessages().stream()
                         .map(msg -> String.format("Invalid request format: %s", msg))
                         .collect(Collectors.toList());
                 final String message = String.join("\n", errorMessages);
-                logModifier.get().accept(logger, logMessageFrom(exception, message, context));
+                logModifier.get().accept(logger, logMessageFrom(invalidRequestException, message, context));
 
                 status = HttpResponseStatus.BAD_REQUEST.code();
                 body = message;
@@ -353,8 +353,8 @@ public class AmpHandler implements Handler<RoutingContext> {
         return origin;
     }
 
-    private static String logMessageFrom(Throwable exception, String message, RoutingContext context) {
-        return exception.getCause() instanceof DecodeException
+    private static String logMessageFrom(InvalidRequestException exception, String message, RoutingContext context) {
+        return exception.isNeedEnhancedLogging()
                 ? String.format("%s, Referer: %s", message, context.request().headers().get(HttpUtil.REFERER_HEADER))
                 : message;
     }

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -219,7 +219,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
         assertThat(future.failed()).isTrue();
         assertThat(future.cause()).isInstanceOf(InvalidRequestException.class);
         assertThat(((InvalidRequestException) future.cause()).getMessages()).hasSize(1)
-                .element(0).asString().startsWith("Failed to decode:");
+                .element(0).asString().startsWith("Error decoding bidRequest: Failed to decode:");
     }
 
     @Test
@@ -840,11 +840,11 @@ public class AuctionRequestFactoryTest extends VertxTest {
     public void shouldAddMissingAliases() {
         // given
         final Imp imp1 = Imp.builder()
-                .ext((ObjectNode) Json.mapper.createObjectNode()
+                .ext(Json.mapper.createObjectNode()
                         .set("requestScopedBidderAlias", Json.mapper.createObjectNode()))
                 .build();
         final Imp imp2 = Imp.builder()
-                .ext((ObjectNode) Json.mapper.createObjectNode()
+                .ext(Json.mapper.createObjectNode()
                         .set("configScopedBidderAlias", Json.mapper.createObjectNode()))
                 .build();
 

--- a/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AmpHandlerTest.java
@@ -37,8 +37,8 @@ import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.exception.BlacklistedAccountException;
 import org.prebid.server.exception.BlacklistedAppException;
 import org.prebid.server.exception.InvalidRequestException;
-import org.prebid.server.execution.LogModifier;
 import org.prebid.server.exception.UnauthorizedAccountException;
+import org.prebid.server.execution.LogModifier;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.metric.MetricName;
@@ -266,7 +266,7 @@ public class AmpHandlerTest extends VertxTest {
                 .containsOnly(
                         tuple("AMP-Access-Control-Allow-Source-Origin", "http://example.com"),
                         tuple("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin"));
-        verify(httpResponse).end(eq("Unauthorised: Account id is not provided"));
+        verify(httpResponse).end(eq("Unauthorized: Account id is not provided"));
     }
 
     @Test
@@ -676,7 +676,7 @@ public class AmpHandlerTest extends VertxTest {
                 .httpContext(givenHttpContext(singletonMap("Origin", "http://example.com")))
                 .origin("http://example.com")
                 .status(400)
-                .errors(singletonList("Request is invalid"))
+                .errors(singletonList("Invalid request format: Request is invalid"))
                 .build());
     }
 

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -30,8 +30,8 @@ import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.exception.BlacklistedAccountException;
 import org.prebid.server.exception.BlacklistedAppException;
 import org.prebid.server.exception.InvalidRequestException;
-import org.prebid.server.execution.LogModifier;
 import org.prebid.server.exception.UnauthorizedAccountException;
+import org.prebid.server.execution.LogModifier;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.metric.MetricName;
@@ -232,7 +232,7 @@ public class AuctionHandlerTest extends VertxTest {
         // then
         verifyZeroInteractions(exchangeService);
         verify(httpResponse).setStatusCode(eq(401));
-        verify(httpResponse).end(eq("Unauthorised: Account id is not provided"));
+        verify(httpResponse).end(eq("Unauthorized: Account id is not provided"));
     }
 
     @Test
@@ -563,7 +563,7 @@ public class AuctionHandlerTest extends VertxTest {
         assertThat(auctionEvent).isEqualTo(AuctionEvent.builder()
                 .httpContext(givenHttpContext())
                 .status(400)
-                .errors(singletonList("Request is invalid"))
+                .errors(singletonList("Invalid request format: Request is invalid"))
                 .build());
     }
 


### PR DESCRIPTION
This PR adds Referring URL to logs if:
- Incoming bid request cannot be parsed
- AMP request not found by tag_id or other stored request processing error