### PR TITLE
Move imp[].ext.context.adserver to  imp[].ext.context.data.adserver

### DIFF
--- a/src/main/java/org/prebid/server/auction/FpdResolver.java
+++ b/src/main/java/org/prebid/server/auction/FpdResolver.java
@@ -183,9 +183,8 @@ public class FpdResolver {
                         ? ExtImpContext.of(
                         extImpContext.getKeywords(),
                         extImpContext.getSearch(),
-                        extImpContext.getAdserver(),
                         resolvedData)
-                        : ExtImpContext.of(null, null, null, resolvedData));
+                        : ExtImpContext.of(null, null, resolvedData));
 
         return jacksonMapper.mapper().valueToTree(resolvedExtImp);
     }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtImpContext.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtImpContext.java
@@ -13,7 +13,5 @@ public class ExtImpContext {
 
     String search;
 
-    ExtImpContextAdserver adserver;
-
     ObjectNode data;
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtImpContextDataAdserver.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtImpContextDataAdserver.java
@@ -3,10 +3,10 @@ package org.prebid.server.proto.openrtb.ext.request;
 import lombok.Value;
 
 /**
- * Defines the contract for bidrequest.imp[i].ext.context.adserver
+ * Defines the contract for bidrequest.imp[i].ext.context.data.adserver
  */
 @Value(staticConstructor = "of")
-public class ExtImpContextAdserver {
+public class ExtImpContextDataAdserver {
 
     String name;
 

--- a/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rubicon/RubiconBidderTest.java
@@ -58,13 +58,11 @@ import org.prebid.server.proto.openrtb.ext.ExtPrebidBidders;
 import org.prebid.server.proto.openrtb.ext.request.ExtApp;
 import org.prebid.server.proto.openrtb.ext.request.ExtImp;
 import org.prebid.server.proto.openrtb.ext.request.ExtImpContext;
-import org.prebid.server.proto.openrtb.ext.request.ExtImpContextAdserver;
 import org.prebid.server.proto.openrtb.ext.request.ExtImpPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisher;
 import org.prebid.server.proto.openrtb.ext.request.ExtRegs;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
-import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidData;
 import org.prebid.server.proto.openrtb.ext.request.ExtSite;
 import org.prebid.server.proto.openrtb.ext.request.ExtUser;
 import org.prebid.server.proto.openrtb.ext.request.ExtUserDigiTrust;
@@ -917,7 +915,7 @@ public class RubiconBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldCreateUserExtLiverampId() throws JsonProcessingException {
+    public void makeHttpRequestsShouldCreateUserExtLiverampId() {
         // given
         final ExtUser extUser = ExtUser.builder()
                 .eids(asList(
@@ -949,7 +947,7 @@ public class RubiconBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldIgnoreLiverampIdIfMissingEidUidId() throws JsonProcessingException {
+    public void makeHttpRequestsShouldIgnoreLiverampIdIfMissingEidUidId() {
         // given
         final ExtUser extUser = ExtUser.builder()
                 .eids(asList(
@@ -1242,7 +1240,7 @@ public class RubiconBidderTest extends VertxTest {
         final ObjectNode impExtContextDataNode = mapper.createObjectNode()
                 .<ObjectNode>set("property", mapper.createArrayNode().add("value"))
                 .put("adslot", "/test");
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextDataNode)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1270,12 +1268,15 @@ public class RubiconBidderTest extends VertxTest {
                 impBuilder -> impBuilder.video(Video.builder().build()),
                 identity());
 
-        final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        final ExtImpContextAdserver impExtContextAdserver = ExtImpContextAdserver.of("gam", "/test-adserver");
+        final ObjectNode adserverNode = mapper.createObjectNode();
+        adserverNode.put("name", "gam");
+        adserverNode.put("adslot", "/test-adserver");
         final ObjectNode impExtContextDataNode = mapper.createObjectNode()
-                .put("adslot", "/test-data");
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(
-                null, null, impExtContextAdserver, impExtContextDataNode)));
+                .put("adslot", "/test-data")
+                .set("adserver", adserverNode);
+
+        final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1302,10 +1303,14 @@ public class RubiconBidderTest extends VertxTest {
                 impBuilder -> impBuilder.video(Video.builder().build()),
                 identity());
 
+        final ObjectNode adserverNode = mapper.createObjectNode();
+        adserverNode.put("name", "gam");
+        adserverNode.put("adslot", "/test-adserver");
+        final ObjectNode impExtContextDataNode = mapper.createObjectNode()
+                .set("adserver", adserverNode);
+
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        final ExtImpContextAdserver impExtContextAdserver = ExtImpContextAdserver.of("gam", "/test-adserver");
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(
-                null, null, impExtContextAdserver, null)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1330,11 +1335,15 @@ public class RubiconBidderTest extends VertxTest {
                 impBuilder -> impBuilder.video(Video.builder().build()),
                 identity());
 
+        final ObjectNode adserverNode = mapper.createObjectNode();
+        adserverNode.put("name", "not-gam");
+        adserverNode.put("adslot", "/test-adserver");
+        final ObjectNode impExtContextDataNode = mapper.createObjectNode()
+                .put("property", "value")
+                .set("adserver", adserverNode);
+
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        final ExtImpContextAdserver impExtContextAdserver = ExtImpContextAdserver.of("not-gam", "/test-adserver");
-        final ObjectNode impExtContextDataNode = mapper.createObjectNode().put("property", "value");
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(
-                null, null, impExtContextAdserver, impExtContextDataNode)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1362,7 +1371,7 @@ public class RubiconBidderTest extends VertxTest {
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
         final ObjectNode impExtContextDataNode = mapper.createObjectNode().put("pbadslot", "/test");
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextDataNode)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1392,7 +1401,7 @@ public class RubiconBidderTest extends VertxTest {
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
         final ObjectNode impExtContextDataNode = mapper.createObjectNode()
                 .set("adslot", mapper.createArrayNode().add("123"));
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextDataNode)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1477,7 +1486,7 @@ public class RubiconBidderTest extends VertxTest {
                 identity());
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextDataNode)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1510,7 +1519,7 @@ public class RubiconBidderTest extends VertxTest {
                 identity());
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextDataNode)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextDataNode)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1538,7 +1547,7 @@ public class RubiconBidderTest extends VertxTest {
                 identity());
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of("imp,ext,context,keywords", null, null, null)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of("imp,ext,context,keywords", null, null)));
         impExt.set(
                 "bidder",
                 mapper.valueToTree(ExtImpRubicon.builder()
@@ -1570,7 +1579,7 @@ public class RubiconBidderTest extends VertxTest {
                 identity());
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, "imp ext search", null, null)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, "imp ext search", null)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1617,7 +1626,7 @@ public class RubiconBidderTest extends VertxTest {
                 identity());
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, "imp ext search", null, null)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, "imp ext search", null)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1635,8 +1644,7 @@ public class RubiconBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldMergeImpExtContextDataAndSiteAttributesAndCopyToRubiconImpExtRpTarget()
-            throws IOException {
+    public void makeHttpRequestsShouldMergeImpExtContextDataAndSiteAttributesAndCopyToRubiconImpExtRpTarget() {
         // given
         final BidRequest bidRequest = givenBidRequest(
                 requestBuilder -> requestBuilder.site(Site.builder()
@@ -1657,7 +1665,7 @@ public class RubiconBidderTest extends VertxTest {
                 .put("search", "imp ext search");
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextData)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextData)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -1690,8 +1698,7 @@ public class RubiconBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldMergeImpExtContextDataAndAppAttributesAndCopyToRubiconImpExtRpTarget()
-            throws IOException {
+    public void makeHttpRequestsShouldMergeImpExtContextDataAndAppAttributesAndCopyToRubiconImpExtRpTarget() {
         // given
         final BidRequest bidRequest = givenBidRequest(
                 requestBuilder -> requestBuilder.app(App.builder()
@@ -1703,10 +1710,10 @@ public class RubiconBidderTest extends VertxTest {
 
         final ObjectNode impExtContextData = mapper.createObjectNode()
                 .<ObjectNode>set("sectioncat", mapper.createArrayNode().add("imp ext sectioncat"))
-                .<ObjectNode>set("pagecat", mapper.createArrayNode().add("imp ext pagecat"));
+                .set("pagecat", mapper.createArrayNode().add("imp ext pagecat"));
 
         final ObjectNode impExt = bidRequest.getImp().get(0).getExt();
-        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, null, impExtContextData)));
+        impExt.set("context", mapper.valueToTree(ExtImpContext.of(null, null, impExtContextData)));
 
         // when
         final Result<List<HttpRequest<BidRequest>>> result = rubiconBidder.makeHttpRequests(bidRequest);
@@ -2243,12 +2250,6 @@ public class RubiconBidderTest extends VertxTest {
                                 .price(price)
                                 .build()))
                         .build()))
-                .build());
-    }
-
-    private static ExtRequest givenExtBidRequestWithRubiconFirstPartyData() {
-        return ExtRequest.of(ExtRequestPrebid.builder()
-                .data(ExtRequestPrebidData.of(singletonList("rubicon")))
                 .build());
     }
 


### PR DESCRIPTION
The fix-PR is related to resolving `adslot` in Rubicon bidder.

FYI, the path is this:
- first (temporary) look for `imp[].ext.context.data.adslot`
- then if `imp[].ext.context.data.adserver.name="gam"` then look for `imp[].ext.context.data.adserver.adslot`
- finally look for `imp[].ext.context.data.pbadslot`