### PR TITLE
Fix AMP merge for Site and User parameters

### DIFF
--- a/src/main/java/org/prebid/server/auction/model/SiteFpd.java
+++ b/src/main/java/org/prebid/server/auction/model/SiteFpd.java
@@ -1,0 +1,61 @@
+package org.prebid.server.auction.model;
+
+import com.iab.openrtb.request.Content;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Builder
+@Value
+public class SiteFpd {
+
+    public static final SiteFpd EMPTY = SiteFpd.builder().build();
+
+    /**
+     * Domain of the site (e.g., “mysite.foo.com”).
+     */
+    String domain;
+
+    /**
+     * Array of IAB content categories of the site. Refer to List 5.1.
+     */
+    List<String> cat;
+
+    /**
+     * Array of IAB content categories that describe the current section of the
+     * site. Refer to List 5.1.
+     */
+    List<String> sectioncat;
+
+    /**
+     * Array of IAB content categories that describe the current page or view of
+     * the site. Refer to List 5.1.
+     */
+    List<String> pagecat;
+
+    /**
+     * URL of the page where the impression will be shown.
+     */
+    String page;
+
+    /**
+     * Referrer URL that caused navigation to the current page.
+     */
+    String ref;
+
+    /**
+     * Search string that caused navigation to the current page.
+     */
+    String search;
+
+    /**
+     * Details about the Content (Section 3.2.16) within the site.
+     */
+    Content content;
+
+    /**
+     * Comma separated list of keywords about the site.
+     */
+    String keywords;
+}

--- a/src/main/java/org/prebid/server/auction/model/UserFpd.java
+++ b/src/main/java/org/prebid/server/auction/model/UserFpd.java
@@ -1,0 +1,27 @@
+package org.prebid.server.auction.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Builder(toBuilder = true)
+@Value
+public class UserFpd {
+
+    public static final UserFpd EMPTY = UserFpd.builder().build();
+
+    /**
+     * Year of birth as a 4-digit integer.
+     */
+    Integer yob;
+
+    /**
+     * Gender, where “M” = male, “F” = female, “O” = known to be other (i.e.,
+     * omitted is unknown).
+     */
+    String gender;
+
+    /**
+     * Comma separated list of keywords, interests, or intent.
+     */
+    String keywords;
+}

--- a/src/test/java/org/prebid/server/auction/StoredRequestProcessorTest.java
+++ b/src/test/java/org/prebid/server/auction/StoredRequestProcessorTest.java
@@ -216,7 +216,7 @@ public class StoredRequestProcessorTest extends VertxTest {
         assertThat(bidRequestFuture.failed()).isTrue();
         assertThat(bidRequestFuture.cause())
                 .isInstanceOf(InvalidRequestException.class)
-                .hasMessageStartingWith("Can't convert merging result for id 123: Cannot deserialize");
+                .hasMessageStartingWith("Couldn't create merge patch from origin object node for id 123: ");
     }
 
     @Test
@@ -483,7 +483,7 @@ public class StoredRequestProcessorTest extends VertxTest {
         assertThat(bidRequestFuture.failed()).isTrue();
         assertThat(bidRequestFuture.cause())
                 .isInstanceOf(InvalidRequestException.class)
-                .hasMessageStartingWith("Can't convert merging result for id 123: Cannot deserialize");
+                .hasMessageStartingWith("Couldn't create merge patch from origin object node for id 123:");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/util/JsonMergeUtilTest.java
+++ b/src/test/java/org/prebid/server/util/JsonMergeUtilTest.java
@@ -1,11 +1,13 @@
 package org.prebid.server.util;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.Publisher;
 import com.iab.openrtb.request.Site;
 import org.junit.Before;
 import org.junit.Test;
 import org.prebid.server.VertxTest;
+import org.prebid.server.auction.model.SiteFpd;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidderConfigFpd;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,4 +72,54 @@ public class JsonMergeUtilTest extends VertxTest {
         assertThat(result).isEqualTo(site);
     }
 
+    @Test
+    public void mergeFamiliarShouldReturnMergedObject() {
+        // given
+        final Site site = Site.builder().id("testId").page("shouldNotBe").build();
+
+        final SiteFpd siteFpd = SiteFpd.builder().domain("testDomain").page("testPage").build();
+
+        // when
+        final Site result = target.mergeFamiliar(siteFpd, site, Site.class);
+
+        // then
+        final Site mergedSite = Site.builder().id("testId").page("testPage").domain("testDomain").build();
+        assertThat(result).isEqualTo(mergedSite);
+    }
+
+    @Test
+    public void mergeJsonsShouldReturnValidInCaseOfNull() {
+        // given
+        final ObjectNode objectNode = mapper.createObjectNode();
+        objectNode.put("test", "test");
+
+        // when and then
+        assertThat(target.mergeJsons(null, objectNode)).isEqualTo(objectNode);
+        assertThat(target.mergeJsons(objectNode, null)).isEqualTo(objectNode);
+        assertThat(target.mergeJsons(null, null)).isEqualTo(null);
+    }
+
+    @Test
+    public void mergeJsonsShouldReturnMergedObject() {
+        // given
+        final ObjectNode originalObject = mapper.createObjectNode()
+                .put("tagsId", 1357)
+                .put("parametro", "")
+                .put("device", "celular");
+
+        final ObjectNode mergingObject = mapper.createObjectNode()
+                .put("device", "ignored")
+                .put("test", 1);
+
+        // when
+        final ObjectNode result = (ObjectNode) target.mergeJsons(originalObject, mergingObject);
+
+        // then
+        final ObjectNode mergedObject = mapper.createObjectNode()
+                .put("test", 1)
+                .put("tagsId", 1357)
+                .put("parametro", "")
+                .put("device", "celular");
+        assertThat(result).isEqualTo(mergedObject);
+    }
 }


### PR DESCRIPTION
`domain, cat, sectioncat, pagecat, page, ref, search, content, keywords` FOR site
`yob, gender, and keywords` FOR user

All other parameters goes into `*.ext.data`