### PR TITLE
Brightroll - enable adapter

### DIFF
--- a/src/main/resources/bidder-config/brightroll.yaml
+++ b/src/main/resources/bidder-config/brightroll.yaml
@@ -1,6 +1,6 @@
 adapters:
   brightroll:
-    enabled: false
+    enabled: true
     endpoint: http://east-bid.ybp.yahoo.com/bid/rubiconpbs
     pbs-enforces-gdpr: true
     modifying-vast-xml-allowed: true


### PR DESCRIPTION
Enabling adapter for integration testing.

Is this a required change? or will it enable by any other settings on Prebid server. I need this change for local testing. So hope it is needed change for production as well. Please confirm.

@rpanchyk , @DGarbar 
