### PR TITLE
Replaсe http calls from E-Planning bidder to https to keep up with Go version

### DIFF
--- a/src/main/resources/bidder-config/eplanning.yaml
+++ b/src/main/resources/bidder-config/eplanning.yaml
@@ -1,7 +1,7 @@
 adapters:
   eplanning:
     enabled: false
-    endpoint: http://ads.us.e-planning.net/hb/1
+    endpoint: https://ads.us.e-planning.net/hb/1
     pbs-enforces-gdpr: true
     modifying-vast-xml-allowed: true
     deprecated-names:

--- a/src/main/resources/static/bidder-params/eplanning.json
+++ b/src/main/resources/static/bidder-params/eplanning.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-04/schema#",
   "title": "EPlanning Adapter Params",
   "description": "A schema which validates params accepted by the EPlanning adapter",
   "type": "object",

--- a/src/test/java/org/prebid/server/bidder/eplanning/EplanningBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/eplanning/EplanningBidderTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class EplanningBidderTest extends VertxTest {
 
-    private static final String ENDPOINT_URL = "http://eplanning.com";
+    private static final String ENDPOINT_URL = "https://eplanning.com";
 
     private EplanningBidder eplanningBidder;
 
@@ -186,7 +186,7 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
                 .containsOnly(
-                        "http://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1");
+                        "https://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1");
     }
 
     @Test
@@ -194,7 +194,7 @@ public class EplanningBidderTest extends VertxTest {
         // given
         final BidRequest bidRequest = givenBidRequest(
                 requestBuilder -> requestBuilder
-                        .site(Site.builder().page("http://www.example.com").domain("DOMAIN").build()),
+                        .site(Site.builder().page("https://www.example.com").domain("DOMAIN").build()),
                 identity());
 
         // when
@@ -205,7 +205,7 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
                 .containsOnly(
-                        "http://eplanning.com/clientId/1/DOMAIN/ROS?ct=1&r=pbs&ncb=1&ur=http%3A%2F%2Fwww.example.com"
+                        "https://eplanning.com/clientId/1/DOMAIN/ROS?ct=1&r=pbs&ncb=1&ur=https%3A%2F%2Fwww.example.com"
                                 + "&e=testadun_itco_de:1x1");
     }
 
@@ -227,7 +227,7 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
                 .containsOnly(
-                        "http://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:300x200");
+                        "https://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:300x200");
     }
 
     @Test
@@ -245,7 +245,7 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
-                .containsOnly("http://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1"
+                .containsOnly("https://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1"
                         + "&uid=Buyer-ID");
     }
 
@@ -264,7 +264,7 @@ public class EplanningBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getUri)
-                .containsOnly("http://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1"
+                .containsOnly("https://eplanning.com/clientId/1/FILE/ROS?ct=1&r=pbs&ncb=1&ur=FILE&e=testadun_itco_de:1x1"
                         + "&ip=123.321.321.123");
     }
 

--- a/src/test/java/org/prebid/server/it/EplanningTest.java
+++ b/src/test/java/org/prebid/server/it/EplanningTest.java
@@ -30,7 +30,7 @@ public class EplanningTest extends IntegrationTest {
         wireMockRule.stubFor(get(urlPathEqualTo("/eplanning-exchange/12345/1/example.com/ROS"))
                 .withQueryParam("r", equalTo("pbs"))
                 .withQueryParam("ncb", equalTo("1"))
-                .withQueryParam("ur", equalTo("http://www.example.com"))
+                .withQueryParam("ur", equalTo("https://www.example.com"))
                 .withQueryParam("e", equalTo("testadunitcode:600x300"))
                 .withQueryParam("ip", equalTo("193.168.244.1"))
                 .withHeader("Content-Type", equalToIgnoreCase("application/json;charset=utf-8"))
@@ -48,10 +48,10 @@ public class EplanningTest extends IntegrationTest {
 
         // when
         final Response response = given(spec)
-                .header("Referer", "http://www.example.com")
+                .header("Referer", "https://www.example.com")
                 .header("X-Forwarded-For", "193.168.244.1")
                 .header("User-Agent", "userAgent")
-                .header("Origin", "http://www.example.com")
+                .header("Origin", "https://www.example.com")
                 // this uids cookie value stands for {"uids":{""eplanning":"EP-UID"}}
                 .cookie("uids", "eyJ1aWRzIjp7ImVwbGFubmluZyI6IkVQLVVJRCJ9fQ==")
                 .body(jsonFrom("openrtb2/eplanning/test-auction-eplanning-request.json"))


### PR DESCRIPTION
Before:
http://eplanning.com/
After:
https://eplanning.com/