### PR TITLE
Add Influxdb tags configuration

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -132,6 +132,7 @@ For `influxdb` backend type available next options:
 - `metrics.influxdb.connectTimeout` - the connect timeout.
 - `metrics.influxdb.readTimeout` - the response timeout.
 - `metrics.influxdb.interval` - interval in seconds between successive sending metrics.
+- `metrics.influxdb.tags` - the influxDb tags, optional key-value metrics metadata.
 
 For `console` backend type available next options:
 - `metrics.console.enabled` - if equals to `true` then `console` will be used to submit metrics.

--- a/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
@@ -83,8 +83,10 @@ public class MetricsConfiguration {
                 influxdbProperties.getConnectTimeout(),
                 influxdbProperties.getReadTimeout(),
                 influxdbProperties.getPrefix());
-        final Map<String, String> cfgTags = influxdbProperties.getTags();
-        final Map<String, String> tags = ObjectUtils.defaultIfNull(cfgTags, Collections.emptyMap());
+        final Map<String, String> tags = ObjectUtils.defaultIfNull(
+                influxdbProperties.getTags(),
+                Collections.emptyMap()
+        );
         final ScheduledReporter reporter = InfluxDbReporter
                 .forRegistry(metricRegistry)
                 .withTags(tags)

--- a/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
@@ -42,6 +42,7 @@ import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -81,7 +82,11 @@ public class MetricsConfiguration {
                 influxdbProperties.getConnectTimeout(),
                 influxdbProperties.getReadTimeout(),
                 influxdbProperties.getPrefix());
-        final ScheduledReporter reporter = InfluxDbReporter.forRegistry(metricRegistry).build(influxDbSender);
+        final Map<String, String> tags = influxdbProperties.getTags();
+        final ScheduledReporter reporter = InfluxDbReporter
+                .forRegistry(metricRegistry)
+                .withTags(tags)
+                .build(influxDbSender);
         reporter.start(influxdbProperties.getInterval(), TimeUnit.SECONDS);
 
         return reporter;
@@ -168,6 +173,7 @@ public class MetricsConfiguration {
         @NotNull
         @Min(1)
         private Integer interval;
+        private Map<String, String> tags;
     }
 
     @Component

--- a/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -82,7 +83,12 @@ public class MetricsConfiguration {
                 influxdbProperties.getConnectTimeout(),
                 influxdbProperties.getReadTimeout(),
                 influxdbProperties.getPrefix());
-        final Map<String, String> tags = influxdbProperties.getTags();
+        Map<String, String> cfgTags = influxdbProperties.getTags();
+        Map<String, String> tags = cfgTags == null
+                ?
+                new LinkedHashMap<String, String>()
+                :
+                cfgTags;
         final ScheduledReporter reporter = InfluxDbReporter
                 .forRegistry(metricRegistry)
                 .withTags(tags)

--- a/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/MetricsConfiguration.java
@@ -19,6 +19,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.Router;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.metric.AccountMetricsVerbosity;
 import org.prebid.server.metric.CounterType;
@@ -43,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -83,12 +83,8 @@ public class MetricsConfiguration {
                 influxdbProperties.getConnectTimeout(),
                 influxdbProperties.getReadTimeout(),
                 influxdbProperties.getPrefix());
-        Map<String, String> cfgTags = influxdbProperties.getTags();
-        Map<String, String> tags = cfgTags == null
-                ?
-                new LinkedHashMap<String, String>()
-                :
-                cfgTags;
+        final Map<String, String> cfgTags = influxdbProperties.getTags();
+        final Map<String, String> tags = ObjectUtils.defaultIfNull(cfgTags, Collections.emptyMap());
         final ScheduledReporter reporter = InfluxDbReporter
                 .forRegistry(metricRegistry)
                 .withTags(tags)


### PR DESCRIPTION
Sometimes influxDb tags can come in handy to split data by region, hostname etc.
I find there is no tagging in current prebid-server-java.
As dropwizard-metrics-influxdb already has tags support, I suggest this simple implementation.