### PR TITLE
Add downgrading to basic when GVL list failed

### DIFF
--- a/src/main/java/org/prebid/server/privacy/gdpr/Tcf2Service.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/Tcf2Service.java
@@ -85,7 +85,7 @@ public class Tcf2Service {
     }
 
     public Future<Collection<VendorPermission>> permissionsFor(Set<Integer> vendorIds, TCString tcfConsent) {
-        final Collection<VendorPermission> vendorPermissions = vendorPermission(vendorIds);
+        final Collection<VendorPermission> vendorPermissions = vendorPermissions(vendorIds);
         return permissionsForInternal(vendorPermissions, tcfConsent, null);
     }
 
@@ -93,11 +93,11 @@ public class Tcf2Service {
                                                                VendorIdResolver vendorIdResolver,
                                                                TCString tcfConsent,
                                                                AccountGdprConfig accountGdprConfig) {
-        final Collection<VendorPermission> vendorPermissions = vendorPermission(bidderNames, vendorIdResolver);
+        final Collection<VendorPermission> vendorPermissions = vendorPermissions(bidderNames, vendorIdResolver);
         return permissionsForInternal(vendorPermissions, tcfConsent, accountGdprConfig);
     }
 
-    private Collection<VendorPermission> vendorPermission(Set<Integer> vendorIds) {
+    private Collection<VendorPermission> vendorPermissions(Set<Integer> vendorIds) {
         return vendorIds.stream()
                 // this check only for illegal arguments...
                 .filter(Objects::nonNull)
@@ -106,8 +106,8 @@ public class Tcf2Service {
                 .collect(Collectors.toList());
     }
 
-    private Collection<VendorPermission> vendorPermission(Set<String> bidderNames,
-                                                          VendorIdResolver vendorIdResolver) {
+    private Collection<VendorPermission> vendorPermissions(Set<String> bidderNames,
+                                                           VendorIdResolver vendorIdResolver) {
 
         return bidderNames.stream()
                 // this check only for illegal arguments...

--- a/src/main/java/org/prebid/server/privacy/gdpr/tcfstrategies/purpose/PurposeStrategy.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/tcfstrategies/purpose/PurposeStrategy.java
@@ -58,8 +58,7 @@ public abstract class PurposeStrategy {
         final boolean isEnforceVendors = BooleanUtils.isNotFalse(purpose.getEnforceVendors());
 
         final EnforcePurpose purposeType = purpose.getEnforcePurpose();
-        // Basic by default
-        if (purposeType == null || Objects.equals(purposeType, EnforcePurpose.basic)) {
+        if (Objects.equals(purposeType, EnforcePurpose.basic)) {
             return allowedByBasicTypeStrategy(vendorConsent, isEnforceVendors, vendorForPurpose, excludedVendors);
         }
 
@@ -67,7 +66,8 @@ public abstract class PurposeStrategy {
             return allowedByNoTypeStrategy(vendorConsent, isEnforceVendors, vendorForPurpose, excludedVendors);
         }
 
-        if (Objects.equals(purposeType, EnforcePurpose.full)) {
+        // Full by default
+        if (purposeType == null || Objects.equals(purposeType, EnforcePurpose.full)) {
             return allowedByFullTypeStrategy(vendorConsent, isEnforceVendors, vendorForPurpose, excludedVendors);
         }
 
@@ -81,7 +81,7 @@ public abstract class PurposeStrategy {
         return CollectionUtils.isEmpty(bidderNameExceptions)
                 ? Collections.emptyList()
                 : CollectionUtils.select(vendorPermissions, vendorPermission ->
-                        bidderNameExceptions.contains(vendorPermission.getVendorPermission().getBidderName()));
+                bidderNameExceptions.contains(vendorPermission.getVendorPermission().getBidderName()));
     }
 
     protected Collection<VendorPermission> allowedByBasicTypeStrategy(


### PR DESCRIPTION
When GVL call failed we downgrade type to basic.

I tried several variants for simplification of `permissionsForInternal`
* You can't create straight forward workflow (
```
.map (p)
.otherwise/recover (downgraded p)
.map` bc in this case you'll be handling exception that can be occurred in map (p).
```
* `setHandle` also bad option, bc it will rethrow failed future.

* Finally, I discovered that compose have overloaded method that can handle both use cases.

Also replaceв lambda with precreation of VendorPermission. (But now we create more objects)