### PR TITLE
Add TCF configuration

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -246,9 +246,9 @@ If not defined in config all other Health Checkers would be disabled and endpoin
 - `gdpr.enabled` - gdpr feature switch. Default `true`.
 - `gdpr.purposes.pN.enforce-purpose` - define type of enforcement confirmation: `no`/`basic`/`full`. Default `full`
 - `gdpr.purposes.pN.enforce-vendors` - if equals to `true`, user must give consent to use vendors. Purposes will be omitted. Default `true`
-- `gdpr.purposes.pN.vendor-exceptions[]` - bidder codes which do not require user consent.
+- `gdpr.purposes.pN.vendor-exceptions[]` - bidder names which do not require user consent.
 - `gdpr.special-features.sfN.enforce` - if equals to `true`, special feature will be enforced for purpose. Default `true`
-- `gdpr.special-features.sfN.vendor-exceptions[]` - bidder codes which do not require user consent.
+- `gdpr.special-features.sfN.vendor-exceptions[]` - bidder names which do not require user consent.
 - `gdpr.purpose-one-treatment-interpretation` - flag that allowing to skip the Purpose one enforcement workflow.
 - `gdpr.vendorlist.http-endpoint-template` - template string for vendor list url, where `{VERSION}` is used as version number placeholder.
 - `gdpr.vendorlist.http-default-timeout-ms` - default operation timeout for obtaining new vendor list.

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -243,6 +243,13 @@ If not defined in config all other Health Checkers would be disabled and endpoin
 - `gdpr.eea-countries` - comma separated list of countries in European Economic Area (EEA).
 - `gdpr.default-value` - determines GDPR in scope default value (if no information in request and no geolocation data).
 - `gdpr.host-vendor-id` - the organization running a cluster of Prebid Servers.
+- `gdpr.enabled` - gdpr feature switch. Default `true`.
+- `gdpr.purposes.pN.enforce-purpose` - define type of enforcement confirmation: `no`/`basic`/`full`. Default `full`
+- `gdpr.purposes.pN.enforce-vendors` - if equals to `true`, user must give consent to use vendors. Purposes will be omitted. Default `true`
+- `gdpr.purposes.pN.vendor-exceptions[]` - bidder codes which do not require user consent.
+- `gdpr.special-features.sfN.enforce` - if equals to `true`, special feature will be enforced for purpose. Default `true`
+- `gdpr.special-features.sfN.vendor-exceptions[]` - bidder codes which do not require user consent.
+- `gdpr.purpose-one-treatment-interpretation` - flag that allowing to skip the Purpose one enforcement workflow.
 - `gdpr.vendorlist.http-endpoint-template` - template string for vendor list url, where `{VERSION}` is used as version number placeholder.
 - `gdpr.vendorlist.http-default-timeout-ms` - default operation timeout for obtaining new vendor list.
 - `gdpr.vendorlist.filesystem-cache-dir` - directory for local storage cache for vendor list. Should be with `WRITE` permissions for user application run from.

--- a/sample/prebid-config.yaml
+++ b/sample/prebid-config.yaml
@@ -17,6 +17,7 @@ settings:
     stored-imps-dir: /var/tmp
     stored-responses-dir: /var/tmp
 gdpr:
+  enabled: true
   vendorlist:
     filesystem-cache-dir: /var/tmp
 status-response: "ok"

