### PR TITLE
Optionally read IFA value and add it the the request url (Adhese)

### DIFF
--- a/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
@@ -56,9 +56,9 @@ public class AdheseBidder implements Bidder<Void> {
             };
 
     private static final String ORIGIN = "JERLICIA";
-    private static final String QUERY_PARAMETER_GDPR = "/xt";
-    private static final String QUERY_PARAMETER_REFERER = "/xf";
-    private static final String QUERY_PARAMETER_IFA = "/xz";
+    private static final String GDPR_QUERY_PARAMETER = "/xt";
+    private static final String REFERER_QUERY_PARAMETER = "/xf";
+    private static final String IFA_QUERY_PARAMETER = "/xz";
 
     private final String endpointUrl;
     private final JacksonMapper mapper;
@@ -138,19 +138,20 @@ public class AdheseBidder implements Bidder<Void> {
         final ExtUser extUser = user != null ? user.getExt() : null;
         final String consent = extUser != null ? extUser.getConsent() : null;
         return StringUtils.isNotBlank(consent)
-                ? String.format("%s%s", QUERY_PARAMETER_GDPR, consent)
+                ? String.format("%s%s", GDPR_QUERY_PARAMETER, consent)
                 : "";
     }
 
     private static String getRefererParameter(Site site) {
         return site != null && StringUtils.isNotBlank(site.getPage())
-                ? String.format("%s%s", QUERY_PARAMETER_REFERER, HttpUtil.encodeUrl(site.getPage()))
+                ? String.format("%s%s", REFERER_QUERY_PARAMETER, HttpUtil.encodeUrl(site.getPage()))
                 : "";
     }
 
     private static String getIfaParameter(Device device) {
-        return device != null && StringUtils.isNotBlank(device.getIfa())
-                ? String.format("%s%s", QUERY_PARAMETER_IFA, device.getIfa()) : "";
+        final String ifa = device != null ? device.getIfa() : null;
+        return StringUtils.isNotBlank(ifa)
+                ? String.format("%s%s", IFA_QUERY_PARAMETER, HttpUtil.encodeUrl(ifa)) : "";
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
@@ -143,17 +143,14 @@ public class AdheseBidder implements Bidder<Void> {
     }
 
     private static String getRefererParameter(Site site) {
-        final String page = site != null ? site.getPage() : null;
-        return StringUtils.isNotBlank(page)
-                ? String.format("%s%s", QUERY_PARAMETER_REFERER, HttpUtil.encodeUrl(page))
+        return site != null && StringUtils.isNotBlank(site.getPage())
+                ? String.format("%s%s", QUERY_PARAMETER_REFERER, HttpUtil.encodeUrl(site.getPage()))
                 : "";
     }
 
     private static String getIfaParameter(Device device) {
-        final String ifa = device != null ? device.getIfa() : null;
-        return StringUtils.isNotBlank(ifa)
-                ? String.format("%s%s", QUERY_PARAMETER_IFA, ifa)
-                : "";
+        return device != null && StringUtils.isNotBlank(device.getIfa())
+                ? String.format("%s%s", QUERY_PARAMETER_IFA, device.getIfa()) : "";
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Site;
 import com.iab.openrtb.request.User;
@@ -57,6 +58,7 @@ public class AdheseBidder implements Bidder<Void> {
     private static final String ORIGIN = "JERLICIA";
     private static final String QUERY_PARAMETER_GDPR = "/xt";
     private static final String QUERY_PARAMETER_REFERER = "/xf";
+    private static final String QUERY_PARAMETER_IFA = "/xz";
 
     private final String endpointUrl;
     private final JacksonMapper mapper;
@@ -103,8 +105,10 @@ public class AdheseBidder implements Bidder<Void> {
         final String slotParameter = String.format("/sl%s-%s", HttpUtil.encodeUrl(extImpAdhese.getLocation()),
                 HttpUtil.encodeUrl(extImpAdhese.getFormat()));
 
-        return String.format("%s%s%s%s%s", uri, slotParameter, getTargetParameters(extImpAdhese),
-                getGdprParameter(request.getUser()), getRefererParameter(request.getSite()));
+        return String.format("%s%s%s%s%s%s", uri, slotParameter, getTargetParameters(extImpAdhese),
+                getGdprParameter(request.getUser()),
+                getRefererParameter(request.getSite()),
+                getIfaParameter(request.getDevice()));
     }
 
     private String getTargetParameters(ExtImpAdhese extImpAdhese) {
@@ -142,6 +146,13 @@ public class AdheseBidder implements Bidder<Void> {
         final String page = site != null ? site.getPage() : null;
         return StringUtils.isNotBlank(page)
                 ? String.format("%s%s", QUERY_PARAMETER_REFERER, HttpUtil.encodeUrl(page))
+                : "";
+    }
+
+    private static String getIfaParameter(Device device) {
+        final String ifa = device != null ? device.getIfa() : null;
+        return StringUtils.isNotBlank(ifa)
+                ? String.format("%s%s", QUERY_PARAMETER_IFA, ifa)
                 : "";
     }
 

--- a/src/test/java/org/prebid/server/bidder/adhese/AdheseBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/adhese/AdheseBidderTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.github.fge.jsonpatch.JsonPatchException;
 import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;
 import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.User;
 import com.iab.openrtb.response.Bid;
@@ -106,6 +107,9 @@ public class AdheseBidderTest extends VertxTest {
                         .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpAdhese.of("demo",
                                 "_adhese_prebid_demo_", "leaderboard", mapper.convertValue(targets, JsonNode.class)))))
                         .build()))
