### PR TITLE
Revise TCF VendorList metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -84,4 +84,4 @@ Following metrics are collected and submitted if account is configured with `det
 - `privacy.tcf.(v1,v2).out-geo` - number of requests received outside of TCF-concerned geo region with consent string of particular version
 - `privacy.usp.specified` - number of requests with a valid US Privacy string (CCPA)
 - `privacy.usp.opt-out` - number of requests that required privacy enforcement according to CCPA rules
-- `privacy.tcf.(v1,v2).vendorlist.{VERSION}.(missing|ok|err)` - number of processed vendor lists of particular version
+- `privacy.tcf.(v1,v2).vendorlist.(missing|ok|err)` - number of processed vendor lists of particular version

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -78,10 +78,10 @@ Following metrics are collected and submitted if account is configured with `det
 - `usersync.<bidder-name>.tcf.blocked` - number of requests received that didn't result in `uid` cookie update for `<bidder-name>` because of lack of user consent for this action according to TCF
 
 ## Privacy metrics
-- `privacy.tcf.invalid` - number of requests lacking a valid consent string
+- `privacy.tcf.(missing|invalid)` - number of requests lacking a valid consent string
 - `privacy.tcf.(v1,v2).unknown-geo` - number of requests received from unknown geo region with consent string of particular version 
 - `privacy.tcf.(v1,v2).in-geo` - number of requests received from TCF-concerned geo region with consent string of particular version 
 - `privacy.tcf.(v1,v2).out-geo` - number of requests received outside of TCF-concerned geo region with consent string of particular version
+- `privacy.tcf.(v1,v2).vendorlist.(missing|ok|err)` - number of processed vendor lists of particular version
 - `privacy.usp.specified` - number of requests with a valid US Privacy string (CCPA)
 - `privacy.usp.opt-out` - number of requests that required privacy enforcement according to CCPA rules
-- `privacy.tcf.(v1,v2).vendorlist.(missing|ok|err)` - number of processed vendor lists of particular version

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -319,40 +319,40 @@ public class Metrics extends UpdatableMetrics {
         }
     }
 
+    public void updatePrivacyTcfMissingMetric() {
+        privacy().tcf().incCounter(MetricName.missing);
+    }
+
     public void updatePrivacyTcfInvalidMetric() {
         privacy().tcf().incCounter(MetricName.invalid);
     }
 
     public void updatePrivacyTcfGeoMetric(int version, Boolean inEea) {
-        final UpdatableMetrics versionMetrics;
-        if (version == 2) {
-            versionMetrics = privacy().tcf().v2();
-        } else {
-            versionMetrics = privacy().tcf().v1();
-        }
+        final UpdatableMetrics versionMetrics = version == 2 ? privacy().tcf().v2() : privacy().tcf().v1();
 
         final MetricName metricName = inEea == null
                 ? MetricName.unknown_geo
                 : inEea ? MetricName.in_geo : MetricName.out_geo;
+
         versionMetrics.incCounter(metricName);
     }
 
