### PR TITLE
Reject duplicated schains

### DIFF
--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -88,8 +88,6 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -451,7 +449,7 @@ public class ExchangeServiceTest extends VertxTest {
         final ExtRequestPrebidSchainSchain specificSchain = ExtRequestPrebidSchainSchain.of("ver", 1,
                 singletonList(specificNodes), schainExtObjectNode);
         final ExtRequestPrebidSchain schainForBidders = ExtRequestPrebidSchain.of(
-                Arrays.asList(bidder1Name, bidder2Name),
+                asList(bidder1Name, bidder2Name),
                 specificSchain);
         final ExtRequestPrebidSchainSchain allSchainObject = ExtRequestPrebidSchainSchain.of("ver", 1,
                 singletonList(specificNodes), schainExtObjectNode);
@@ -462,7 +460,7 @@ public class ExchangeServiceTest extends VertxTest {
         final ExtRequestPrebidSchain allSchain = ExtRequestPrebidSchain.of(singletonList("*"), generalSchain);
         final ObjectNode extBidRequest = mapper.valueToTree(ExtBidRequest.of(
                 ExtRequestPrebid.builder()
-                        .schains(Arrays.asList(schainForBidders, allSchain))
+                        .schains(asList(schainForBidders, allSchain))
                         .auctiontimestamp(1000L)
                         .build()));
 
@@ -500,6 +498,36 @@ public class ExchangeServiceTest extends VertxTest {
         assertThat(requestSchain3).isNotNull();
         assertThat(requestSchain3).isEqualTo(allSchainObject);
         assertThat(capturedBidRequest3.getExt().get("prebid").get("schains")).isNull();
+    }
+
+    @Test
+    public void shouldRejectDuplicatedSchainBidders() {
+        // given
+        final String bidder1 = "bidder";
+        final String bidder2 = "bidder"; // same name
+
+        final ExtRequestPrebidSchain schainForBidder1 = ExtRequestPrebidSchain.of(
+                singletonList(bidder1), ExtRequestPrebidSchainSchain.of("ver1", null, null, null));
+        final ExtRequestPrebidSchain schainForBidder2 = ExtRequestPrebidSchain.of(
+                singletonList(bidder2), ExtRequestPrebidSchainSchain.of("ver2", null, null, null));
+
+        final ObjectNode extBidRequest = mapper.valueToTree(ExtBidRequest.of(
+                ExtRequestPrebid.builder()
+                        .schains(asList(schainForBidder1, schainForBidder2))
+                        .build()));
+
+        final BidRequest bidRequest = givenBidRequest(asList(
+                givenImp(singletonMap(bidder1, 1), identity()),
+                givenImp(singletonMap(bidder2, 2), identity())),
+                builder -> builder.ext(extBidRequest));
+
+        // when
+        exchangeService.holdAuction(givenRequestContext(bidRequest));
+
+        // then
+        final ArgumentCaptor<BidRequest> bidRequestCaptor = ArgumentCaptor.forClass(BidRequest.class);
+        verify(httpBidderRequester).requestBids(any(), bidRequestCaptor.capture(), any(), anyBoolean());
+        assertThat(bidRequestCaptor.getValue().getSource()).isNull();
     }
 
     @Test
@@ -1474,7 +1502,7 @@ public class ExchangeServiceTest extends VertxTest {
         final User requestUser = User.builder().id("erased").buyeruid("testBuyerId").build();
 
         final ExtRequestPrebid extRequestPrebid = ExtRequestPrebid.builder()
-                .bidderconfig(Arrays.asList(allFpdConfig, concreteFpdConfig))
+                .bidderconfig(asList(allFpdConfig, concreteFpdConfig))
                 .build();
         final BidRequest bidRequest = givenBidRequest(givenSingleImp(singletonMap("someBidder", 1)),
                 builder -> builder.site(requestSite)
@@ -1755,7 +1783,7 @@ public class ExchangeServiceTest extends VertxTest {
         givenBidder("bidder2", mock(Bidder.class), givenSeatBid(singletonList(
                 givenBid(Bid.builder().price(BigDecimal.valueOf(10.0)).build(), "CUR"))));
 
-        final BidRequest bidRequest = BidRequest.builder().cur(Collections.singletonList("BAD"))
+        final BidRequest bidRequest = BidRequest.builder().cur(singletonList("BAD"))
                 .imp(singletonList(givenImp(doubleMap("bidder1", 2, "bidder2", 3),
                         identity()))).build();
 
@@ -1801,7 +1829,7 @@ public class ExchangeServiceTest extends VertxTest {
 
         final BidRequest bidRequest = givenBidRequest(
                 singletonList(givenImp(singletonMap("bidder", 2), identity())),
-                builder -> builder.cur(Arrays.asList("CUR1", "CUR2", "CUR2")));
+                builder -> builder.cur(asList("CUR1", "CUR2", "CUR2")));
 
         final BigDecimal updatedPrice = BigDecimal.valueOf(10.0);
         given(currencyService.convertCurrency(any(), any(), any(), any())).willReturn(updatedPrice);


### PR DESCRIPTION
PBS rejects bidder-specific schains when a given bidder is defined more than once.