### PR TITLE
Hotfix imp[].ext.context.data.adslot issue

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -529,7 +529,10 @@ public class ExchangeService {
         return BidderRequest.of(bidder, bidRequest.toBuilder()
                 .user(privacyEnforcementResult.getUser())
                 .device(privacyEnforcementResult.getDevice())
-                .imp(prepareImps(bidder, imps, firstPartyDataBidders.contains(bidder)))
+                // FIXME: remove firstPartyDataBidders.isEmpty() after FPD will be reworked
+                //  https://github.com/prebid/prebid-server/issues/879
+                .imp(prepareImps(bidder, imps,
+                        firstPartyDataBidders.contains(bidder) || firstPartyDataBidders.isEmpty()))
                 .app(prepareApp(app, extApp, firstPartyDataBidders.contains(bidder)))
                 .site(prepareSite(site, extSite, firstPartyDataBidders.contains(bidder)))
                 .source(prepareSource(bidder, bidderToPrebidSchains, bidRequest.getSource()))
@@ -591,7 +594,9 @@ public class ExchangeService {
     private ObjectNode prepareImpExt(String bidder, ObjectNode impExt, boolean useFirstPartyData) {
         final ObjectNode result = mapper.mapper().valueToTree(ExtPrebid.of(impExt.get(PREBID_EXT), impExt.get(bidder)));
 
-        if (useFirstPartyData) {
+        // FIXME: consider to remove impExt.get(CONTEXT_EXT) != null after FPD will be reworked
+        //  https://github.com/prebid/prebid-server/issues/879
+        if (useFirstPartyData && impExt.get(CONTEXT_EXT) != null) {
             result.set(CONTEXT_EXT, impExt.get(CONTEXT_EXT));
         }
 


### PR DESCRIPTION
This PR fixes First Party Data applying for `imp[].ext.context.data`.
Especially, mapping `imp[].ext.context.data.adslot` to `imp[].ext.rp.target.dfp_ad_unit_code`.

Before, to apply FPD we had to specify bidders explicitly: 
```
  "ext": {
    "prebid": {
      "data": {
        "bidders": [ "rubicon" ]
      }
  }
```

Take into account, this is just a hotfix. After https://github.com/prebid/prebid-server/issues/879 reworked - changes may be removed.