-    public void updatePrivacyTcfVendorListMissingMetric(int tcfVersion, int vendorListVersion) {
-        updatePrivacyTcfVendorListMetric(tcfVersion, vendorListVersion, MetricName.missing);
+    public void updatePrivacyTcfVendorListMissingMetric(int version) {
+        updatePrivacyTcfVendorListMetric(version, MetricName.missing);
     }
 
-    public void updatePrivacyTcfVendorListOkMetric(int tcfVersion, int vendorListVersion) {
-        updatePrivacyTcfVendorListMetric(tcfVersion, vendorListVersion, MetricName.ok);
+    public void updatePrivacyTcfVendorListOkMetric(int version) {
+        updatePrivacyTcfVendorListMetric(version, MetricName.ok);
     }
 
-    public void updatePrivacyTcfVendorListErrorMetric(int tcfVersion, int vendorListVersion) {
-        updatePrivacyTcfVendorListMetric(tcfVersion, vendorListVersion, MetricName.err);
+    public void updatePrivacyTcfVendorListErrorMetric(int version) {
+        updatePrivacyTcfVendorListMetric(version, MetricName.err);
     }
 
-    private void updatePrivacyTcfVendorListMetric(int tcfVersion, int vendorListVersion, MetricName metricName) {
+    private void updatePrivacyTcfVendorListMetric(int version, MetricName metricName) {
         final TcfMetrics tcfMetrics = privacy().tcf();
-        final TcfMetrics.TcfVersionMetrics tcfVersionMetrics = tcfVersion == 2 ? tcfMetrics.v2() : tcfMetrics.v1();
-        tcfVersionMetrics.forVendorList(vendorListVersion).incCounter(metricName);
+        final TcfMetrics.TcfVersionMetrics tcfVersionMetrics = version == 2 ? tcfMetrics.v2() : tcfMetrics.v1();
+        tcfVersionMetrics.vendorList().incCounter(metricName);
     }
 
     public void updateConnectionAcceptErrors() {

--- a/src/main/java/org/prebid/server/metric/TcfMetrics.java
+++ b/src/main/java/org/prebid/server/metric/TcfMetrics.java
@@ -2,8 +2,6 @@ package org.prebid.server.metric;
 
 import com.codahale.metrics.MetricRegistry;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -43,8 +41,7 @@ class TcfMetrics extends UpdatableMetrics {
 
     static class TcfVersionMetrics extends UpdatableMetrics {
 
-        private final Function<Integer, VendorListMetrics> vendorListMetricsCreator;
-        private final Map<Integer, VendorListMetrics> vendorListMetrics;
+        private final VendorListMetrics vendorListMetrics;
 
         TcfVersionMetrics(MetricRegistry metricRegistry, CounterType counterType, String prefix, String version) {
             super(
@@ -52,9 +49,8 @@ class TcfMetrics extends UpdatableMetrics {
                     Objects.requireNonNull(counterType),
                     nameCreator(createVersionPrefix(Objects.requireNonNull(prefix), Objects.requireNonNull(version))));
 
-            vendorListMetricsCreator = vendorList -> new VendorListMetrics(metricRegistry, counterType,
-                    createVersionPrefix(prefix, version), vendorList);
-            vendorListMetrics = new HashMap<>();
+            vendorListMetrics = new VendorListMetrics(metricRegistry, counterType,
+                    createVersionPrefix(prefix, version));
         }
 
         private static String createVersionPrefix(String prefix, String version) {
@@ -65,22 +61,22 @@ class TcfMetrics extends UpdatableMetrics {
             return metricName -> String.format("%s.%s", prefix, metricName.toString());
         }
 
-        public VendorListMetrics forVendorList(int vendorList) {
-            return vendorListMetrics.computeIfAbsent(vendorList, vendorListMetricsCreator);
+        VendorListMetrics vendorList() {
+            return vendorListMetrics;
         }
     }
 
     static class VendorListMetrics extends UpdatableMetrics {
 
-        VendorListMetrics(MetricRegistry metricRegistry, CounterType counterType, String prefix, int vendorList) {
+        VendorListMetrics(MetricRegistry metricRegistry, CounterType counterType, String prefix) {
             super(
                     metricRegistry,
                     counterType,
-                    nameCreator(createVersionPrefix(prefix, vendorList)));
+                    nameCreator(createVersionPrefix(prefix)));
         }
 
-        private static String createVersionPrefix(String prefix, int vendorList) {
-            return String.format("%s.vendorlist.%s", prefix, vendorList);
+        private static String createVersionPrefix(String prefix) {
+            return String.format("%s.vendorlist", prefix);
         }
 
         private static Function<MetricName, String> nameCreator(String prefix) {

--- a/src/main/java/org/prebid/server/privacy/gdpr/TcfDefinerService.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/TcfDefinerService.java
@@ -213,25 +213,12 @@ public class TcfDefinerService {
             return allowAllTcfResponseCreator.apply(country);
         }
 
-        TCString tcString = decodeTcString(gdprInfoWithCountry.getConsent());
-        updatePrivacyTcfMetrics(gdprInfoWithCountry, tcString);
+        final TCString tcString = parseConsentString(gdprInfoWithCountry.getConsent());
+        metrics.updatePrivacyTcfGeoMetric(tcString.getVersion(), gdprInfoWithCountry.getInEea());
 
-        // parsing TC string should not fail the entire request, assume the user does not consent
-        if (tcString == null) {
-            tcString = new TCStringEmpty(2);
-        }
-
-        if (tcString.getVersion() == 2) {
-            return tcf2Strategy.apply(tcString, country);
-        }
-
-        return gdprStrategy.apply(gdprInfoWithCountry.getConsent(), country);
-    }
-
-    private void updatePrivacyTcfMetrics(GdprInfoWithCountry<String> gdprInfoWithCountry, TCString tcString) {
-        if (tcString != null) {
-            metrics.updatePrivacyTcfGeoMetric(tcString.getVersion(), gdprInfoWithCountry.getInEea());
-        }
+        return tcString.getVersion() == 2
+                ? tcf2Strategy.apply(tcString, country)
+                : gdprStrategy.apply(gdprInfoWithCountry.getConsent(), country);
     }
 
     private <T> Future<TcfResponse<T>> createAllowAllTcfResponse(Set<T> keys, String country) {
@@ -321,12 +308,31 @@ public class TcfDefinerService {
         return Objects.equals(gdprInfo.getGdpr(), GDPR_ONE);
     }
 
+    /**
+     * Returns decoded {@link TCString} or {@link TCStringEmpty} in case of empty consent or error occurred.
+     * <p>
+     * Note: parsing TC string should not fail the entire request, but assume the user does not consent.
+     */
+    private TCString parseConsentString(String consentString) {
+        if (StringUtils.isBlank(consentString)) {
+            metrics.updatePrivacyTcfMissingMetric();
+            return TCStringEmpty.create();
+        }
+
+        final TCString tcString = decodeTcString(consentString);
+        if (tcString == null) {
+            metrics.updatePrivacyTcfInvalidMetric();
+            return TCStringEmpty.create();
+        }
+
+        return tcString;
+    }
+
     private TCString decodeTcString(String consentString) {
         try {
-            return StringUtils.isBlank(consentString) ? null : TCString.decode(consentString);
+            return TCString.decode(consentString);
         } catch (Throwable e) {
-            metrics.updatePrivacyTcfInvalidMetric();
-            logger.info("Parsing consent string failed with error: {0}", e.getMessage());
+            logger.info("Parsing consent string failed: {0}", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/org/prebid/server/privacy/gdpr/TcfDefinerService.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/TcfDefinerService.java
@@ -332,7 +332,7 @@ public class TcfDefinerService {
         try {
             return TCString.decode(consentString);
         } catch (Throwable e) {
-            logger.info("Parsing consent string failed: {0}", e.getMessage());
+            logger.info("Parsing consent string ''{0}'' failed: {1}", consentString, e.getMessage());
             return null;
         }
     }

--- a/src/main/java/org/prebid/server/privacy/gdpr/model/TCStringEmpty.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/model/TCStringEmpty.java
@@ -11,15 +11,13 @@ import java.util.List;
 
 public class TCStringEmpty implements TCString {
 
-    private int version;
-
-    public TCStringEmpty(int version) {
-        this.version = version;
+    public static TCString create() {
+        return new TCStringEmpty();
     }
 
     @Override
     public int getVersion() {
-        return version;
+        return 2;
     }
 
     @Override

--- a/src/main/java/org/prebid/server/privacy/gdpr/vendorlist/VendorListService.java
+++ b/src/main/java/org/prebid/server/privacy/gdpr/vendorlist/VendorListService.java
@@ -181,7 +181,7 @@ public abstract class VendorListService<T, V> {
             return Future.succeededFuture(idToVendor);
         } else {
             final int tcf = getTcfVersion();
-            metrics.updatePrivacyTcfVendorListMissingMetric(tcf, version);
+            metrics.updatePrivacyTcfVendorListMissingMetric(tcf);
 
             logger.info("TCF {0} vendor list for version {1} not found, started downloading.", tcf, version);
             fetchNewVendorListFor(version);
@@ -254,9 +254,9 @@ public abstract class VendorListService<T, V> {
         cache.put(version, filterVendorIdToVendors(vendorListResult.getVendorList()));
 
         final int tcf = getTcfVersion();
-        metrics.updatePrivacyTcfVendorListOkMetric(tcf, version);
+        metrics.updatePrivacyTcfVendorListOkMetric(tcf);
 
-        logger.info("Created new TCF {0} vendor list for version {0}", tcf, version);
+        logger.info("Created new TCF {0} vendor list for version {1}", tcf, version);
         return null;
     }
 
@@ -265,7 +265,7 @@ public abstract class VendorListService<T, V> {
      */
     private Void handleError(Throwable exception, int version) {
         final int tcf = getTcfVersion();
-        metrics.updatePrivacyTcfVendorListErrorMetric(tcf, version);
+        metrics.updatePrivacyTcfVendorListErrorMetric(tcf);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Error while obtaining TCF {0} vendor list for version {1}",

--- a/src/test/java/org/prebid/server/metric/MetricsTest.java
+++ b/src/test/java/org/prebid/server/metric/MetricsTest.java
@@ -667,6 +667,26 @@ public class MetricsTest {
     }
 
     @Test
+    public void privacyShouldReturnSameMetricsOnSuccessiveCalls() {
+        assertThat(metrics.privacy()).isSameAs(metrics.privacy());
+    }
+
+    @Test
+    public void privacyTcfShouldReturnSameMetricsOnSuccessiveCalls() {
+        assertThat(metrics.privacy().tcf()).isSameAs(metrics.privacy().tcf());
+    }
+
+    @Test
+    public void privacyTcfVersionShouldReturnSameMetricsOnSuccessiveCalls() {
+        assertThat(metrics.privacy().tcf().v1()).isSameAs(metrics.privacy().tcf().v1());
+    }
+
+    @Test
+    public void privacyTcfVersionVendorListShouldReturnSameMetricsOnSuccessiveCalls() {
+        assertThat(metrics.privacy().tcf().v2().vendorList()).isSameAs(metrics.privacy().tcf().v2().vendorList());
+    }
+
+    @Test
     public void updatePrivacyCoppaMetricShouldIncrementMetric() {
         // when
         metrics.updatePrivacyCoppaMetric();
@@ -695,6 +715,15 @@ public class MetricsTest {
     }
 
     @Test
+    public void updatePrivacyTcfMissingMetricShouldIncrementMetric() {
+        // when
+        metrics.updatePrivacyTcfMissingMetric();
+
+        // then
+        assertThat(metricRegistry.counter("privacy.tcf.missing").getCount()).isEqualTo(1);
+    }
+
+    @Test
     public void updatePrivacyTcfInvalidMetricShouldIncrementMetric() {
         // when
         metrics.updatePrivacyTcfInvalidMetric();
@@ -719,28 +748,28 @@ public class MetricsTest {
     @Test
     public void updatePrivacyTcfVendorListMissingMetricShouldIncrementMetric() {
         // when
-        metrics.updatePrivacyTcfVendorListMissingMetric(1, 2);
+        metrics.updatePrivacyTcfVendorListMissingMetric(1);
 
         // then
-        assertThat(metricRegistry.counter("privacy.tcf.v1.vendorlist.2.missing").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("privacy.tcf.v1.vendorlist.missing").getCount()).isEqualTo(1);
     }
 
     @Test
     public void updatePrivacyTcfVendorListOkMetricShouldIncrementMetric() {
         // when
-        metrics.updatePrivacyTcfVendorListOkMetric(1, 2);
+        metrics.updatePrivacyTcfVendorListOkMetric(1);
 
         // then
-        assertThat(metricRegistry.counter("privacy.tcf.v1.vendorlist.2.ok").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("privacy.tcf.v1.vendorlist.ok").getCount()).isEqualTo(1);
     }
 
     @Test
     public void updatePrivacyTcfVendorListErrorMetricShouldIncrementMetric() {
         // when
-        metrics.updatePrivacyTcfVendorListErrorMetric(1, 2);
+        metrics.updatePrivacyTcfVendorListErrorMetric(1);
 
         // then
-        assertThat(metricRegistry.counter("privacy.tcf.v1.vendorlist.2.err").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter("privacy.tcf.v1.vendorlist.err").getCount()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/privacy/gdpr/TcfDefinerServiceTest.java
+++ b/src/test/java/org/prebid/server/privacy/gdpr/TcfDefinerServiceTest.java
@@ -201,13 +201,23 @@ public class TcfDefinerServiceTest {
     }
 
     @Test
+    public void resultForVendorIdsShouldReturnRestrictAllWhenConsentIsMissing() {
+        // when
+        target.resultForVendorIds(singleton(1), "1", null, "ip", null, null);
+
+        // then
+        verify(tcf2Service).permissionsFor(any(), argThat(arg -> arg.getClass() == TCStringEmpty.class));
+        verifyZeroInteractions(gdprService);
+        verify(metrics).updatePrivacyTcfMissingMetric();
+    }
+
+    @Test
     public void resultForVendorIdsShouldReturnRestrictAllWhenConsentIsNotValid() {
         // when
         target.resultForVendorIds(singleton(1), "1", "consent", "ip", null, null);
 
         // then
-        verify(tcf2Service).permissionsFor(
-                any(), argThat(arg -> arg.getClass() == TCStringEmpty.class));
+        verify(tcf2Service).permissionsFor(any(), argThat(arg -> arg.getClass() == TCStringEmpty.class));
         verifyZeroInteractions(gdprService);
         verify(metrics).updatePrivacyTcfInvalidMetric();
     }

--- a/src/test/java/org/prebid/server/privacy/gdpr/vendorlist/VendorListServiceV1Test.java
+++ b/src/test/java/org/prebid/server/privacy/gdpr/vendorlist/VendorListServiceV1Test.java
@@ -336,7 +336,7 @@ public class VendorListServiceV1Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListMissingMetric(eq(1), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListMissingMetric(eq(1));
     }
 
     @Test
@@ -348,7 +348,7 @@ public class VendorListServiceV1Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(1), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(1));
     }
 
     @Test
@@ -363,7 +363,7 @@ public class VendorListServiceV1Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(1), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(1));
     }
 
     @Test
@@ -378,7 +378,7 @@ public class VendorListServiceV1Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListOkMetric(eq(1), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListOkMetric(eq(1));
     }
 
     private static VendorListV1 givenVendorList() {

--- a/src/test/java/org/prebid/server/privacy/gdpr/vendorlist/VendorListServiceV2Test.java
+++ b/src/test/java/org/prebid/server/privacy/gdpr/vendorlist/VendorListServiceV2Test.java
@@ -367,7 +367,7 @@ public class VendorListServiceV2Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListMissingMetric(eq(2), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListMissingMetric(eq(2));
     }
 
     @Test
@@ -379,7 +379,7 @@ public class VendorListServiceV2Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(2), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(2));
     }
 
     @Test
@@ -394,7 +394,7 @@ public class VendorListServiceV2Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(2), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListErrorMetric(eq(2));
     }
 
     @Test
@@ -409,7 +409,7 @@ public class VendorListServiceV2Test extends VertxTest {
         vendorListService.forVersion(1);
 
         // then
-        verify(metrics).updatePrivacyTcfVendorListOkMetric(eq(2), eq(1));
+        verify(metrics).updatePrivacyTcfVendorListOkMetric(eq(2));
     }
 
     private static VendorListV2 givenVendorList() {


### PR DESCRIPTION
This PR changes the metrics:
- rename `privacy.tcf.(v1,v2).vendorlist.{VERSION}.(missing|ok|err)` to `privacy.tcf.(v1,v2).vendorlist.(missing|ok|err)` - no reason for granularity by each vendor list since we can check this info in logs.
- add new `privacy.tcf.missing` metric.