### PR TITLE
Make invalid CCPA string doesn't break the auction

### DIFF
--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -37,9 +37,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.bidder.BidderCatalog;
-import org.prebid.server.exception.PreBidException;
 import org.prebid.server.json.JacksonMapper;
-import org.prebid.server.privacy.ccpa.Ccpa;
 import org.prebid.server.proto.openrtb.ext.request.ExtApp;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidRequest;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevice;
@@ -503,15 +501,6 @@ public class RequestValidator {
                 final Integer gdpr = extRegs == null ? null : extRegs.getGdpr();
                 if (gdpr != null && gdpr != 0 && gdpr != 1) {
                     throw new ValidationException("request.regs.ext.gdpr must be either 0 or 1");
-                }
-
-                final String usPrivacy = extRegs == null ? null : extRegs.getUsPrivacy();
-                if (usPrivacy != null) {
-                    try {
-                        Ccpa.validateUsPrivacy(usPrivacy);
-                    } catch (PreBidException ex) {
-                        throw new ValidationException(String.format("request.regs.ext.%s", ex.getMessage()));
-                    }
                 }
             } catch (JsonProcessingException e) {
                 throw new ValidationException("request.regs.ext is invalid: %s", e.getMessage());

--- a/src/test/java/org/prebid/server/bidder/HttpAdapterConnectorTest.java
+++ b/src/test/java/org/prebid/server/bidder/HttpAdapterConnectorTest.java
@@ -86,8 +86,10 @@ public class HttpAdapterConnectorTest extends VertxTest {
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
     @Mock
     private HttpClient httpClient;
+
     private Clock clock;
 
     private HttpAdapterConnector httpAdapterConnector;
@@ -99,6 +101,7 @@ public class HttpAdapterConnectorTest extends VertxTest {
     private UidsCookie uidsCookie;
 
     private AdapterRequest adapterRequest;
+
     private PreBidRequestContext preBidRequestContext;
 
     @Before
@@ -580,7 +583,7 @@ public class HttpAdapterConnectorTest extends VertxTest {
     public void callShouldReturnGdprAwareAdapterResponseWithNoCookieIfNoAdapterUidInCookieAndNoAppInPreBidRequest()
             throws IOException {
         // given
-        final Regs regs = Regs.of(0, mapper.valueToTree(ExtRegs.of(1, "1--")));
+        final Regs regs = Regs.of(0, mapper.valueToTree(ExtRegs.of(1, "1---")));
         final User user = User.builder()
                 .ext(mapper.valueToTree(ExtUser.builder().consent("consent$1").build()))
                 .build();
@@ -603,7 +606,7 @@ public class HttpAdapterConnectorTest extends VertxTest {
         assertThat(adapterResponse.getBidderStatus().getNoCookie()).isTrue();
         assertThat(adapterResponse.getBidderStatus().getUsersync()).isNotNull();
         assertThat(adapterResponse.getBidderStatus().getUsersync()).isEqualTo(UsersyncInfo.of(
-                "http://url?redir=%26gdpr%3D1%26gdpr_consent%3Dconsent%241%26us_privacy=1--", null, false));
+                "http://url?redir=%26gdpr%3D1%26gdpr_consent%3Dconsent%241%26us_privacy=1---", null, false));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/privacy/PrivacyExtractorTest.java
+++ b/src/test/java/org/prebid/server/privacy/PrivacyExtractorTest.java
@@ -44,8 +44,10 @@ public class PrivacyExtractorTest extends VertxTest {
 
     @Test
     public void shouldReturnGdprEmptyValueWhenRegExtIsNotValidJson() throws IOException {
-        // given and when
+        // given
         final Regs regs = Regs.of(null, (ObjectNode) mapper.readTree("{\"gdpr\": \"gdpr\"}"));
+
+        // when
         final String gdpr = privacyExtractor.validPrivacyFrom(regs, null).getGdpr();
 
         // then
@@ -54,8 +56,10 @@ public class PrivacyExtractorTest extends VertxTest {
 
     @Test
     public void shouldReturnGdprEmptyValueWhenRegsExtGdprIsNoEqualsToOneOrZero() {
-        // given and when
+        // given
         final Regs regs = Regs.of(null, mapper.valueToTree(ExtRegs.of(2, null)));
+
+        // when
         final String gdpr = privacyExtractor.validPrivacyFrom(regs, null).getGdpr();
 
         // then
@@ -64,8 +68,10 @@ public class PrivacyExtractorTest extends VertxTest {
 
     @Test
     public void shouldReturnGdprOneWhenExtRegsContainsGdprOne() {
-        // given and when
+        // given
         final Regs regs = Regs.of(null, mapper.valueToTree(ExtRegs.of(1, null)));
+
+        // when
         final String gdpr = privacyExtractor.validPrivacyFrom(regs, null).getGdpr();
 
         // then
@@ -74,8 +80,10 @@ public class PrivacyExtractorTest extends VertxTest {
 
     @Test
     public void shouldReturnGdprZeroWhenExtRegsContainsGdprZero() {
-        // given and when
+        // given
         final Regs regs = Regs.of(null, mapper.valueToTree(ExtRegs.of(0, null)));
+
+        // when
         final String gdpr = privacyExtractor.validPrivacyFrom(regs, null).getGdpr();
 
         // then
@@ -93,10 +101,10 @@ public class PrivacyExtractorTest extends VertxTest {
 
     @Test
     public void shouldReturnConsentEmptyValueWhenUserConsentIsNull() {
-        // given and when
-        final User user = User.builder()
-                .ext(mapper.valueToTree(ExtUser.builder().build()))
-                .build();
+        // given
+        final User user = User.builder().ext(mapper.valueToTree(ExtUser.builder().build())).build();
+
+        // when
         final String consent = privacyExtractor.validPrivacyFrom(null, user).getConsent();
 
         // then
@@ -105,10 +113,10 @@ public class PrivacyExtractorTest extends VertxTest {
 
     @Test
     public void shouldReturnConsentWhenUserContainsConsent() {
-        // given and when
-        final User user = User.builder()
-                .ext(mapper.valueToTree(ExtUser.builder().consent("consent").build()))
-                .build();
+        // given
+        final User user = User.builder().ext(mapper.valueToTree(ExtUser.builder().consent("consent").build())).build();
+
+        // when
         final String consent = privacyExtractor.validPrivacyFrom(null, user).getConsent();
 
         // then
@@ -116,16 +124,27 @@ public class PrivacyExtractorTest extends VertxTest {
     }
 
     @Test
+    public void shouldReturnDefaultCcpaIfNotValid() {
+        // given
+        final Regs regs = Regs.of(null, mapper.valueToTree(ExtRegs.of(null, "invalid")));
+
+        // when
+        final Ccpa ccpa = privacyExtractor.validPrivacyFrom(regs, null).getCcpa();
+
+        // then
+        assertThat(ccpa).isEqualTo(Ccpa.EMPTY);
+    }
+
+    @Test
     public void shouldReturnPrivacyWithExtractedParameters() {
-        // given and when
-        final User user = User.builder()
-                .ext(mapper.valueToTree(ExtUser.builder().consent("consent").build()))
-                .build();
-        final Regs regs = Regs.of(null, mapper.valueToTree(ExtRegs.of(0, "YAN")));
+        // given
+        final Regs regs = Regs.of(null, mapper.valueToTree(ExtRegs.of(0, "1Yn-")));
+        final User user = User.builder().ext(mapper.valueToTree(ExtUser.builder().consent("consent").build())).build();
+
+        // when
         final Privacy privacy = privacyExtractor.validPrivacyFrom(regs, user);
 
         // then
-        assertThat(privacy).isEqualTo(Privacy.of("0", "consent", Ccpa.of("YAN")));
+        assertThat(privacy).isEqualTo(Privacy.of("0", "consent", Ccpa.of("1Yn-")));
     }
 }
-

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -1832,34 +1832,6 @@ public class RequestValidatorTest extends VertxTest {
     }
 
     @Test
-    public void validateShouldReturnValidationResultWithErrorsWhenCcpaIsEmpty() {
-        // given
-        final ObjectNode ext = mapper.createObjectNode().put("us_privacy", "");
-        final BidRequest bidRequest = validBidRequestBuilder().regs(Regs.of(null, ext)).build();
-
-        // when
-        final ValidationResult result = requestValidator.validate(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).hasSize(1)
-                .element(0).asString().contains("request.regs.ext.us_privacy must contain 4 characters");
-    }
-
-    @Test
-    public void validateShouldReturnValidationResultWithErrorsWhenCcpaIsNotValid() {
-        // given
-        final ObjectNode ext = mapper.createObjectNode().put("us_privacy", "invalid");
-        final BidRequest bidRequest = validBidRequestBuilder().regs(Regs.of(null, ext)).build();
-
-        // when
-        final ValidationResult result = requestValidator.validate(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).hasSize(1)
-                .element(0).asString().contains("request.regs.ext.us_privacy must contain 4 characters");
-    }
-
-    @Test
     public void validateShouldNotReturnErrorMessageWhenSourceExtIsNotValid() {
         // given
         final BidRequest bidRequest = validBidRequestBuilder()


### PR DESCRIPTION
This PR follows https://github.com/prebid/prebid-server/issues/1129 for **CCPA Phase 2 changes** and fixes: 
```
If a CCPA signal is invalid, process the bid request as normal 
and send a warning back to the publisher in a bid response indicating 
the CCPA was invalid and ignored.
```
But leaves unchanged bid response until #758 will be done.