### PR TITLE
Add usage of ppuids[0].id for user.id when empty

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rubicon/RubiconAdapter.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/RubiconAdapter.java
@@ -339,7 +339,8 @@ public class RubiconAdapter extends OpenrtbAdapter {
         if (userBuilder == null) {
             userBuilder = user != null ? user.toBuilder() : User.builder();
         }
-        userBuilder.id(updatedUserId(user));
+        final String updatedUserId = updatedUserId(userBuilder.build());
+        userBuilder.id(updatedUserId);
 
         final ExtUser extUser = user == null ? null : user.getExt();
         final ExtUser rubiconUserExt = makeUserExt(rubiconParams, extUser);

--- a/src/main/java/org/prebid/server/bidder/rubicon/proto/RubiconUserExtData.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/proto/RubiconUserExtData.java
@@ -1,0 +1,11 @@
+package org.prebid.server.bidder.rubicon.proto;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value(staticConstructor = "of")
+public class RubiconUserExtData {
+
+    List<RubiconUserExtDataPpuid> ppuids;
+}

--- a/src/main/java/org/prebid/server/bidder/rubicon/proto/RubiconUserExtDataPpuid.java
+++ b/src/main/java/org/prebid/server/bidder/rubicon/proto/RubiconUserExtDataPpuid.java
@@ -1,0 +1,11 @@
+package org.prebid.server.bidder.rubicon.proto;
+
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class RubiconUserExtDataPpuid {
+
+    String type;
+
+    String id;
+}


### PR DESCRIPTION
The Prebid Server side of supporting Publisher-Provided User ID is to update

Modify the Rubicon Prebid Server adapter

    if the user.id field doesn't exist, check for user.ext.data.ppuids[0].id. If that exists, pass it through to XAPI as user.id.