### PR TITLE
DNT header support added

### DIFF
--- a/src/main/java/org/prebid/server/auction/PrivacyEnforcementService.java
+++ b/src/main/java/org/prebid/server/auction/PrivacyEnforcementService.java
@@ -324,12 +324,13 @@ public class PrivacyEnforcementService {
         final boolean isLmtEnabled = isLmtEnabled(device);
         final boolean isDntEnabled = isDntEnabled(device, dntHeader);
 
-        final boolean maskGeo = privacyEnforcementAction.isMaskGeo() || isLmtEnabled || isDntEnabled;
-        final boolean maskUserIds = privacyEnforcementAction.isRemoveUserIds() || isLmtEnabled || isDntEnabled;
+        boolean isLmtOrDntEnabled = isLmtEnabled || isDntEnabled;
+        final boolean maskGeo = privacyEnforcementAction.isMaskGeo() || isLmtOrDntEnabled;
+        final boolean maskUserIds = privacyEnforcementAction.isRemoveUserIds() || isLmtOrDntEnabled;
         final User maskedUser = maskTcfUser(user, maskUserIds, maskGeo);
 
-        final boolean maskIp = privacyEnforcementAction.isMaskDeviceIp() || isLmtEnabled || isDntEnabled;
-        final boolean maskInfo = privacyEnforcementAction.isMaskDeviceInfo() || isLmtEnabled || isDntEnabled;
+        final boolean maskIp = privacyEnforcementAction.isMaskDeviceIp() || isLmtOrDntEnabled;
+        final boolean maskInfo = privacyEnforcementAction.isMaskDeviceInfo() || isLmtOrDntEnabled;
         final Device maskedDevice = maskTcfDevice(device, maskIp, maskGeo, maskInfo);
 
         return BidderPrivacyResult.builder()

--- a/src/main/java/org/prebid/server/metric/MetricName.java
+++ b/src/main/java/org/prebid/server/metric/MetricName.java
@@ -76,6 +76,7 @@ public enum MetricName {
     // privacy
     coppa,
     lmt,
+    dnt,
     specified,
     opt_out("opt-out"),
     invalid,

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -302,6 +302,10 @@ public class Metrics extends UpdatableMetrics {
         privacy().incCounter(MetricName.lmt);
     }
 
+    public void updatePrivacyDntMetric() {
+        privacy().incCounter(MetricName.dnt);
+    }
+
     public void updatePrivacyCcpaMetrics(boolean isSpecified, boolean isEnforced) {
         if (isSpecified) {
             privacy().usp().incCounter(MetricName.specified);

--- a/src/test/java/org/prebid/server/handler/SetuidHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/SetuidHandlerTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,6 +31,7 @@ import org.prebid.server.privacy.gdpr.TcfDefinerService;
 import org.prebid.server.privacy.gdpr.model.PrivacyEnforcementAction;
 import org.prebid.server.privacy.gdpr.model.TcfResponse;
 import org.prebid.server.settings.ApplicationSettings;
+import org.prebid.server.util.HttpUtil;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -468,6 +470,21 @@ public class SetuidHandlerTest extends VertxTest {
 
         // then
         verify(metrics).updateUserSyncSetsMetric(eq(RUBICON));
+    }
+
+    @Test
+    public void shouldPassNoContentIfDNTHeaderIsPresented() {
+        // given
+        final VertxHttpHeaders headers = new VertxHttpHeaders();
+        headers.add(HttpUtil.DNT_HEADER, "1");
+        given(httpRequest.headers()).willReturn(headers);
+
+        // when
+        setuidHandler.handle(routingContext);
+
+        // then
+        final SetuidEvent setuidEvent = captureSetuidEvent();
+        assertThat(setuidEvent).isEqualTo(SetuidEvent.builder().status(204).build());
     }
 
     @Test


### PR DESCRIPTION
If the "DNT" http header has a value of "1"
or if device.dnt has a value of "1"
Then follow the same anonymization rules as for device.lmt defined in #833

In addition, when the DNT:1 HTTP header is seen, /cookie-sync and /setuid should immediately give up with HTTP 204