### PR TITLE
Add Liveramp IDL to Rubicon user.ext

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rubicon/proto/RubiconUserExt.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/proto/RubiconUserExt.java
@@ -10,7 +10,9 @@ import java.util.List;
 @Value
 public class RubiconUserExt {
 
+    RubiconUserExtRp rp;
+
     List<ExtUserTpIdRubicon> tpid;
 
-    RubiconUserExtRp rp;
+    String liverampIdl;
 }


### PR DESCRIPTION
Rubicon Adapter should translate the "liveramp.com" *id* from the "user.ext.eids" array to "user.ext.liveramp_idl" as follows:
```
{
  "user": {
    "ext": {
      "eids": [{
        "source": 'liveramp.com',
        "uids": [{
          "id": "the-id"
        }]
      }]
    }
  }
}
```
 to XAPI:
```
{
  "user": {
    "ext": {
      "liveramp_idl": "the-id"
    }
  }
}
```