--- a/src/main/java/org/prebid/server/privacy/gdpr/TcfEnforcementService.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/TcfEnforcementService.java
@@ -1,0 +1,68 @@
+package org.prebid.server.privacy.gdpr;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.prebid.server.geolocation.GeoLocationService;
+import org.prebid.server.metric.Metrics;
+import org.prebid.server.settings.model.Purpose;
+import org.prebid.server.settings.model.Purposes;
+
+import java.util.List;
+import java.util.Objects;
+
+public class TcfEnforcementService {
+
+    private final Boolean gdprEnabled;
+    private final String gdprDefaultValue;
+    private final Purposes defaultPurposes;
+    private final GdprService gdprService;
+    private final List<String> eeaCountries;
+    private final GeoLocationService geoLocationService;
+    private final Metrics metrics;
+
+    public TcfEnforcementService(Boolean gdprEnabled,
+                                 String gdprDefaultValue,
+                                 Purposes defaultPurposes,
+                                 GdprService gdprService,
+                                 List<String> eeaCountries,
+                                 GeoLocationService geoLocationService,
+                                 Metrics metrics) {
+        this.gdprEnabled = gdprEnabled;
+        this.gdprDefaultValue = gdprDefaultValue;
+        this.defaultPurposes = defaultPurposes;
+        this.gdprService = gdprService;
+        this.eeaCountries = eeaCountries;
+        this.geoLocationService = geoLocationService;
+        this.metrics = metrics;
+
+        validateParameters(gdprEnabled);
+    }
+
+    private void validateParameters(Boolean isEnabled) {
+        if (BooleanUtils.isTrue(isEnabled)) {
+            Objects.requireNonNull(gdprDefaultValue);
+            Objects.requireNonNull(defaultPurposes);
+            Objects.requireNonNull(gdprService);
+            Objects.requireNonNull(eeaCountries);
+            Objects.requireNonNull(geoLocationService);
+            Objects.requireNonNull(metrics);
+        }
+    }
+
+    private Purposes mergeAccountPurposes(Purposes accountPurposes) {
+        return Purposes.builder()
+                .p1(mergePurpose(accountPurposes.getP1(), defaultPurposes.getP1()))
+                .p2(mergePurpose(accountPurposes.getP2(), defaultPurposes.getP2()))
+                .p3(mergePurpose(accountPurposes.getP3(), defaultPurposes.getP3()))
+                .p4(mergePurpose(accountPurposes.getP4(), defaultPurposes.getP4()))
+                .p5(mergePurpose(accountPurposes.getP5(), defaultPurposes.getP5()))
+                .p6(mergePurpose(accountPurposes.getP6(), defaultPurposes.getP6()))
+                .p7(mergePurpose(accountPurposes.getP7(), defaultPurposes.getP7()))
+                .p8(mergePurpose(accountPurposes.getP8(), defaultPurposes.getP8()))
+                .p9(mergePurpose(accountPurposes.getP9(), defaultPurposes.getP9()))
+                .build();
+    }
+
+    private static Purpose mergePurpose(Purpose prioritisedPurpose, Purpose purpose) {
+        return prioritisedPurpose == null ? purpose : prioritisedPurpose;
+    }
+}

--- a/src/main/java/org/prebid/server/privacy/gdpr/TcfEnforcementService.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/TcfEnforcementService.java
@@ -3,8 +3,9 @@ package org.prebid.server.privacy.gdpr;
 import org.apache.commons.lang3.BooleanUtils;
 import org.prebid.server.geolocation.GeoLocationService;
 import org.prebid.server.metric.Metrics;
-import org.prebid.server.settings.model.Purpose;
+import org.prebid.server.settings.model.Gdpr;
 import org.prebid.server.settings.model.Purposes;
+import org.prebid.server.settings.model.SpecialFeatures;
 
 import java.util.List;
 import java.util.Objects;
