### PR TITLE
 Add protected endpoint to invalidate account from cache

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -201,6 +201,8 @@ For caching available next options:
 - `settings.in-memory-cache.cache-size` - the size of LRU cache.
 - `settings.in-memory-cache.notification-endpoints-enabled` - if equals to `true` two additional endpoints will be
 available: [/storedrequests/openrtb2](endpoints/storedrequests/openrtb2.md) and [/storedrequests/amp](endpoints/storedrequests/amp.md).
+- `settings.in-memory-cache.account-invalidation-enabled` - if equals to `true` additional admin protected endpoints will be
+available: `/cache/invalidate?account={accountId}` which remove account from the cache.
 - `settings.in-memory-cache.http-update.endpoint` - the url to fetch stored request updates.
 - `settings.in-memory-cache.http-update.amp-endpoint` - the url to fetch AMP stored request updates.
 - `settings.in-memory-cache.http-update.refresh-rate` - refresh period in ms for stored request updates.

--- a/src/main/java/org/prebid/server/handler/AccountCacheInvalidationHandler.java
+++ b/src/main/java/org/prebid/server/handler/AccountCacheInvalidationHandler.java
@@ -17,7 +17,7 @@ import org.prebid.server.util.HttpUtil;
 import java.util.Objects;
 
 /**
- * Handles HTTP requests for updating/invalidating settings cache.
+ * Handles HTTP requests for invalidating account settings cache.
  */
 public class AccountCacheInvalidationHandler implements Handler<RoutingContext> {
 

--- a/src/main/java/org/prebid/server/handler/AccountCacheInvalidationHandler.java
+++ b/src/main/java/org/prebid/server/handler/AccountCacheInvalidationHandler.java
@@ -2,16 +2,10 @@ package org.prebid.server.handler;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.lang3.StringUtils;
-import org.prebid.server.json.DecodeException;
-import org.prebid.server.json.JacksonMapper;
-import org.prebid.server.settings.CacheNotificationListener;
 import org.prebid.server.settings.CachingApplicationSettings;
-import org.prebid.server.settings.proto.request.InvalidateSettingsCacheRequest;
-import org.prebid.server.settings.proto.request.UpdateSettingsCacheRequest;
 import org.prebid.server.util.HttpUtil;
 
 import java.util.Objects;

--- a/src/main/java/org/prebid/server/handler/AccountCacheInvalidationHandler.java
+++ b/src/main/java/org/prebid/server/handler/AccountCacheInvalidationHandler.java
@@ -1,0 +1,44 @@
+package org.prebid.server.handler;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.StringUtils;
+import org.prebid.server.json.DecodeException;
+import org.prebid.server.json.JacksonMapper;
+import org.prebid.server.settings.CacheNotificationListener;
+import org.prebid.server.settings.CachingApplicationSettings;
+import org.prebid.server.settings.proto.request.InvalidateSettingsCacheRequest;
+import org.prebid.server.settings.proto.request.UpdateSettingsCacheRequest;
+import org.prebid.server.util.HttpUtil;
+
+import java.util.Objects;
+
+/**
+ * Handles HTTP requests for updating/invalidating settings cache.
+ */
+public class AccountCacheInvalidationHandler implements Handler<RoutingContext> {
+
+    private static final String ACCOUNT_ID_PARAM = "account";
+
+    private final CachingApplicationSettings cachingApplicationSettings;
+
+    public AccountCacheInvalidationHandler(CachingApplicationSettings cachingApplicationSettings) {
+        this.cachingApplicationSettings = Objects.requireNonNull(cachingApplicationSettings);
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        final HttpServerRequest request = context.request();
+        final String accountId = request.getParam(ACCOUNT_ID_PARAM);
+
+        if (StringUtils.isBlank(accountId)) {
+            HttpUtil.respondWith(context, HttpResponseStatus.BAD_REQUEST, "Account id is not defined");
+        } else {
+            cachingApplicationSettings.invalidateAccountCache(accountId);
+            HttpUtil.respondWith(context, HttpResponseStatus.OK, null);
+        }
+    }
+}

--- a/src/main/java/org/prebid/server/settings/CachingApplicationSettings.java
+++ b/src/main/java/org/prebid/server/settings/CachingApplicationSettings.java
@@ -9,7 +9,6 @@ import org.prebid.server.settings.model.Account;
 import org.prebid.server.settings.model.StoredDataResult;
 import org.prebid.server.settings.model.StoredResponseDataResult;
 import org.prebid.server.settings.model.TriFunction;
-import org.prebid.server.vertx.CircuitBreaker;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/org/prebid/server/settings/CachingApplicationSettings.java
+++ b/src/main/java/org/prebid/server/settings/CachingApplicationSettings.java
@@ -1,12 +1,15 @@
 package org.prebid.server.settings;
 
 import io.vertx.core.Future;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.prebid.server.exception.PreBidException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.settings.model.Account;
 import org.prebid.server.settings.model.StoredDataResult;
 import org.prebid.server.settings.model.StoredResponseDataResult;
 import org.prebid.server.settings.model.TriFunction;
+import org.prebid.server.vertx.CircuitBreaker;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,6 +23,8 @@ import java.util.function.BiFunction;
  * Adds caching functionality for {@link ApplicationSettings} implementation
  */
 public class CachingApplicationSettings implements ApplicationSettings {
+
+    private static final Logger logger = LoggerFactory.getLogger(CachingApplicationSettings.class);
 
     private final ApplicationSettings delegate;
 
@@ -171,5 +176,10 @@ public class CachingApplicationSettings implements ApplicationSettings {
             }
         }
         return storedIdToJson;
+    }
+
+    public void invalidateAccountCache(String accountId) {
+        accountCache.remove(accountId);
+        logger.debug("Account with id {0} was invalidated", accountId);
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -28,6 +28,7 @@ import org.prebid.server.cache.CacheService;
 import org.prebid.server.cookie.UidsCookieService;
 import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.execution.TimeoutFactory;
+import org.prebid.server.handler.AccountCacheInvalidationHandler;
 import org.prebid.server.handler.AdminHandler;
 import org.prebid.server.handler.AuctionHandler;
 import org.prebid.server.handler.BidderParamHandler;
@@ -57,6 +58,7 @@ import org.prebid.server.privacy.PrivacyExtractor;
 import org.prebid.server.privacy.gdpr.GdprService;
 import org.prebid.server.privacy.gdpr.TcfDefinerService;
 import org.prebid.server.settings.ApplicationSettings;
+import org.prebid.server.settings.CachingApplicationSettings;
 import org.prebid.server.settings.SettingsCache;
 import org.prebid.server.util.HttpUtil;
 import org.prebid.server.validation.BidderParamValidator;
@@ -447,6 +449,9 @@ public class WebConfiguration {
         private CurrencyRatesHandler currencyRatesHandler;
 
         @Autowired(required = false)
+        private AccountCacheInvalidationHandler accountCacheInvalidationHandler;
+
+        @Autowired(required = false)
         private SettingsCacheNotificationHandler cacheNotificationHandler;
 
         @Autowired(required = false)
@@ -456,10 +461,11 @@ public class WebConfiguration {
         private int adminPort;
 
         @Bean
-        @ConditionalOnProperty(prefix = "settings.in-memory-cache", name = "notification-endpoints-enabled",
+        @ConditionalOnProperty(prefix = "settings.in-memory-cache", name = "account-invalidation-enabled",
                 havingValue = "true")
-        SettingsCacheNotificationHandler cacheNotificationHandler(SettingsCache settingsCache, JacksonMapper mapper) {
-            return new SettingsCacheNotificationHandler(settingsCache, mapper);
+        AccountCacheInvalidationHandler accountCacheInvalidationHandler(
+                CachingApplicationSettings cachingApplicationSettings) {
+            return new AccountCacheInvalidationHandler(cachingApplicationSettings);
         }
 
         @Bean
@@ -469,6 +475,13 @@ public class WebConfiguration {
                 SettingsCache ampSettingsCache, JacksonMapper mapper) {
 
             return new SettingsCacheNotificationHandler(ampSettingsCache, mapper);
+        }
+
+        @Bean
+        @ConditionalOnProperty(prefix = "settings.in-memory-cache", name = "notification-endpoints-enabled",
+                havingValue = "true")
+        SettingsCacheNotificationHandler cacheNotificationHandler(SettingsCache settingsCache, JacksonMapper mapper) {
+            return new SettingsCacheNotificationHandler(settingsCache, mapper);
         }
 
         @Bean
@@ -507,6 +520,9 @@ public class WebConfiguration {
             }
             if (ampCacheNotificationHandler != null) {
                 router.route("/storedrequests/amp").handler(ampCacheNotificationHandler);
+            }
+            if (accountCacheInvalidationHandler != null) {
+                router.route("/cache/invalidate").handler(accountCacheInvalidationHandler);
             }
 
             contextRunner.<HttpServer>runOnServiceContext(promise ->

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,6 +75,7 @@ settings:
     cache-size: 10000
     ttl-seconds: 360
     notification-endpoints-enabled: false
+    account-invalidation-enabled: true
 recaptcha-url: https://www.google.com/recaptcha/api/siteverify
 recaptcha-secret: secret_value
 host-cookie:

--- a/src/test/java/org/prebid/server/handler/AccountCacheInvalidationHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/AccountCacheInvalidationHandlerTest.java
@@ -1,0 +1,76 @@
+package org.prebid.server.handler;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.prebid.server.VertxTest;
+import org.prebid.server.settings.CachingApplicationSettings;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+public class AccountCacheInvalidationHandlerTest extends VertxTest {
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private CachingApplicationSettings cachingApplicationSettings;
+
+    private AccountCacheInvalidationHandler handler;
+    @Mock
+    private RoutingContext routingContext;
+    @Mock
+    private HttpServerRequest httpRequest;
+    @Mock
+    private HttpServerResponse httpResponse;
+
+    @Before
+    public void setUp() {
+        handler = new AccountCacheInvalidationHandler(cachingApplicationSettings);
+
+        given(routingContext.request()).willReturn(httpRequest);
+        given(routingContext.response()).willReturn(httpResponse);
+        given(routingContext.response().setStatusCode(anyInt())).willReturn(httpResponse);
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenAccountParamIsMissing() {
+        // given
+        given(httpRequest.getParam(any())).willReturn(null);
+
+        // when
+        handler.handle(routingContext);
+
+        // then
+        verify(httpResponse).setStatusCode(eq(400));
+        verify(httpResponse).end(eq("Account id is not defined"));
+
+        verify(httpRequest).getParam("account");
+    }
+
+    @Test
+    public void shouldReturnOkAndTriggerInvalidateWhenAccountIdIsPresent() {
+        // given
+        given(httpRequest.getParam(any())).willReturn("123");
+
+        // when
+        handler.handle(routingContext);
+
+        // then
+        verify(httpResponse).setStatusCode(eq(200));
+        verify(cachingApplicationSettings).invalidateAccountCache("123");
+
+        verify(httpRequest).getParam("account");
+    }
+}
+


### PR DESCRIPTION
`/cache/invalidate?account={accountId}`
config:
`settings.in-memory-cache.account-invalidation-enabled` = true