+                .device(Device.builder()
+                        .ifa("dum-my")
+                        .build())
                 .build();
 
         // when
@@ -115,7 +119,7 @@ public class AdheseBidderTest extends VertxTest {
         assertThat(result.getValue())
                 .extracting(HttpRequest::getUri)
                 .containsOnly("https://ads-demo.adhese.com/json/sl_adhese_prebid_demo_-leaderboard/ag55/cigent;brussels"
-                        + "/tlall/xtdummy");
+                        + "/tlall/xtdummy/xzdum-my");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/adhese/AdheseBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/adhese/AdheseBidderTest.java
@@ -107,9 +107,7 @@ public class AdheseBidderTest extends VertxTest {
                         .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpAdhese.of("demo",
                                 "_adhese_prebid_demo_", "leaderboard", mapper.convertValue(targets, JsonNode.class)))))
                         .build()))
-                .device(Device.builder()
-                        .ifa("dum-my")
-                        .build())
+                .device(Device.builder().ifa("dum-my").build())
                 .build();
 
         // when

--- a/src/test/java/org/prebid/server/it/AdheseTest.java
+++ b/src/test/java/org/prebid/server/it/AdheseTest.java
@@ -21,7 +21,7 @@ public class AdheseTest extends IntegrationTest {
     public void openrtb2AuctionShouldRespondWithBidsFromAdhese() throws IOException, JSONException {
 
         WIRE_MOCK_RULE.stubFor(WireMock.get(WireMock.urlPathEqualTo("/adhese-exchange/sl_adhese_prebid_demo_-"
-                + "leaderboard/ag55/cigent;brussels/tlall/xtconsentValue/xfhttp%3A%2F%2Fwww.example.com"))
+                + "leaderboard/ag55/cigent;brussels/tlall/xtconsentValue/xfhttp%3A%2F%2Fwww.example.com/xzifaId"))
                 .withHeader("Accept", WireMock.equalTo("application/json"))
                 .withHeader("Content-Type", WireMock.equalTo("application/json;charset=UTF-8"))
                 .withRequestBody(WireMock.absent())


### PR DESCRIPTION
Next to the referer and the consent string we also want to send the Device IFA (if present) to our Adhese endpoint - if present.