### PR TITLE
Create Github Actions workflow for publishing new releases

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,11 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
+change-template: '- $TITLE (#$NUMBER)'
+no-changes-template: '- No changes'
+template: |
+  ## What’s Changed
+  $CHANGES
+  
+  ## Contributors
+  
+  $CONTRIBUTORS

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,5 +1,3 @@
-name-template: '$NEXT_PATCH_VERSION'
-tag-template: '$NEXT_PATCH_VERSION'
 change-template: '- $TITLE (#$NUMBER)'
 no-changes-template: '- No changes'
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Publish release
 
 on:
   push:
@@ -7,10 +7,22 @@ on:
 
 jobs:
   update_release_draft:
+    name: Publish release with notes
     runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, 'Prebid Server prepare release ')"
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - name: Extract tag from commit message
+        run: |
+          target_tag=${COMMIT_MSG#"Prebid Server prepare release "}
+          echo "::set-env name=TARGET_TAG::$target_tag"
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+      - name: Create and publish release
+        uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-config.yml
+          publish: true
+          name: "v${{ env.TARGET_TAG }}"
+          tag: ${{ env.TARGET_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After this workflow is configured it starts reacting on specific commits to `master` branch pushed by `maven-release-plugin` and having message `Prebid Server prepare release <tag>`.

The workflow leverages Release Drafter action to publish a release with release notes (consisting of PRs contained in this release).

Caveat: the workflow kicks-off when commit is pushed i.e. before tag is pushed by `maven-release-plugin`. That should not be an issue since bootstrapping workflow and its actions takes time and delay between pushing commit and tag is really short.