@@ -14,55 +15,63 @@ public class TcfEnforcementService {
     private final Boolean gdprEnabled;
     private final String gdprDefaultValue;
     private final Purposes defaultPurposes;
+    private final SpecialFeatures defaultSpecialFeatures;
     private final GdprService gdprService;
     private final List<String> eeaCountries;
     private final GeoLocationService geoLocationService;
     private final Metrics metrics;
 
-    public TcfEnforcementService(Boolean gdprEnabled,
-                                 String gdprDefaultValue,
-                                 Purposes defaultPurposes,
-                                 GdprService gdprService,
+    public TcfEnforcementService(Gdpr gdpr,
                                  List<String> eeaCountries,
+                                 GdprService gdprService,
                                  GeoLocationService geoLocationService,
                                  Metrics metrics) {
-        this.gdprEnabled = gdprEnabled;
-        this.gdprDefaultValue = gdprDefaultValue;
-        this.defaultPurposes = defaultPurposes;
-        this.gdprService = gdprService;
-        this.eeaCountries = eeaCountries;
-        this.geoLocationService = geoLocationService;
-        this.metrics = metrics;
-
-        validateParameters(gdprEnabled);
-    }
-
-    private void validateParameters(Boolean isEnabled) {
-        if (BooleanUtils.isTrue(isEnabled)) {
-            Objects.requireNonNull(gdprDefaultValue);
-            Objects.requireNonNull(defaultPurposes);
-            Objects.requireNonNull(gdprService);
-            Objects.requireNonNull(eeaCountries);
-            Objects.requireNonNull(geoLocationService);
-            Objects.requireNonNull(metrics);
+        if (gdpr != null && BooleanUtils.isTrue(gdpr.getEnabled())) {
+            this.gdprEnabled = true;
+            this.gdprDefaultValue = Objects.requireNonNull(gdpr.getDefaultValue());
+            this.defaultPurposes = gdpr.getPurposes() == null ? Purposes.builder().build() : gdpr.getPurposes();
+            this.defaultSpecialFeatures = gdpr.getSpecialFeatures() == null
+                    ? SpecialFeatures.builder().build()
+                    : gdpr.getSpecialFeatures();
+            this.gdprService = Objects.requireNonNull(gdprService);
+            this.eeaCountries = Objects.requireNonNull(eeaCountries);
+            this.geoLocationService = geoLocationService;
+            this.metrics = Objects.requireNonNull(metrics);
+        } else {
+            this.gdprEnabled = false;
+            this.gdprDefaultValue = null;
+            this.defaultPurposes = null;
+            this.defaultSpecialFeatures = null;
+            this.gdprService = gdprService;
+            this.eeaCountries = eeaCountries;
+            this.geoLocationService = geoLocationService;
+            this.metrics = metrics;
         }
     }
 
     private Purposes mergeAccountPurposes(Purposes accountPurposes) {
         return Purposes.builder()
-                .p1(mergePurpose(accountPurposes.getP1(), defaultPurposes.getP1()))
-                .p2(mergePurpose(accountPurposes.getP2(), defaultPurposes.getP2()))
-                .p3(mergePurpose(accountPurposes.getP3(), defaultPurposes.getP3()))
-                .p4(mergePurpose(accountPurposes.getP4(), defaultPurposes.getP4()))
-                .p5(mergePurpose(accountPurposes.getP5(), defaultPurposes.getP5()))
-                .p6(mergePurpose(accountPurposes.getP6(), defaultPurposes.getP6()))
-                .p7(mergePurpose(accountPurposes.getP7(), defaultPurposes.getP7()))
-                .p8(mergePurpose(accountPurposes.getP8(), defaultPurposes.getP8()))
-                .p9(mergePurpose(accountPurposes.getP9(), defaultPurposes.getP9()))
+                .p1(mergeItem(accountPurposes.getP1(), defaultPurposes.getP1()))
+                .p2(mergeItem(accountPurposes.getP2(), defaultPurposes.getP2()))
+                .p3(mergeItem(accountPurposes.getP3(), defaultPurposes.getP3()))
+                .p4(mergeItem(accountPurposes.getP4(), defaultPurposes.getP4()))
+                .p5(mergeItem(accountPurposes.getP5(), defaultPurposes.getP5()))
+                .p6(mergeItem(accountPurposes.getP6(), defaultPurposes.getP6()))
+                .p7(mergeItem(accountPurposes.getP7(), defaultPurposes.getP7()))
+                .p8(mergeItem(accountPurposes.getP8(), defaultPurposes.getP8()))
+                .p9(mergeItem(accountPurposes.getP9(), defaultPurposes.getP9()))
                 .build();
     }
 
-    private static Purpose mergePurpose(Purpose prioritisedPurpose, Purpose purpose) {
-        return prioritisedPurpose == null ? purpose : prioritisedPurpose;
+    private SpecialFeatures mergeAccountSpecialFeatures(SpecialFeatures accountSpecialFeatures) {
+        return SpecialFeatures.builder()
+                .sf1(mergeItem(accountSpecialFeatures.getSf1(), defaultSpecialFeatures.getSf1()))
+                .sf2(mergeItem(accountSpecialFeatures.getSf2(), defaultSpecialFeatures.getSf2()))
+                .build();
+    }
+
+    private static <T> T mergeItem(T prioritisedItem, T item) {
+        return prioritisedItem == null ? item : prioritisedItem;
     }
 }
+

--- a/src/main/java/org/prebid/server/settings/model/Account.java
+++ b/src/main/java/org/prebid/server/settings/model/Account.java
@@ -19,6 +19,8 @@ public class Account {
 
     Boolean enforceGdpr;
 
+    Gdpr gdpr;
+
     Integer analyticsSamplingFactor;
 }
 

--- a/src/main/java/org/prebid/server/settings/model/EnforcePurpose.java
+++ b/src/main/java/org/prebid/server/settings/model/EnforcePurpose.java
@@ -1,0 +1,24 @@
+package org.prebid.server.settings.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EnforcePurpose {
+    no("no"), base("base"), full("full");
+
+    private String name;
+
+    EnforcePurpose(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonCreator
+    public static EnforcePurpose forValue(String value) {
+        return EnforcePurpose.valueOf(value);
+    }
+}

--- a/src/main/java/org/prebid/server/settings/model/Gdpr.java
+++ b/src/main/java/org/prebid/server/settings/model/Gdpr.java
@@ -1,0 +1,28 @@
+package org.prebid.server.settings.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+
+@Builder
+@Value
+public class Gdpr {
+
+    @JsonProperty("host-vendor-id")
+    String hostVendorId;
+
+    @JsonProperty(defaultValue = "true")
+    Boolean enabled;
+
+    @JsonProperty(value = "default-value")
+    Boolean defaultValue;
+
+    Purposes purposes;
+
+    @JsonProperty("special-features")
+    SpecialFeatures specialFeatures;
+
+    @JsonProperty("purpose-one-treatment-interpretation")
+    Boolean purposeOneTreatmentInterpretation;
+}
+

--- a/src/main/java/org/prebid/server/settings/model/Gdpr.java
+++ b/src/main/java/org/prebid/server/settings/model/Gdpr.java
@@ -1,11 +1,15 @@
 package org.prebid.server.settings.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
-@Value
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class Gdpr {
 
     @JsonProperty("host-vendor-id")
@@ -15,7 +19,7 @@ public class Gdpr {
     Boolean enabled;
 
     @JsonProperty(value = "default-value")
-    Boolean defaultValue;
+    String defaultValue;
 
     Purposes purposes;
 

--- a/src/main/java/org/prebid/server/settings/model/Purpose.java
+++ b/src/main/java/org/prebid/server/settings/model/Purpose.java
@@ -1,11 +1,8 @@
 package org.prebid.server.settings.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Value;
 
 import java.util.List;
 

--- a/src/main/java/org/prebid/server/settings/model/Purpose.java
+++ b/src/main/java/org/prebid/server/settings/model/Purpose.java
@@ -17,5 +17,5 @@ public class Purpose {
     Boolean enforceVendors;
 
     @JsonProperty("vendor-exceptions")
-    List<Integer> vendorExceptions;
+    List<String> vendorExceptions;
 }

--- a/src/main/java/org/prebid/server/settings/model/Purpose.java
+++ b/src/main/java/org/prebid/server/settings/model/Purpose.java
@@ -1,0 +1,24 @@
+package org.prebid.server.settings.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class Purpose {
+
+    @JsonProperty(value = "enforce-purpose", defaultValue = "full")
+    EnforcePurpose enforcePurpose;
+
+    @JsonProperty(value = "enforce-vendors", defaultValue = "true")
+    Boolean enforceVendors;
+
+    @JsonProperty("vendor-exceptions")
+    List<Integer> vendorExceptions;
+}

--- a/src/main/java/org/prebid/server/settings/model/Purposes.java
+++ b/src/main/java/org/prebid/server/settings/model/Purposes.java
@@ -1,0 +1,33 @@
+package org.prebid.server.settings.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Purposes {
+
+    Purpose p1;
+
+    Purpose p2;
+
+    Purpose p3;
+
+    Purpose p4;
+
+    Purpose p5;
+
+    Purpose p6;
+
+    Purpose p7;
+
+    Purpose p8;
+
+    Purpose p9;
+}
+

--- a/src/main/java/org/prebid/server/settings/model/Purposes.java
+++ b/src/main/java/org/prebid/server/settings/model/Purposes.java
@@ -28,5 +28,7 @@ public class Purposes {
     Purpose p8;
 
     Purpose p9;
+
+    Purpose p10;
 }
 

--- a/src/main/java/org/prebid/server/settings/model/Purposes.java
+++ b/src/main/java/org/prebid/server/settings/model/Purposes.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Value;
 
 @Data
 @Builder

--- a/src/main/java/org/prebid/server/settings/model/SpecialFeature.java
+++ b/src/main/java/org/prebid/server/settings/model/SpecialFeature.java
@@ -1,0 +1,19 @@
+package org.prebid.server.settings.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class SpecialFeature {
+
+    @JsonProperty(defaultValue = "true")
+    Boolean enforce;
+
+    @JsonProperty("vendor-exceptions")
+    List<Integer> vendorExceptions;
+}
+

--- a/src/main/java/org/prebid/server/settings/model/SpecialFeatures.java
+++ b/src/main/java/org/prebid/server/settings/model/SpecialFeatures.java
@@ -1,0 +1,24 @@
+package org.prebid.server.settings.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpecialFeatures {
+
+    SpecialFeature sf1;
+
+    SpecialFeature sf2;
+
+    SpecialFeature sf3;
+
+    SpecialFeature sf4;
+
+    SpecialFeature sf5;
+}
+

--- a/src/main/java/org/prebid/server/settings/model/SpecialFeatures.java
+++ b/src/main/java/org/prebid/server/settings/model/SpecialFeatures.java
@@ -14,11 +14,5 @@ public class SpecialFeatures {
     SpecialFeature sf1;
 
     SpecialFeature sf2;
-
-    SpecialFeature sf3;
-
-    SpecialFeature sf4;
-
-    SpecialFeature sf5;
 }
 

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -42,8 +42,13 @@ import org.prebid.server.metric.Metrics;
 import org.prebid.server.optout.GoogleRecaptchaVerifier;
 import org.prebid.server.privacy.PrivacyExtractor;
 import org.prebid.server.privacy.gdpr.GdprService;
+import org.prebid.server.privacy.gdpr.TcfEnforcementService;
 import org.prebid.server.privacy.gdpr.vendorlist.VendorListService;
 import org.prebid.server.settings.ApplicationSettings;
+import org.prebid.server.settings.model.Purpose;
+import org.prebid.server.settings.model.Purposes;
+import org.prebid.server.settings.model.SpecialFeature;
+import org.prebid.server.settings.model.SpecialFeatures;
 import org.prebid.server.spring.config.model.CircuitBreakerProperties;
 import org.prebid.server.spring.config.model.ExternalConversionProperties;
 import org.prebid.server.spring.config.model.HttpClientProperties;
@@ -380,6 +385,43 @@ public class ServiceConfiguration {
 
         final List<String> eeaCountries = Arrays.asList(eeaCountriesAsString.trim().split(","));
         return new GdprService(eeaCountries, defaultValue, geoLocationService, metrics, vendorListService);
+    }
+
+    @Bean
+    TcfEnforcementService tcfEnforcementService(
+            @Value("${gdpr.enabled:true}") Boolean gdprEnabled,
+            @Value("${gdpr.eea-countries}") String eeaCountriesAsString,
+            @Value("${gdpr.default-value}") String defaultValue,
+            @Autowired(required = false) GeoLocationService geoLocationService,
+            @Autowired Purposes defaultPurposes,
+            GdprService gdprService,
+            Metrics metrics) {
+
+        final List<String> eeaCountries = Arrays.asList(eeaCountriesAsString.trim().split(","));
+        return new TcfEnforcementService(gdprEnabled, defaultValue, defaultPurposes, gdprService, eeaCountries,
+                geoLocationService, metrics);
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "gdpr.purposes")
+    Purposes purposes() {
+        return new Purposes();
+    }
+
+    @Bean
+    Purpose purpose() {
+        return new Purpose();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "gdpr.special-features")
+    SpecialFeatures specialFeatures() {
+        return new SpecialFeatures();
+    }
+
+    @Bean
+    SpecialFeature specialFeature() {
+        return new SpecialFeature();
     }
 
     @Bean

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -45,6 +45,7 @@ import org.prebid.server.privacy.gdpr.GdprService;
 import org.prebid.server.privacy.gdpr.TcfEnforcementService;
 import org.prebid.server.privacy.gdpr.vendorlist.VendorListService;
 import org.prebid.server.settings.ApplicationSettings;
+import org.prebid.server.settings.model.Gdpr;
 import org.prebid.server.settings.model.Purpose;
 import org.prebid.server.settings.model.Purposes;
 import org.prebid.server.settings.model.SpecialFeature;
@@ -389,17 +390,20 @@ public class ServiceConfiguration {
 
     @Bean
     TcfEnforcementService tcfEnforcementService(
-            @Value("${gdpr.enabled:true}") Boolean gdprEnabled,
+            Gdpr gdpr,
             @Value("${gdpr.eea-countries}") String eeaCountriesAsString,
-            @Value("${gdpr.default-value}") String defaultValue,
-            @Autowired(required = false) GeoLocationService geoLocationService,
-            @Autowired Purposes defaultPurposes,
             GdprService gdprService,
+            @Autowired(required = false) GeoLocationService geoLocationService,
             Metrics metrics) {
 
         final List<String> eeaCountries = Arrays.asList(eeaCountriesAsString.trim().split(","));
-        return new TcfEnforcementService(gdprEnabled, defaultValue, defaultPurposes, gdprService, eeaCountries,
-                geoLocationService, metrics);
+        return new TcfEnforcementService(gdpr, eeaCountries, gdprService, geoLocationService, metrics);
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "gdpr")
+    Gdpr gdpr() {
+        return new Gdpr();
     }
 
     @Bean


### PR DESCRIPTION
We have same model for account (.yaml) and default config (.properties).
Additional beans was added to create ConfigurationProperties class with multiple classes. (does not work without it)

account .yaml example:
```
accounts:
  - id: 1001
    gdpr:
      host-vendor-id: 52
      enabled: true
      default-value: 1
      purpose-one-treatment-interpretation: ignore
      purposes:
        p1:
          enforce-purpose: no
          enforce-vendors: true
          vendor-exceptions:
            - rubicon
        p2:
          enforce-purpose: full
          enforce-vendors: false
          vendor-exceptions:
            - appnexus
      special-features:
        sf2:
          enforce: true
          vendor-exceptions:
            - appnexus
```

.properties example:
```
gdpr.purposes.p1.enforce-purpose= no
gdpr.purposes.p1.enforce-vendors= true
gdpr.purposes.p1.vendor-exceptions[0]= rubicon
gdpr.purposes.p1.vendor-exceptions[1]= appnexus
gdpr.purposes.p2.enforce-purpose= base
gdpr.purposes.p2.enforce-vendors= false
gdpr.purposes.p2.vendor-exceptions[0]= appnexus
gdpr.special-features.sf1.enforce= true
gdpr.special-features.sf1.vendor-exceptions=
```