### PR TITLE
consumable: Correct width and height reported in response.

### DIFF
--- a/src/main/java/org/prebid/server/bidder/consumable/ConsumableBidder.java
+++ b/src/main/java/org/prebid/server/bidder/consumable/ConsumableBidder.java
@@ -3,7 +3,6 @@ package org.prebid.server.bidder.consumable;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Device;
-import com.iab.openrtb.request.Format;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Regs;
 import com.iab.openrtb.request.Site;
@@ -190,12 +189,11 @@ public class ConsumableBidder implements Bidder<ConsumableBidRequest> {
             return Result.emptyWithError(BidderError.badServerResponse(e.getMessage()));
         }
         final List<BidderError> errors = new ArrayList<>();
-        final List<BidderBid> bidderBids = extractBids(bidRequest, consumableResponse.getDecisions(), errors);
+        final List<BidderBid> bidderBids = extractBids(bidRequest, consumableResponse.getDecisions());
         return Result.of(bidderBids, errors);
     }
 
-    private static List<BidderBid> extractBids(BidRequest bidRequest, Map<String, ConsumableDecision> impIdToDecisions,
-                                               List<BidderError> errors) {
+    private static List<BidderBid> extractBids(BidRequest bidRequest, Map<String, ConsumableDecision> impIdToDecisions) {
         final List<BidderBid> bidderBids = new ArrayList<>();
         for (Map.Entry<String, ConsumableDecision> entry : impIdToDecisions.entrySet()) {
             final ConsumableDecision decision = entry.getValue();
@@ -204,30 +202,15 @@ public class ConsumableBidder implements Bidder<ConsumableBidRequest> {
                 final ConsumablePricing pricing = decision.getPricing();
                 if (pricing != null && pricing.getClearPrice() != null) {
                     final String impId = entry.getKey();
-                    final Imp imp;
-                    try {
-                        imp = getImpById(impId, bidRequest);
-                    } catch (PreBidException e) {
-                        errors.add(BidderError.badServerResponse(e.getMessage()));
-                        continue;
-                    }
 
-                    final List<Format> formats = imp.getBanner().getFormat();
-                    if (CollectionUtils.isEmpty(formats)) {
-                        errors.add(BidderError.badInput(
-                                String.format("Skipping imp ID: %s - null or empty formats", imp.getId())));
-                        continue;
-                    }
-
-                    final Format firstFormat = formats.get(0);
                     final Bid bid = Bid.builder()
                             .id(bidRequest.getId())
                             .impid(impId)
                             .price(BigDecimal.valueOf(pricing.getClearPrice()))
                             .adm(CollectionUtils.isNotEmpty(decision.getContents())
                                     ? decision.getContents().get(0).getBody() : "")
-                            .w(firstFormat.getW())
-                            .h(firstFormat.getH())
+                            .w(decision.getWidth())
+                            .h(decision.getHeight())
                             .crid(String.valueOf(decision.getAdId()))
                             .exp(30)
                             .build();
@@ -236,15 +219,6 @@ public class ConsumableBidder implements Bidder<ConsumableBidRequest> {
             }
         }
         return bidderBids;
-    }
-
-    private static Imp getImpById(String impId, BidRequest bidRequest) {
-        return bidRequest.getImp().stream()
-                .filter(imp -> imp.getId().equals(impId))
-                .findFirst()
-                .orElseThrow(() -> new PreBidException(
-                        String.format("ignoring bid id=%s, request doesn't contain any impression with id=%s",
-                                bidRequest.getId(), impId)));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/consumable/ConsumableBidder.java
+++ b/src/main/java/org/prebid/server/bidder/consumable/ConsumableBidder.java
@@ -193,7 +193,8 @@ public class ConsumableBidder implements Bidder<ConsumableBidRequest> {
         return Result.of(bidderBids, errors);
     }
 
-    private static List<BidderBid> extractBids(BidRequest bidRequest, Map<String, ConsumableDecision> impIdToDecisions) {
+    private static List<BidderBid> extractBids(BidRequest bidRequest,
+                                               Map<String, ConsumableDecision> impIdToDecisions) {
         final List<BidderBid> bidderBids = new ArrayList<>();
         for (Map.Entry<String, ConsumableDecision> entry : impIdToDecisions.entrySet()) {
             final ConsumableDecision decision = entry.getValue();

--- a/src/main/java/org/prebid/server/bidder/consumable/model/ConsumableDecision.java
+++ b/src/main/java/org/prebid/server/bidder/consumable/model/ConsumableDecision.java
@@ -26,9 +26,7 @@ public class ConsumableDecision {
     @JsonProperty("impressionUrl")
     String impressionUrl;
 
-    @JsonProperty("width")
     Integer width;
 
-    @JsonProperty("height")
     Integer height;
 }

--- a/src/main/java/org/prebid/server/bidder/consumable/model/ConsumableDecision.java
+++ b/src/main/java/org/prebid/server/bidder/consumable/model/ConsumableDecision.java
@@ -25,4 +25,10 @@ public class ConsumableDecision {
 
     @JsonProperty("impressionUrl")
     String impressionUrl;
+
+    @JsonProperty("width")
+    Integer width;
+
+    @JsonProperty("height")
+    Integer height;
 }

--- a/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
@@ -290,7 +290,7 @@ public class ConsumableBidderTest extends VertxTest {
         // given
         final HttpCall<ConsumableBidRequest> httpCall = givenHttpCall(identity(),
                 decision -> decision.pricing(ConsumablePricing.of(11.1)).adId(123L)
-                        .width(120).height(90)
+                        .width(300).height(250)
                         .contents(singletonList(ConsumableContents.of("contents_body"))));
 
         // when
@@ -303,7 +303,7 @@ public class ConsumableBidderTest extends VertxTest {
                 .contains(BidderBid.of(
                         Bid.builder()
                                 .id("request_id").impid("firstImp").price(BigDecimal.valueOf(11.1))
-                                .adm("contents_body").w(120).h(90).exp(30).crid("123").build(),
+                                .adm("contents_body").w(300).h(250).exp(30).crid("123").build(),
                         BidType.banner, null));
     }
 

--- a/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
@@ -37,11 +37,9 @@ import org.prebid.server.util.HttpUtil;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -288,26 +286,6 @@ public class ConsumableBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeBidsShouldSkipDecisionsWithAbsentImpIdAndAddError() throws JsonProcessingException {
-        // given
-        final Map<String, ConsumableDecision> decisionMap = new HashMap<>();
-        decisionMap.put("firstImp", ConsumableDecision.builder().pricing(ConsumablePricing.of(10.5)).build());
-        decisionMap.put("missing_Imp", ConsumableDecision.builder().pricing(ConsumablePricing.of(1.1)).build());
-
-        final HttpCall<ConsumableBidRequest> httpCall = givenHttpCall(() -> ConsumableBidResponse.of(decisionMap));
-
-        // when
-        final Result<List<BidderBid>> result = consumableBidder.makeBids(httpCall,
-                givenBidRequestWithTwoImpsAndTwoFormats());
-
-        // then
-        assertThat(result.getErrors()).hasSize(1)
-                .containsOnly(BidderError.badServerResponse("ignoring bid id=request_id, request doesn't contain any "
-                        + "impression with id=missing_Imp"));
-        assertThat(result.getValue()).hasSize(1);
-    }
-
-    @Test
     public void makeBidsShouldReturnBannerBidWithExpectedFields() throws JsonProcessingException {
         // given
         final HttpCall<ConsumableBidRequest> httpCall = givenHttpCall(identity(),
@@ -400,15 +378,6 @@ public class ConsumableBidderTest extends VertxTest {
         return HttpCall.success(
                 HttpRequest.<ConsumableBidRequest>builder().build(),
                 HttpResponse.of(200, null, body),
-                null);
-    }
-
-    private static HttpCall<ConsumableBidRequest> givenHttpCall(Supplier<ConsumableBidResponse> bidResponseSupplier)
-            throws JsonProcessingException {
-
-        return HttpCall.success(
-                HttpRequest.<ConsumableBidRequest>builder().build(),
-                HttpResponse.of(200, null, mapper.writeValueAsString(bidResponseSupplier.get())),
                 null);
     }
 }

--- a/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/consumable/ConsumableBidderTest.java
@@ -290,6 +290,7 @@ public class ConsumableBidderTest extends VertxTest {
         // given
         final HttpCall<ConsumableBidRequest> httpCall = givenHttpCall(identity(),
                 decision -> decision.pricing(ConsumablePricing.of(11.1)).adId(123L)
+                        .width(120).height(90)
                         .contents(singletonList(ConsumableContents.of("contents_body"))));
 
         // when


### PR DESCRIPTION
This PR corresponds to Prebid/prebid-server#1459.

Corrects the width and height specified in the bid response.

After this change, Prebid Server uses the width and height specified in the **bid response** from Consumable.

Previously, Prebid Server would reuse the width and height specified in the **bid request**. That older behaviour was ported from an older version of the prebid.js adapter but is no longer valid.

I am submitting this PR on behalf of Consumable, cc @naffis.