### PR TITLE
Generate source.tid if it wasn't defined in request

### DIFF
--- a/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AmpRequestFactory.java
@@ -236,7 +236,7 @@ public class AmpRequestFactory {
         final Site updatedSite = overrideSite(bidRequest.getSite(), targeting, request);
         final Imp updatedImp = overrideImp(bidRequest.getImp().get(0), request);
         final Long updatedTimeout = overrideTimeout(bidRequest.getTmax(), request);
-        final User updatedUser = overrideUser(bidRequest.getUser(), gdprConsent, targeting, request);
+        final User updatedUser = overrideUser(bidRequest.getUser(), gdprConsent, targeting);
         final Regs updatedRegs = overrideRegs(bidRequest.getRegs(), ccpaConsent);
         final ObjectNode updatedExt = overrideExt(bidRequest.getExt(), targeting);
 
@@ -424,7 +424,7 @@ public class AmpRequestFactory {
         return timeout > 0 && !Objects.equals(timeout, tmax) ? timeout : null;
     }
 
-    private User overrideUser(User user, String gdprConsent, Targeting targeting, HttpServerRequest request) {
+    private User overrideUser(User user, String gdprConsent, Targeting targeting) {
         final ObjectNode targetingUser = targeting.getUser();
         if (StringUtils.isBlank(gdprConsent) && targetingUser == null) {
             return null;

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -426,19 +426,16 @@ public class AuctionRequestFactory {
      */
     private Source populateSource(Source source) {
         final String tid = source != null ? source.getTid() : null;
-        if (StringUtils.isNotEmpty(tid)) {
-            return null;
+        if (StringUtils.isEmpty(tid)) {
+            final String generatedId = idGenerator.generateId();
+            if (StringUtils.isNotEmpty(generatedId)) {
+                final Source.SourceBuilder builder = source != null ? source.toBuilder() : Source.builder();
+                return builder
+                        .tid(generatedId)
+                        .build();
+            }
         }
-
-        final String generatedId = idGenerator.generateId();
-        if (StringUtils.isEmpty(generatedId)) {
-            return null;
-        }
-
-        final Source.SourceBuilder builder = source != null ? source.toBuilder() : Source.builder();
-        return builder
-                .tid(generatedId)
-                .build();
+        return null;
     }
 
     /**

--- a/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/AuctionRequestFactory.java
@@ -9,6 +9,7 @@ import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Publisher;
 import com.iab.openrtb.request.Site;
+import com.iab.openrtb.request.Source;
 import com.iab.openrtb.request.User;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -29,6 +30,7 @@ import org.prebid.server.exception.PreBidException;
 import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
+import org.prebid.server.identity.IdGenerator;
 import org.prebid.server.json.DecodeException;
 import org.prebid.server.json.JacksonMapper;
 import org.prebid.server.log.ConditionalLogger;
@@ -92,6 +94,7 @@ public class AuctionRequestFactory {
     private final TimeoutResolver timeoutResolver;
     private final TimeoutFactory timeoutFactory;
     private final ApplicationSettings applicationSettings;
+    private final IdGenerator idGenerator;
     private final JacksonMapper mapper;
 
     public AuctionRequestFactory(long maxRequestSize,
@@ -109,6 +112,7 @@ public class AuctionRequestFactory {
                                  TimeoutResolver timeoutResolver,
                                  TimeoutFactory timeoutFactory,
                                  ApplicationSettings applicationSettings,
+                                 IdGenerator idGenerator,
                                  JacksonMapper mapper) {
 
         this.maxRequestSize = maxRequestSize;
@@ -126,6 +130,7 @@ public class AuctionRequestFactory {
         this.timeoutResolver = Objects.requireNonNull(timeoutResolver);
         this.timeoutFactory = Objects.requireNonNull(timeoutFactory);
         this.applicationSettings = Objects.requireNonNull(applicationSettings);
+        this.idGenerator = Objects.requireNonNull(idGenerator);
         this.mapper = Objects.requireNonNull(mapper);
     }
 
@@ -226,37 +231,49 @@ public class AuctionRequestFactory {
         }
 
         final BidRequest result;
-
         final HttpServerRequest request = context.request();
+
+        final Device device = bidRequest.getDevice();
+        final Device populatedDevice = populateDevice(device, request);
+
+        final Site site = bidRequest.getSite();
+        final Site populatedSite = hasApp ? null : populateSite(site, request);
+
+        final User user = bidRequest.getUser();
+        final User populatedUser = populateUser(user);
+
+        final Source source = bidRequest.getSource();
+        final Source populatedSource = populateSource(source);
+
         final List<Imp> imps = bidRequest.getImp();
-
-        final Device populatedDevice = populateDevice(bidRequest.getDevice(), request);
-        final Site populatedSite = hasApp ? null : populateSite(bidRequest.getSite(), request);
-        final User populatedUser = populateUser(bidRequest.getUser());
         final List<Imp> populatedImps = populateImps(imps, request);
-        final Integer at = bidRequest.getAt();
-        final boolean updateAt = at == null || at == 0;
-        final ObjectNode ext = bidRequest.getExt();
-        final ObjectNode populatedExt = ext != null
-                ? populateBidRequestExtension(ext, ObjectUtils.defaultIfNull(populatedImps, imps))
-                : null;
-        final boolean updateCurrency = CollectionUtils.isEmpty(bidRequest.getCur()) && adServerCurrency != null;
-        final Long resolvedTmax = resolveTmax(bidRequest.getTmax(), timeoutResolver);
 
-        if (populatedDevice != null || populatedSite != null || populatedUser != null || populatedImps != null
-                || updateAt || populatedExt != null || updateCurrency || resolvedTmax != null) {
+        final Integer at = bidRequest.getAt();
+        final Integer resolvedAt = resolveAt(at);
+
+        final List<String> cur = bidRequest.getCur();
+        final List<String> resolvedCurrencies = resolveCurrencies(cur);
+
+        final Long tmax = bidRequest.getTmax();
+        final Long resolvedTmax = resolveTmax(tmax, timeoutResolver);
+
+        final ObjectNode ext = bidRequest.getExt();
+        final ObjectNode populatedExt = populateRequestExt(ext, ObjectUtils.defaultIfNull(populatedImps, imps));
+
+        if (populatedDevice != null || populatedSite != null || populatedUser != null || populatedSource != null
+                || populatedImps != null || resolvedAt != null || resolvedCurrencies != null || resolvedTmax != null
+                || populatedExt != null) {
 
             result = bidRequest.toBuilder()
-                    .device(populatedDevice != null ? populatedDevice : bidRequest.getDevice())
-                    .site(populatedSite != null ? populatedSite : bidRequest.getSite())
-                    .user(populatedUser != null ? populatedUser : bidRequest.getUser())
+                    .device(populatedDevice != null ? populatedDevice : device)
+                    .site(populatedSite != null ? populatedSite : site)
+                    .user(populatedUser != null ? populatedUser : user)
+                    .source(populatedSource != null ? populatedSource : source)
                     .imp(populatedImps != null ? populatedImps : imps)
-                    // set the auction type to 1 if it wasn't on the request,
-                    // since header bidding is generally a first-price auction.
-                    .at(updateAt ? Integer.valueOf(1) : at)
+                    .at(resolvedAt != null ? resolvedAt : at)
+                    .cur(resolvedCurrencies != null ? resolvedCurrencies : cur)
+                    .tmax(resolvedTmax != null ? resolvedTmax : tmax)
                     .ext(populatedExt != null ? populatedExt : ext)
-                    .cur(updateCurrency ? Collections.singletonList(adServerCurrency) : bidRequest.getCur())
-                    .tmax(resolvedTmax != null ? resolvedTmax : bidRequest.getTmax())
                     .build();
         } else {
             result = bidRequest;
@@ -266,10 +283,9 @@ public class AuctionRequestFactory {
 
     private void checkBlacklistedApp(App app) {
         final String appId = app.getId();
-        if (CollectionUtils.isNotEmpty(blacklistedApps) && StringUtils.isNotBlank(appId)
-                && blacklistedApps.contains(appId)) {
-            throw new BlacklistedAppException(String.format(
-                    "Prebid-server does not process requests from App ID: %s", appId));
+        if (StringUtils.isNotBlank(appId) && blacklistedApps.contains(appId)) {
+            throw new BlacklistedAppException(
+                    String.format("Prebid-server does not process requests from App ID: %s", appId));
         }
     }
 
@@ -404,6 +420,26 @@ public class AuctionRequestFactory {
     }
 
     /**
+     * Returns {@link Source} with updated source.tid or null if nothing changed.
+     */
+    private Source populateSource(Source source) {
+        final String tid = source != null ? source.getTid() : null;
+        if (StringUtils.isNotEmpty(tid)) {
+            return null;
+        }
+
+        final String generatedId = idGenerator.generateId();
+        if (StringUtils.isEmpty(generatedId)) {
+            return null;
+        }
+
+        final Source.SourceBuilder builder = source != null ? source.toBuilder() : Source.builder();
+        return builder
+                .tid(generatedId)
+                .build();
+    }
+
+    /**
      * Updates imps with security 1, when secured request was received and imp security was not defined.
      */
     private List<Imp> populateImps(List<Imp> imps, HttpServerRequest request) {
@@ -421,34 +457,33 @@ public class AuctionRequestFactory {
     /**
      * Returns updated {@link ExtBidRequest} if required or null otherwise.
      */
-    private ObjectNode populateBidRequestExtension(ObjectNode extNode, List<Imp> imps) {
-        final ExtBidRequest extBidRequest = extBidRequest(extNode);
-        final ExtRequestPrebid prebid = extBidRequest.getPrebid();
+    private ObjectNode populateRequestExt(ObjectNode extNode, List<Imp> imps) {
+        final ExtBidRequest ext = extBidRequest(extNode);
+        if (ext != null) {
+            final ExtRequestPrebid prebid = ext.getPrebid();
 
-        final Set<BidType> impMediaTypes = getImpMediaTypes(imps);
-        final ExtRequestTargeting updatedTargeting = targetingOrNull(prebid, impMediaTypes);
+            final Set<BidType> impMediaTypes = getImpMediaTypes(imps);
+            final ExtRequestTargeting updatedTargeting = targetingOrNull(prebid, impMediaTypes);
 
-        final Map<String, String> updatedAliases = aliasesOrNull(prebid, imps);
-        final ExtRequestPrebidCache updatedCache = cacheOrNull(prebid);
+            final Map<String, String> updatedAliases = aliasesOrNull(prebid, imps);
+            final ExtRequestPrebidCache updatedCache = cacheOrNull(prebid);
 
-        final ObjectNode result;
-        if (updatedTargeting != null || updatedAliases != null || updatedCache != null) {
-            final ExtRequestPrebid.ExtRequestPrebidBuilder prebidBuilder = prebid != null
-                    ? prebid.toBuilder()
-                    : ExtRequestPrebid.builder();
+            if (updatedTargeting != null || updatedAliases != null || updatedCache != null) {
+                final ExtRequestPrebid.ExtRequestPrebidBuilder prebidBuilder = prebid != null
+                        ? prebid.toBuilder()
+                        : ExtRequestPrebid.builder();
 
-            result = mapper.mapper().valueToTree(ExtBidRequest.of(prebidBuilder
-                    .aliases(ObjectUtils.defaultIfNull(updatedAliases,
-                            getIfNotNull(prebid, ExtRequestPrebid::getAliases)))
-                    .targeting(ObjectUtils.defaultIfNull(updatedTargeting,
-                            getIfNotNull(prebid, ExtRequestPrebid::getTargeting)))
-                    .cache(ObjectUtils.defaultIfNull(updatedCache,
-                            getIfNotNull(prebid, ExtRequestPrebid::getCache)))
-                    .build()));
-        } else {
-            result = null;
+                return mapper.mapper().valueToTree(ExtBidRequest.of(prebidBuilder
+                        .aliases(ObjectUtils.defaultIfNull(updatedAliases,
+                                getIfNotNull(prebid, ExtRequestPrebid::getAliases)))
+                        .targeting(ObjectUtils.defaultIfNull(updatedTargeting,
+                                getIfNotNull(prebid, ExtRequestPrebid::getTargeting)))
+                        .cache(ObjectUtils.defaultIfNull(updatedCache,
+                                getIfNotNull(prebid, ExtRequestPrebid::getCache)))
+                        .build()));
+            }
         }
-        return result;
+        return null;
     }
 
     /**
@@ -626,6 +661,24 @@ public class AuctionRequestFactory {
                     true);
         }
         return null;
+    }
+
+    /**
+     * Returns updated request.at or null if nothing changed.
+     * <p>
+     * Set the auction type to 1 if it wasn't on the request, since header bidding is generally a first-price auction.
+     */
+    private static Integer resolveAt(Integer at) {
+        return at == null || at == 0 ? 1 : null;
+    }
+
+    /**
+     * Returns default list of currencies if it wasn't on the request, otherwise null.
+     */
+    private List<String> resolveCurrencies(List<String> currencies) {
+        return CollectionUtils.isEmpty(currencies) && adServerCurrency != null
+                ? Collections.singletonList(adServerCurrency)
+                : null;
     }
 
     /**

--- a/src/main/java/org/prebid/server/identity/IdGenerator.java
+++ b/src/main/java/org/prebid/server/identity/IdGenerator.java
@@ -1,0 +1,9 @@
+package org.prebid.server.identity;
+
+/**
+ * Generates identity string.
+ */
+public interface IdGenerator {
+
+    String generateId();
+}

--- a/src/main/java/org/prebid/server/identity/IdGeneratorType.java
+++ b/src/main/java/org/prebid/server/identity/IdGeneratorType.java
@@ -1,0 +1,8 @@
+package org.prebid.server.identity;
+
+/**
+ * Describes all available {@link IdGenerator} types.
+ */
+public enum IdGeneratorType {
+    none, uuid
+}

--- a/src/main/java/org/prebid/server/identity/NoneIdGenerator.java
+++ b/src/main/java/org/prebid/server/identity/NoneIdGenerator.java
@@ -1,0 +1,12 @@
+package org.prebid.server.identity;
+
+/**
+ * Returns ID as null.
+ */
+public class NoneIdGenerator implements IdGenerator {
+
+    @Override
+    public String generateId() {
+        return null;
+    }
+}

--- a/src/main/java/org/prebid/server/identity/UUIDIdGenerator.java
+++ b/src/main/java/org/prebid/server/identity/UUIDIdGenerator.java
@@ -1,0 +1,14 @@
+package org.prebid.server.identity;
+
+import java.util.UUID;
+
+/**
+ * Returns ID as {@link UUID} string.
+ */
+public class UUIDIdGenerator implements IdGenerator {
+
+    @Override
+    public String generateId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -35,6 +35,10 @@ import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.events.EventsService;
 import org.prebid.server.execution.TimeoutFactory;
 import org.prebid.server.geolocation.GeoLocationService;
+import org.prebid.server.identity.IdGenerator;
+import org.prebid.server.identity.IdGeneratorType;
+import org.prebid.server.identity.NoneIdGenerator;
+import org.prebid.server.identity.UUIDIdGenerator;
 import org.prebid.server.json.JacksonMapper;
 import org.prebid.server.manager.AdminManager;
 import org.prebid.server.metric.Metrics;
@@ -168,6 +172,7 @@ public class ServiceConfiguration {
             @Value("${auction.ad-server-currency:#{null}}") String adServerCurrency,
             @Value("${auction.blacklisted-apps}") String blacklistedAppsString,
             @Value("${auction.blacklisted-accounts}") String blacklistedAccountsString,
+            @Value("${auction.id-generator-type}")IdGeneratorType idGeneratorType,
             StoredRequestProcessor storedRequestProcessor,
             ImplicitParametersExtractor implicitParametersExtractor,
             UidsCookieService uidsCookieService,
@@ -181,6 +186,9 @@ public class ServiceConfiguration {
 
         final List<String> blacklistedApps = splitCommaSeparatedString(blacklistedAppsString);
         final List<String> blacklistedAccounts = splitCommaSeparatedString(blacklistedAccountsString);
+        final IdGenerator idGenerator = idGeneratorType == IdGeneratorType.uuid
+                ? new UUIDIdGenerator()
+                : new NoneIdGenerator();
 
         return new AuctionRequestFactory(
                 maxRequestSize,
@@ -198,6 +206,7 @@ public class ServiceConfiguration {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 mapper);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ auction:
   timeout-adjustment-ms: 30
   stored-requests-timeout-ms: 50
   max-request-size: 262144
+  id-generator-type: uuid
   generate-bid-id: false
   cache:
     expected-request-time-ms: 10

--- a/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/AuctionRequestFactoryTest.java
@@ -11,6 +11,7 @@ import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Publisher;
 import com.iab.openrtb.request.Site;
+import com.iab.openrtb.request.Source;
 import com.iab.openrtb.request.User;
 import com.iab.openrtb.request.Video;
 import io.vertx.core.Future;
@@ -38,6 +39,7 @@ import org.prebid.server.exception.PreBidException;
 import org.prebid.server.exception.UnauthorizedAccountException;
 import org.prebid.server.execution.Timeout;
 import org.prebid.server.execution.TimeoutFactory;
+import org.prebid.server.identity.IdGenerator;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidRequest;
 import org.prebid.server.proto.openrtb.ext.request.ExtGranularityRange;
 import org.prebid.server.proto.openrtb.ext.request.ExtMediaTypePriceGranularity;
@@ -101,6 +103,8 @@ public class AuctionRequestFactoryTest extends VertxTest {
     private InterstitialProcessor interstitialProcessor;
     @Mock
     private ApplicationSettings applicationSettings;
+    @Mock
+    private IdGenerator idGenerator;
 
     private AuctionRequestFactory factory;
     @Mock
@@ -115,6 +119,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
     @Before
     public void setUp() {
         given(interstitialProcessor.process(any())).will(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(idGenerator.generateId()).willReturn(null);
 
         given(routingContext.request()).willReturn(httpRequest);
         given(httpRequest.headers()).willReturn(new CaseInsensitiveHeaders());
@@ -138,6 +143,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
     }
 
@@ -175,6 +181,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         givenValidBidRequest();
@@ -210,6 +217,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         given(applicationSettings.getAccountById(any(), any()))
@@ -254,6 +262,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         given(routingContext.getBody()).willReturn(Buffer.buffer("body"));
@@ -520,6 +529,21 @@ public class AuctionRequestFactoryTest extends VertxTest {
     }
 
     @Test
+    public void shouldSetSourceTidIfNotDefined() {
+        // given
+        given(idGenerator.generateId()).willReturn("f6965ea7-f281-4eb9-9de2-560a52d954a3");
+
+        givenBidRequest(BidRequest.builder().build());
+
+        // when
+        final BidRequest request = factory.fromRequest(routingContext, 0L).result().getBidRequest();
+
+        // then
+        assertThat(request.getSource())
+                .isEqualTo(Source.builder().tid("f6965ea7-f281-4eb9-9de2-560a52d954a3").build());
+    }
+
+    @Test
     public void shouldSetDefaultAtIfInitialValueIsEqualsToZero() {
         // given
         givenBidRequest(BidRequest.builder().at(0).build());
@@ -755,6 +779,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
         givenBidRequest(BidRequest.builder()
                 .imp(singletonList(Imp.builder().ext(mapper.createObjectNode()).build()))
@@ -795,6 +820,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         givenBidRequest(BidRequest.builder()
@@ -834,6 +860,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         givenBidRequest(BidRequest.builder()
@@ -873,6 +900,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         givenBidRequest(BidRequest.builder()
@@ -939,6 +967,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         givenBidRequest(BidRequest.builder()
@@ -980,6 +1009,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 timeoutResolver,
                 timeoutFactory,
                 applicationSettings,
+                idGenerator,
                 jacksonMapper);
 
         final ObjectNode extBidRequest = mapper.valueToTree(ExtBidRequest.of(ExtRequestPrebid.builder()

--- a/src/test/java/org/prebid/server/identity/NoneIdGeneratorTest.java
+++ b/src/test/java/org/prebid/server/identity/NoneIdGeneratorTest.java
@@ -1,0 +1,20 @@
+package org.prebid.server.identity;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NoneIdGeneratorTest {
+
+    @Test
+    public void shouldReturnNull() {
+        // given
+        final NoneIdGenerator generator = new NoneIdGenerator();
+
+        // when
+        final String id = generator.generateId();
+
+        // then
+        assertThat(id).isNull();
+    }
+}

--- a/src/test/java/org/prebid/server/identity/UUIDIdGeneratorTest.java
+++ b/src/test/java/org/prebid/server/identity/UUIDIdGeneratorTest.java
@@ -1,0 +1,22 @@
+package org.prebid.server.identity;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UUIDIdGeneratorTest {
+
+    @Test
+    public void shouldGenerateUUID() {
+        // given
+        final UUIDIdGenerator generator = new UUIDIdGenerator();
+
+        // when
+        final String id = generator.generateId();
+
+        // then
+        assertThat(id).satisfies(value -> assertThat(UUID.fromString(value)).isInstanceOf(UUID.class));
+    }
+}

--- a/src/test/resources/org/prebid/server/it/test-application.properties
+++ b/src/test/resources/org/prebid/server/it/test-application.properties
@@ -226,6 +226,7 @@ default-timeout-ms=2000
 timeout-adjustment-ms=0
 auction.default-timeout-ms=2000
 auction.timeout-adjustment-ms=0
+auction.id-generator-type=none
 currency-converter.external-rates.enabled=true
 currency-converter.external-rates.url=http://localhost:8090/currency-rates
 amp.default-timeout-ms=2000


### PR DESCRIPTION
Implements first part of https://github.com/prebid/prebid-server/issues/1337
```
All request types should have a source.tid. If the incoming request doesn't have one, 
Prebid Server should generate a random UUID.
```